### PR TITLE
simple update to allow use of "friendly_name" field

### DIFF
--- a/src/js/components/deployments/deploymentdevicelist.js
+++ b/src/js/components/deployments/deploymentdevicelist.js
@@ -44,9 +44,14 @@ var ProgressDeviceList = createReactClass({
         }
 
         var encodedDevice = encodeURIComponent("id="+device.id);
+        var id_value = device.id;
+        var friendly_name = (this.props.deviceInventory[device.id] || {}).friendly_name;
+        if ( friendly_name ) {
+          id_value = friendly_name + ' (' + id_value + ')';
+        }
         var deviceLink = (
         <div>
-          <Link style={{fontWeight:"500"}} to={`/devices/groups/null/${encodedDevice}`}>{device.id}</Link>
+          <Link style={{fontWeight:"500"}} to={`/devices/groups/null/${encodedDevice}`}>{id_value}</Link>
         </div>
         );
 

--- a/src/js/components/devices/devicelist.js
+++ b/src/js/components/devices/devicelist.js
@@ -222,7 +222,10 @@ var Authorized =  createReactClass({
       if ( self.state.expandRow === index ) {
         expanded = <ExpandedDevice docsVersion={this.props.docsVersion} showHelpTips={this.props.showHelptips} device={this.state.expandedDevice || device} rejectOrDecomm={this.props.rejectOrDecomm} attrs={device.attributes} device_type={attrs.device_type} styles={this.props.styles} block={this.props.block} accept={this.props.accept} redirect={this.props.redirect} artifacts={this.props.artifacts} selectedGroup={this.props.group} groups={this.props.groups} />
       }
-     
+      var id_value = device.device_id || device.id;
+      if ( attrs.friendly_name ) {
+        id_value = attrs.friendly_name + ' (' + id_value + ')';
+      }
       return (
         <TableRow 
           hoverable={!expanded}
@@ -235,7 +238,7 @@ var Authorized =  createReactClass({
               e.stopPropagation();
               this._expandRow(index,0);
             }}>
-            {device.device_id || device.id}
+            {id_value}
             </div>
           </TableRowColumn>
           <TableRowColumn style={{padding: 0}}>


### PR DESCRIPTION
@estenberg 

I can't seem to get gulp/etc working local so I haven't been able to test this, but this is a simple change that would allow an inventory field named "friendly_name" to be used in addition to the mongo ID in the UI.

Changelog: Title