### PR TITLE
use endpoint returning full devices (not ids) when getting group devices

### DIFF
--- a/src/js/actions/app-actions.js
+++ b/src/js/actions/app-actions.js
@@ -141,12 +141,11 @@ var AppActions = {
     var count = 0;
     var per_page = 100;
     var page = 1;
-    var forGroup = group ? `/groups/${group}` : '';
-    var ungroupedFilter = group ? '' : '&has_group=false';
+    var forGroup = group ? `&group=${group}` : '&has_group=false';
     var devices = [];
     function getDeviceCount() {
       DevicesApi
-      .get(`${inventoryApiUrl}${forGroup}/devices?per_page=${per_page}&page=${page}${ungroupedFilter}`)
+      .get(`${inventoryApiUrl}/devices?per_page=${per_page}&page=${page}${forGroup}`)
       .then(function(res) {
         var links = parse(res.headers['link']);
         count += res.body.length;

--- a/src/js/components/deployments/deployments.js
+++ b/src/js/components/deployments/deployments.js
@@ -305,11 +305,11 @@ var Deployments = createReactClass({
   _getGroupDevices: function(group) {
     // get list of devices for each group and save them to state
     var self = this;
-    AppActions.getNumberOfDevicesInGroup((count, devices) => {
+    AppActions.getAllDevicesInGroup(group).then(devices => {
       let state = {};
       state[group] = devices;
       self.setState(state);
-    }, group);
+    });
       },
   componentWillUnmount: function() {
     clearInterval(this.timer);

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -175,6 +175,9 @@ var DeviceGroups = createReactClass({
       if (group === UNGROUPED_GROUP.id) {
         // don't use backend count for ungrouped devices, as this includes 'pending', 'preauthorized', ... devices as well
         promisedGroupCount = self._refreshUngroupedDevices().then(() => Promise.resolve(self.state.ungroupedDevices.length));
+      } else if (group === '') {
+        // don't use backend count for 'All devices', as this just refers to 'accepted' devices
+        promisedGroupCount = AppActions.getAllDevicesByStatus('accepted').then(devices => Promise.resolve(devices.length));
       } else {
         promisedGroupCount = AppActions.getNumberOfDevicesInGroup(theGroup);
         }


### PR DESCRIPTION
Changelog: fix an issue that prevented deployments to filtered devices
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>