### PR TITLE
changed call to tenantadm to only call in appropriate environments

### DIFF
--- a/src/js/components/common/dialogs/deviceconnectiondialog.js
+++ b/src/js/components/common/dialogs/deviceconnectiondialog.js
@@ -23,10 +23,12 @@ export default class DeviceConnectionDialog extends React.Component {
     this.state = {
       onDevice: false,
       progress: 1,
+      token: null,
       virtualDevice: false
     };
-    const self = this;
-    AppActions.getUserOrganization().then(org => (org ? self.setState({ token: org.tenant_token }) : null));
+    if (AppStore.hasMultitenancy() || AppStore.getIsEnterprise() || AppStore.getIsHosted()) {
+      AppActions.getUserOrganization().then(org => (org ? self.setState({ token: org.tenant_token }) : null));
+    }
     AppActions.getReleases().then(releases => AppActions.setOnboardingArtifactIncluded(!!releases.length));
   }
 


### PR DESCRIPTION
in response to: https://hub.mender.io/t/issue-with-mender-2-0-ui-blank-release-list-page/619/7?u=mzedel

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>