### PR TITLE
fixed faulty fallback file definition in nginx config

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -34,7 +34,7 @@ http {
     root /var/www/mender-gui/dist;
     index index.html index.htm;
     location / {
-      try_files $uri $uri/index.html index.html;
+      try_files $uri $uri/index.html /index.html;
     }
   }
 }


### PR DESCRIPTION
the fallback file has to be defined with a leading / for the file to be found
this is in response to the error reported [here](https://hub.mender.io/t/gui-2-1-x-error-in-log-open-var-www-mender-gui-distindex-html-failed-2-no-such-file-or-directory/1084)

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>