### PR TITLE
MEN-2691 Fix/onboarding issues

### DIFF
--- a/src/js/components/common/dialogs/confirmdismisshelptips.js
+++ b/src/js/components/common/dialogs/confirmdismisshelptips.js
@@ -1,17 +1,15 @@
 import React from 'react';
 
-import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core';
 
 import AppActions from '../../../actions/app-actions';
+import { persistOnboardingState } from '../../../utils/onboardingmanager';
 
 export default class ConfirmDismissHelptips extends React.Component {
   onClose() {
     AppActions.setShowOnboardingHelp(false);
     AppActions.setShowDismissOnboardingTipsDialog(false);
+    setTimeout(() => persistOnboardingState(), 500);
   }
   render() {
     return (

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.js
@@ -34,7 +34,7 @@ export default class PhysicalDeviceOnboarding extends React.Component {
   copied() {
     var self = this;
     self.setState({ copied: true });
-    advanceOnboarding('devices-accepted-onboarding');
+    advanceOnboarding('dashboard-onboarding-start');
     setTimeout(() => {
       self.setState({ copied: false });
     }, 5000);

--- a/src/js/components/dashboard/dashboard.js
+++ b/src/js/components/dashboard/dashboard.js
@@ -20,7 +20,12 @@ export default class Dashboard extends React.Component {
   componentDidMount() {
     const self = this;
     setTimeout(() => {
-      if (AppStore.getCurrentUser() && !AppStore.getOnboardingComplete() && !getOnboardingStepCompleted('devices-pending-accepting-onboarding')) {
+      if (
+        AppStore.getCurrentUser() &&
+        AppStore.getShowOnboardingTips() &&
+        !AppStore.getOnboardingComplete() &&
+        !getOnboardingStepCompleted('devices-pending-accepting-onboarding')
+      ) {
         AppActions.setSnackbar('open', 10000, '', <WelcomeSnackTip progress={1} />, () => {}, self.onCloseSnackbar);
       }
     }, 1000);

--- a/src/js/components/deployments/pastdeployments.js
+++ b/src/js/components/deployments/pastdeployments.js
@@ -42,7 +42,7 @@ export default class Past extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.showHelptips && !AppStore.getOnboardingComplete() && this.props.past.length) {
+    if (this.props.showHelptips && AppStore.getShowOnboardingTips() && !AppStore.getOnboardingComplete() && this.props.past.length) {
       const progress = getOnboardingStepCompleted('artifact-modified-onboarding') && this.props.past.length > 1 ? 4 : 3;
       setTimeout(() => {
         !AppStore.getOnboardingComplete()

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -44,7 +44,7 @@ export default class Authorized extends React.Component {
       prevProps.pageNo !== this.props.pageNo
     ) {
       self.setState({ selectedRows: [], expandRow: null, allRowsSelected: false });
-      if (AppStore.showHelptips() && !AppStore.getOnboardingComplete() && this.props.devices.length) {
+      if (AppStore.showHelptips() && AppStore.getShowOnboardingTips() && !AppStore.getOnboardingComplete() && this.props.devices.length) {
         setTimeout(() => {
           AppActions.setSnackbar('open', 10000, '', <WelcomeSnackTip progress={2} />, () => {}, self.onCloseSnackbar);
         }, 400);

--- a/src/js/components/devices/pending-devices.js
+++ b/src/js/components/devices/pending-devices.js
@@ -254,7 +254,7 @@ export default class Pending extends React.Component {
           </div>
         ) : (
           <div>
-            {self.state.showHelptips && !AppStore.getOnboardingComplete() && !deviceConnectingProgressed ? (
+            {self.state.showHelptips && AppStore.getShowOnboardingTips() && !AppStore.getOnboardingComplete() && !deviceConnectingProgressed ? (
               <DevicePendingTip />
             ) : (
               <div className={this.state.authLoading ? 'hidden' : 'dashboard-placeholder'}>

--- a/src/js/components/user-management/login.js
+++ b/src/js/components/user-management/login.js
@@ -122,7 +122,12 @@ export default class Login extends React.Component {
             // logged in, so redirect
             self.setState({ redirectToReferrer: true });
             setTimeout(() => {
-              if (!AppStore.getOnboardingComplete() && !getOnboardingStepCompleted('devices-pending-accepting-onboarding')) {
+              if (
+                AppStore.showHelptips() &&
+                AppStore.getShowOnboardingTips() &&
+                !AppStore.getOnboardingComplete() &&
+                !getOnboardingStepCompleted('devices-pending-accepting-onboarding')
+              ) {
                 AppActions.setSnackbar('open', 10000, '', <WelcomeSnackTip progress={1} />, () => {}, self.onCloseSnackbar);
               }
             }, 1000);


### PR DESCRIPTION
this should fix the problems with physical devices, where the onboarding tips wouldn't show once they were returned as pending from the backend
the second fix should prevent the "dismiss" click on the onboarding tips to show up once the page is reloaded