### PR TITLE
removed initial pagination api calls and ungrouped group determination

### DIFF
--- a/src/js/actions/app-actions.js
+++ b/src/js/actions/app-actions.js
@@ -139,7 +139,9 @@ var AppActions = {
   getNumberOfDevicesInGroup: function(group) {
     var forGroup = group ? `/groups/${group}` : '';
     var ungroupedFilter = group ? '' : '&has_group=false';
-    return DevicesApi.get(`${inventoryApiUrl}${forGroup}/devices?per_page=1&page=1${ungroupedFilter}`).then(res => Promise.resolve(res.headers.groupcount));
+    return DevicesApi.get(`${inventoryApiUrl}${forGroup}/devices?per_page=1&page=1${ungroupedFilter}`).then(res =>
+      Promise.resolve(Number(res.headers['x-total-count']))
+    );
   },
   getAllDevicesInGroup: function(group) {
     var forGroup = group ? `/groups/${group}` : '';

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -141,7 +141,7 @@ var DeviceGroups = createReactClass({
       success: () => {},
       error: () => {}
     };
-    AppActions.getDeviceCount(callback, 'accepted').catch(console.err);
+    AppActions.getDeviceCount(callback, 'accepted');
   },
 
   _refreshUngroupedDevices: function() {
@@ -173,6 +173,7 @@ var DeviceGroups = createReactClass({
 		// get number of devices in group first for pagination
       let promisedGroupCount;
       if (group === UNGROUPED_GROUP.id) {
+        // don't use backend count for ungrouped devices, as this includes 'pending', 'preauthorized', ... devices as well
         promisedGroupCount = self._refreshUngroupedDevices().then(() => Promise.resolve(self.state.ungroupedDevices.length));
       } else {
         promisedGroupCount = AppActions.getNumberOfDevicesInGroup(theGroup);


### PR DESCRIPTION
this depends on: https://github.com/mendersoftware/inventory/pull/114 in order to get the total number of devices per group from the inventory API
There is a special API route in the deviceauth backend already, so there is currently no need to change anything there.
Furthermore the ungrouped list is now retrieved on every group change - this is slower than the earlier implementation but should in most cases still be reasonably fast + it doesn't slow down the UI in all the other groups.

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>