### PR TITLE
MEN-303: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM iron/base
+
+RUN mkdir -p /var/www/mender-gui
+WORKDIR /var/www/mender-gui
+
+COPY dist/ dist/
+
+WORKDIR dist
+CMD ["httpd", "-f", "-p", "80"]


### PR DESCRIPTION
I'll include it in 'integration' when we have working dockerhub builds.

For now run it via vanilla docker, e.g.:

sudo docker build -t mender-gui .
sudo docker run -d --name=mender-gui -p 8080:80 mender-gui 
