### PR TITLE
MEN-2430: fix tab handling + initial state for past deployments

### DIFF
--- a/src/js/components/deployments/deployments.js
+++ b/src/js/components/deployments/deployments.js
@@ -44,9 +44,15 @@ export default class Deployments extends React.Component {
 
   constructor(props, context) {
     super(props, context);
+    const today = new Date();
+    today.setHours(0, 0, 0);
+    const tonight = new Date();
+    tonight.setHours(23, 59, 59);
     this.state = {
       docsVersion: this.props.docsVersion ? `${this.props.docsVersion}/` : 'development/',
       invalid: true,
+      startDate: today,
+      endDate: tonight,
       per_page: 20,
       refreshDeploymentsLength: 30000,
       dialog: false,
@@ -457,7 +463,7 @@ export default class Deployments extends React.Component {
     return routes.active.route;
   }
 
-  _getCurrentLabel(tab = this.context.router.route.match.params.status) {
+  _getCurrentLabel(tab = this.context.router.route.match.params.tab) {
     if (routes.hasOwnProperty(tab)) {
       return routes[tab].title;
     }
@@ -532,7 +538,7 @@ export default class Deployments extends React.Component {
         >
           Create a deployment
         </Button>
-        <Tabs value={tabIndex} onChange={tabIndex => this._changeTab(tabIndex)} style={{ display: 'inline-block' }}>
+        <Tabs value={tabIndex} onChange={(e, tabIndex) => this._changeTab(tabIndex)} style={{ display: 'inline-block' }}>
           {Object.values(routes).map(route => (
             <Tab component={Link} key={route.route} label={route.title} to={route.route} value={route.route} />
           ))}

--- a/src/js/components/deployments/pastdeployments.js
+++ b/src/js/components/deployments/pastdeployments.js
@@ -32,6 +32,7 @@ export default class Past extends React.Component {
       today: new Date(),
       active: 'today'
     };
+    this.setDefaultRange(0, 0, 'today');
   }
   _setDateRange(after, before) {
     var self = this;


### PR DESCRIPTION
the bug was in deployments.js on lines 466 + 541, but reselecting finished deployments didn't update the date range properly - so some additional changes

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>