### PR TITLE
allow preauth dialog to update on key upload/ press

### DIFF
--- a/src/js/components/devices/preauthorize-devices.js
+++ b/src/js/components/devices/preauthorize-devices.js
@@ -65,11 +65,11 @@ export default class Preauthorize extends React.Component {
   }
 
   shouldComponentUpdate(_, nextState) {
+    const self = this;
     return (
-      this.state.pageLoading != nextState.pageLoading ||
-      this.state.devices.some((device, index) => device !== nextState.devices[index]) ||
-      this.state.openPreauth !== nextState.openPreauth ||
-      this.state.openRemove !== nextState.openRemove
+      ['pageLoading', 'filename', 'public', 'json_identity', 'inputs', 'openPreauth', 'openRemove'].some(
+        attribute => self.state[attribute] !== nextState[attribute]
+      ) || this.state.devices.some((device, index) => device !== nextState.devices[index])
     );
   }
 

--- a/src/js/components/devices/preauthorize-devices.js
+++ b/src/js/components/devices/preauthorize-devices.js
@@ -65,12 +65,7 @@ export default class Preauthorize extends React.Component {
   }
 
   shouldComponentUpdate(_, nextState) {
-    const self = this;
-    return (
-      ['pageLoading', 'filename', 'public', 'json_identity', 'inputs', 'openPreauth', 'openRemove'].some(
-        attribute => self.state[attribute] !== nextState[attribute]
-      ) || this.state.devices.some((device, index) => device !== nextState.devices[index])
-    );
+    return !this.state.devices.every((device, index) => device === nextState.devices[index]) || true;
   }
 
   _onChange() {


### PR DESCRIPTION
due to the change in the way the device lists gather their data, the preauthorisation dialog was blocked from updating - this commit fixes this regression

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>