### PR TITLE
replaced comma in twitter link with appropriate dot

### DIFF
--- a/src/js/components/help/__snapshots__/more-help-resources.test.js.snap
+++ b/src/js/components/help/__snapshots__/more-help-resources.test.js.snap
@@ -68,7 +68,7 @@ exports[`renders correctly 1`] = `
         Follow us on Twitter
          
         <a
-          href="https://twitter,com/mender_io"
+          href="https://twitter.com/mender_io"
           target="_blank"
         >
           @mender_io

--- a/src/js/components/help/more-help-resources.js
+++ b/src/js/components/help/more-help-resources.js
@@ -50,7 +50,7 @@ export default class MoreHelp extends React.Component {
           <li>
             <p>
               Follow us on Twitter{' '}
-              <a href="https://twitter,com/mender_io" target="_blank">
+              <a href="https://twitter.com/mender_io" target="_blank">
                 @mender_io
               </a>
             </p>


### PR DESCRIPTION
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>