### PR TITLE
MEN-2571: Fix onboarding install instructions for HM and demo server

### DIFF
--- a/src/js/components/common/dialogs/deviceconnectiondialog.js
+++ b/src/js/components/common/dialogs/deviceconnectiondialog.js
@@ -85,7 +85,7 @@ export default class DeviceConnectionDialog extends React.Component {
     );
 
     if (onDevice) {
-      content = <PhysicalDeviceOnboarding progress={progress} />;
+      content = <PhysicalDeviceOnboarding progress={progress} token={token} />;
     } else if (virtualDevice) {
       content = <VirtualDeviceOnboarding token={token} />;
     }

--- a/src/js/components/help/application-updates/mender-deb-package.js
+++ b/src/js/components/help/application-updates/mender-deb-package.js
@@ -30,9 +30,10 @@ export default class DebPackage extends React.Component {
 
     var tenantToken = (this.props.org || {}).tenant_token;
 
-    var dpkgCode = 'wget https://d1b0l86ne08fsf.cloudfront.net/2.0.0/dist-packages/debian/armhf/mender-client_2.0.0-1_armhf.deb \nsudo dpkg -i mender-client_2.0.0-1_armhf.deb';
+    /* TODO: Replace the hardcoded master with the mender-client version */
+    var dpkgCode = 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb \nsudo dpkg -i mender-client_master-1_armhf.deb';
     var cpCode = 'sudo cp /etc/mender/mender.conf.demo /etc/mender/mender.conf';
-    var echoCode = 'sudo mkdir -p /var/lib/mender \necho "device_type=generic-armv6" > /var/lib/mender/device_type';
+    var echoCode = 'sudo mkdir -p /var/lib/mender \necho "device_type=generic-armv6" | sudo tee /var/lib/mender/device_type';
     var startCode = 'sudo systemctl enable mender && sudo systemctl start mender';
     var tenantCode = 'TENANT_TOKEN="'+ tenantToken +'" \nsudo sed -i "s/'+ tenantToken +'/$TENANT_TOKEN/" /etc/mender/mender.conf';
 


### PR DESCRIPTION
The steps are now aligned with mender-docs, differentiating between
Hosted Mender and demo server.

It remains to figure out the user private IP address to be able to set
it in the device as the demo server.

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>