### PR TITLE
adjusted ci to reuse built image + skip lint docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,9 @@
 image: docker:git
 
-services:
-  - docker:dind
-
 stages:
   - test
   - build
+  - e2e-test
   - publish
 
 before_script:
@@ -18,6 +16,8 @@ before_script:
 
 build:master:
   stage: build
+  services:
+    - docker:dind
   script:
     - echo "building gui for ${SERVICE_IMAGE}"
     - docker build
@@ -37,6 +37,10 @@ build:master:
 
 build:
   stage: build
+  services:
+    - docker:dind
+  except:
+    - master
   script:
     - echo "building gui for ${SERVICE_IMAGE}"
     - docker build
@@ -44,8 +48,6 @@ build:
       -t $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
       .
     - docker save $SERVICE_IMAGE > image.tar
-  except:
-    - master
   artifacts:
     expire_in: 2w
     paths:
@@ -72,20 +74,23 @@ test:static:
 
 test:lint:
   stage: test
+  image: node
   script:
-    - docker build -t gui-test-image -f Dockerfile.testing .
-    - docker run --rm gui-test-image
+    - npm ci
+    - npm run lint
   except:
     - master
-  tags:
-    - docker
 
 test:acceptance:
   image: tiangolo/docker-with-compose
+  dependencies:
+    - build
   services:
     - docker:18-dind
-  stage: test
+  stage: e2e-test
   script:
+    - docker load -i image.tar
+    - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:pr
     - apk add git bash
     - git clone https://github.com/mendersoftware/integration.git
     - cp -r integration/tests/* tests
@@ -95,6 +100,8 @@ test:acceptance:
 
 publish:
   stage: publish
+  services:
+    - docker:dind
   dependencies:
     - test:lint
     - test:acceptance

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,6 +1,0 @@
-FROM node:11.6.0-alpine AS build
-WORKDIR /usr/src/app
-COPY package-lock.json package.json ./
-RUN npm install
-COPY . ./
-CMD npm run lint


### PR DESCRIPTION
this depends on https://github.com/mendersoftware/integration/pull/671 to be merged

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>