### PR TITLE
Make `disclaimer.txt` available under container's dist folder.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY package-lock.json package.json ./
 RUN npm install
 COPY . ./
 RUN npm run build
+RUN npm run disclaim
 
 FROM alpine:3.4
 COPY ./entrypoint.sh /entrypoint.sh

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "url": "git+https://github.com/mendersoftware/gui.git"
   },
   "scripts": {
-    "disclaim": "yarn licenses generate-disclaimer > disclaimer.txt",
+    "disclaim": "yarn licenses generate-disclaimer > ./dist/disclaimer.txt",
     "lint": "eslint src",
     "lint-fix": "eslint --fix src",
     "build": "webpack --mode production ./src/js/main.js",


### PR DESCRIPTION
This way it can easily be grabbed for inclusion in the license docs:

  docker cp CONTAINER:/var/www/mender-gui/dist/disclaimer.txt .