### PR TITLE
MEN- 2341 fixed filter usage on device list page as device by id goes to a different endpoint

### DIFF
--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -331,6 +331,10 @@ var DeviceGroups = createReactClass({
 					params += this.state.selectedGroup ? "group="+this.state.selectedGroup : "";
 				}
     		if (hasFilters) {
+        const filterId = this.state.filters.find(item => item.key === 'id');
+        if (filterId) {
+          return AppActions.getDeviceById(filterId);
+        }
     		  params += this.encodeFilters(this.state.filters);
     		}
     		// if a group or filters, must use inventory API


### PR DESCRIPTION
Changelog: Fixed single device selection in the device list UI, which could remove device selection otherwise
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>