### PR TITLE
moved to use more environment details to detect onboarding progress

### DIFF
--- a/src/js/utils/onboardingmanager.js
+++ b/src/js/utils/onboardingmanager.js
@@ -212,6 +212,22 @@ export function getOnboardingStepCompleted(id) {
   return progress > stepIndex;
 }
 
+const determineProgress = (acceptedDevices, pendingDevices, releases, pastDeployments) => {
+  const steps = Object.keys(onboardingSteps);
+  let progress = -1;
+  progress = pendingDevices.length > 1 ? steps.findIndex(step => step === 'devices-pending-accepting-onboarding') : progress;
+  progress = acceptedDevices.length > 1 && releases.length > 1 ? steps.findIndex(step => step === 'application-update-reminder-tip') : progress;
+  progress =
+    acceptedDevices.length > 1 && releases.length > 1 && pastDeployments.length > 1 ? steps.findIndex(step => step === 'deployments-past-completed') : progress;
+  progress =
+    acceptedDevices.length >= 1 && releases.length >= 2 && pastDeployments.length > 1
+      ? steps.findIndex(step => step === 'artifact-modified-onboarding')
+      : progress;
+  progress =
+    acceptedDevices.length >= 1 && releases.length >= 2 && pastDeployments.length > 2 ? steps.findIndex(step => step === 'onboarding-finished') : progress;
+  return progress;
+};
+
 export function getOnboardingState(userId) {
   let promises = Promise.resolve(getCurrentOnboardingState());
   const onboardingKey = `${userId}-onboarding`;
@@ -223,7 +239,7 @@ export function getOnboardingState(userId) {
       AppActions.setOnboardingComplete(Boolean(userCookie));
     }
     const requests = [
-      AppActions.getDevicesByStatus('accepted'),
+      AppActions.getDevicesByStatus('accepted').then(AppActions.getDevicesWithInventory),
       AppActions.getReleases(),
       AppActions.getPastDeployments(),
       Promise.resolve(userCookie),
@@ -231,17 +247,24 @@ export function getOnboardingState(userId) {
     ];
 
     promises = Promise.all(requests).then(([acceptedDevices, releases, pastDeployments, onboardedCookie, pendingDevices]) => {
+      const deviceType =
+        acceptedDevices.length && acceptedDevices[0].hasOwnProperty('attributes')
+          ? acceptedDevices[0].attributes.find(item => item.name === 'device_type').value
+          : '';
       const state = {
         complete: !!(
           Boolean(onboardedCookie) ||
           (acceptedDevices.length > 1 && pendingDevices.length > 0 && releases.length > 1 && pastDeployments.length > 1) ||
-          (acceptedDevices.length >= 1 && releases.length >= 2 && pastDeployments.length >= 2)
+          (acceptedDevices.length >= 1 && releases.length >= 2 && pastDeployments.length > 2)
         ),
         showTips: onboardedCookie ? !onboardedCookie : true,
-        deviceType: AppStore.getOnboardingDeviceType(),
-        approach: AppStore.getOnboardingApproach(),
+        deviceType:
+          AppStore.getOnboardingDeviceType() || (acceptedDevices.length && acceptedDevices[0].hasOwnProperty('attributes'))
+            ? acceptedDevices[0].attributes.find(item => item.name === 'device_type').value
+            : null,
+        approach: AppStore.getOnboardingApproach() || deviceType.startsWith('qemu') ? 'virtual' : 'physical',
         artifactIncluded: AppStore.getOnboardingArtifactIncluded(),
-        progress: -1
+        progress: determineProgress(acceptedDevices, pendingDevices, releases, pastDeployments)
       };
       window.localStorage.setItem(onboardingKey, JSON.stringify(state));
       return Promise.resolve(state);


### PR DESCRIPTION
previously onboarding progress could be lost after refreshing
if progress was not persisted to localstorage at that moment

Changelog: None