### PR TITLE
cherry-pick of #551

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -34,7 +34,7 @@ http {
     root /var/www/mender-gui/dist;
     index index.html index.htm;
     location / {
-      try_files $uri $uri/index.html index.html;
+      try_files $uri $uri/index.html /index.html;
     }
   }
 }


### PR DESCRIPTION
fixed faulty fallback file definition in nginx config
the fallback file has to be defined with a leading / for the file to be found

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>