### PR TITLE
id attributes now based on popularity in recently created devices

### DIFF
--- a/src/js/components/settings/global.js
+++ b/src/js/components/settings/global.js
@@ -49,27 +49,31 @@ var Global = createReactClass({
 		var self = this;
 		var callback = {
 			success: function(devices) {
-				if (!isEmpty(devices)) {
-					var attributes = [{value:"Device ID", label:"Device ID"}];
-					var common1 = devices[0].identity_data;
-					var common2 = {};
-					// if more than 1 devices, get common keys from attributes
-					if (devices.length>1) {
-						common2 = devices[1].identity_data;
-						common1[intersection(common1,common2)] = intersection(common1,common2); 
-					}
-					
-					Object.keys(common1).forEach(function (x) {
-						attributes.push({value: x, label: x});
-					});
-					self.setState({id_attributes: attributes});
-				}
+        const availableAttributes = devices.reduce((accu, item) => {
+          return Object.keys(item.identity_data).reduce((keyAccu, key) => {
+            keyAccu[key] = keyAccu[key] + 1 || 1;
+            return keyAccu;
+          }, accu);
+        }, {});
+        const id_attributes = Object.entries(availableAttributes)
+          // sort in reverse order, to have most common attribute at the top of the select
+          .sort((a, b) => b[1] - a[1])
+          // limit the selection of the available attribute to AVAILABLE_ATTRIBUTE_LIMIT
+          .slice(0, AVAILABLE_ATTRIBUTE_LIMIT)
+          .reduce(
+            (accu, item) => {
+              accu.push({ value: item[0], label: item[0] });
+              return accu;
 			},
+            [{ value: 'Device ID', label: 'Device ID' }]
+          );
+        self.setState({ id_attributes });
+      },
 			error: function(err) {
-				console.log("error");
+        console.log('error');
 			}
 		};
-		AppActions.getDevicesByStatus(callback);
+    AppActions.getDevicesByStatus(callback, null, 1, 500);
 	},
 
 	changeIdAttribute: function (value) { 

--- a/src/js/components/settings/global.js
+++ b/src/js/components/settings/global.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Form from '../common/forms/form';
 import SelectInput from '../common/forms/selectinput';
-import PasswordInput from '../common/forms/passwordinput';
 import { isEmpty, preformatWithRequestID, deepCompare, intersection } from '../../helpers.js';
 
 require('../common/prototype/Array.prototype.equals');
@@ -13,6 +12,7 @@ import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import FontIcon from 'material-ui/FontIcon';
 
+const AVAILABLE_ATTRIBUTE_LIMIT = 10;
 
 var Global = createReactClass({
 	getInitialState() {


### PR DESCRIPTION
this depends on a backend change, as the devices retrieved from the [devices endpoint](https://docs.mender.io/development/apis/management-apis/device-authentication#get-a-list-of-tenants-devices) are not yet ordered by `creation_ts` as written in the docs, but by `id`. I will setup a PR there to fix that, but the changes here work with whatever order they get from the backend... It would however lead to a more useful selection if the backend would respond as described.

Changelog: more device identity attributes are now able to select, depending on their popularity
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>