### PR TITLE
MEN-665: Remove rootUrl setting from env

### DIFF
--- a/set_gateway_host.sh
+++ b/set_gateway_host.sh
@@ -6,7 +6,7 @@
 # * GATEWAY_IP - defaults to: localhost
 # * GATEWAY_PORT - gateway port, defaults to no specified port
 
-HOSTNAME=localhost
+HOSTNAME=""
 
 if [ -n "$GATEWAY_IP" ]; then
     HOSTNAME=$GATEWAY_IP
@@ -17,4 +17,8 @@ if [ -n "$GATEWAY_PORT" ]; then
 fi 
 
 # It is expected that gateway uri is set as 'rootUrl' variable 
-sed -i "s/var rootUrl.*/var rootUrl = 'https:\/\/$HOSTNAME'/g" $1
+if [ ! -z "$HOSTNAME" ]; then
+    sed -i "s/var rootUrl.*/var rootUrl = 'https:\/\/$HOSTNAME'/g" $1
+else
+    sed -i "s/var rootUrl.*/var rootUrl = ''/g" $1    
+fi


### PR DESCRIPTION
Change default HOSTNAME to "" instead of "https://localhost" (if GATEWAY_IP/PORT not set)

@michaelatmender @mchalski 
