### PR TITLE
MEN-2747 use injected api host ip during onboarding

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,17 +17,11 @@ fi
 
 if [ -n "$GATEWAY_PORT" ]; then
     HOSTNAME=$HOSTNAME':'$GATEWAY_PORT
-fi 
-
-ROOT_URL=""
-# It is expected that gateway uri is set as 'rootUrl' variable 
-if [ ! -z "$HOSTNAME" ]; then
-    ROOT_URL="https://$HOSTNAME"
 fi
 
 cat >/var/www/mender-gui/dist/env.js <<EOF
   mender_environment = {
-    rootUrl: "$ROOT_URL",
+    hostAddress: "$HOSTNAME",
     hostedAnnouncement: "$ANNOUCEMENT",
     isDemoMode: "$DEMO",
     features: {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 cat >/var/www/mender-gui/dist/env.js <<EOF
   mender_environment = {
     hostAddress: "$HOSTNAME",
-    hostedAnnouncement: "$ANNOUCEMENT",
+    hostedAnnouncement: "$ANNOUNCEMENT",
     isDemoMode: "$DEMO",
     features: {
       hasMultitenancy: "$HAVE_MULTITENANT",

--- a/src/js/actions/app-actions.js
+++ b/src/js/actions/app-actions.js
@@ -8,9 +8,8 @@ import UsersApi from '../api/users-api';
 import parse from 'parse-link-header';
 import { advanceOnboarding } from '../utils/onboardingmanager';
 
-const rootUrl = mender_environment && mender_environment.rootUrl ? mender_environment.rootUrl : '';
-const apiUrl = `${rootUrl}/api/management/v1`;
-const apiUrlV2 = `${rootUrl}/api/management/v2`;
+const apiUrl = '/api/management/v1';
+const apiUrlV2 = '/api/management/v2';
 const deploymentsApiUrl = `${apiUrl}/deployments`;
 const deviceAuthV2 = `${apiUrlV2}/devauth`;
 const inventoryApiUrl = `${apiUrl}/inventory`;

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.js
@@ -18,15 +18,17 @@ export default class PhysicalDeviceOnboarding extends React.Component {
     super(props, context);
     this.state = {
       selection: null,
-      ipAddress: null,
+      ipAddress: AppStore.getHostAddress(),
       copied: false
     };
   }
 
   componentDidMount() {
     const self = this;
-    findLocalIpAddress().then(ipAddress => self.setState({ ipAddress }));
-    AppActions.setOnboardingApproach('virtual');
+    if (!self.state.ipAddress || self.state.ipAddress === 'X.X.X.X') {
+      findLocalIpAddress().then(ipAddress => self.setState({ ipAddress }));
+    }
+    AppActions.setOnboardingApproach('physical');
   }
 
   copied() {
@@ -51,7 +53,7 @@ export default class PhysicalDeviceOnboarding extends React.Component {
     let connectionInstructions = `
 sed /etc/mender/mender.conf -i -e "/Paste your Hosted Mender token here/d;s/hosted.mender.io/docker.mender.io/;1 a \\ \\ \\"ServerCertificate\\": \\"/etc/mender/server.crt\\","
 wget -q -O /etc/mender/server.crt https://raw.githubusercontent.com/mendersoftware/meta-mender/master/meta-mender-demo/recipes-mender/mender/files/server.crt
-DOCKER_HOST_IP="${ipAddress ? ipAddress : 'X.X.X.X'}"
+DOCKER_HOST_IP="${ipAddress || 'X.X.X.X'}"
 grep "\\ss3.docker.mender.io" /etc/hosts >/dev/null 2>&1 || echo "$DOCKER_HOST_IP s3.docker.mender.io # Added by mender" | tee -a /etc/hosts > /dev/null
 grep "\\sdocker.mender.io" /etc/hosts >/dev/null 2>&1 || echo "$DOCKER_HOST_IP docker.mender.io # Added by mender" | tee -a /etc/hosts > /dev/null
 `;
@@ -82,7 +84,7 @@ systemctl enable mender && systemctl restart mender'
       {
         title: 'Generic ARMv6 or newer',
         value: 'generic-armv6'
-      },
+      }
     ];
 
     const steps = {
@@ -106,8 +108,12 @@ systemctl enable mender && systemctl restart mender'
             style={{ maxWidth: 300 }}
           >
             <div>
-              <p>If you don&apos;t see your exact device on the list, choose <i>Generic ARMv6 or newer</i> to continue the tutorial for now.</p>
-              <p>(Note: if your device is <i>not</i> based on ARMv6 or newer, the tutorial won&apos;t work - instead, go back and use the virtual device)</p>
+              <p>
+                If you don&apos;t see your exact device on the list, choose <i>Generic ARMv6 or newer</i> to continue the tutorial for now.
+              </p>
+              <p>
+                (Note: if your device is <i>not</i> based on ARMv6 or newer, the tutorial won&apos;t work - instead, go back and use the virtual device)
+              </p>
             </div>
           </ReactTooltip>
         </div>

--- a/src/js/stores/app-store.js
+++ b/src/js/stores/app-store.js
@@ -37,6 +37,7 @@ var _onboardingArtifactIncluded = null;
 var _groups = [];
 var _releasesRepo = [];
 var _uploadInProgress = false;
+const _hostAddress = mender_environment && mender_environment.hostAddress ? mender_environment.hostAddress : null;
 const _MenderVersion = mender_environment && mender_environment.menderVersion ? mender_environment.menderVersion : 'master';
 const _menderArtifactVersion = mender_environment && mender_environment.menderArtifactVersion ? mender_environment.menderArtifactVersion : 'master';
 const _menderDebPackageVersion = mender_environment && mender_environment.menderDebPackageVersion ? mender_environment.menderDebPackageVersion : 'master';
@@ -654,6 +655,8 @@ var AppStore = Object.assign({}, EventEmitter.prototype, {
   getIsHosted: () => (mender_environment && mender_environment.features.isHosted) || window.location.hostname === 'hosted.mender.io',
 
   getIsEnterprise: () => mender_environment && mender_environment.features.isEnterprise,
+
+  getHostAddress: () => _hostAddress,
 
   getVersionInformation: () => _versionInformation,
 


### PR DESCRIPTION
+ removed apiroot rewriting, since the gui is always served from the same gateway/ address as the rest of the backend

this depends on the following integration PR: https://github.com/mendersoftware/integration/pull/689

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>