### PR TITLE
Men 2427 use mender setup

### DIFF
--- a/src/js/components/common/dialogs/createartifactdialog.js
+++ b/src/js/components/common/dialogs/createartifactdialog.js
@@ -57,19 +57,19 @@ export default class CreateArtifactDialog extends React.Component {
     const artifactGenerator = 'single-file-artifact-gen';
     const artifactName = 'demo-webserver-updated';
     const chmodCode = `
-wget https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/${AppStore.getMenderArtifactVersion()}/${downloadFolder[detectOsIdentifier()]}/mender-artifact
-chmod +x mender-artifact
-wget https://raw.githubusercontent.com/mendersoftware/mender/${AppStore.getMenderVersion()}/support/modules-artifact-gen/${artifactGenerator}
-chmod +x ${artifactGenerator}
+wget https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/${AppStore.getMenderArtifactVersion()}/${downloadFolder[detectOsIdentifier()]}/mender-artifact && \\
+chmod +x mender-artifact && \\
+wget https://raw.githubusercontent.com/mendersoftware/mender/${AppStore.getMenderVersion()}/support/modules-artifact-gen/${artifactGenerator} && \\
+chmod +x ${artifactGenerator} && \\
 sudo cp mender-artifact ${artifactGenerator} /usr/local/bin/
 `;
 
     const artifactGenCode = `
-ARTIFACT_NAME="${artifactName}"; \
-DEVICE_TYPE="${deviceType}"; \
-OUTPUT_PATH="${artifactName}.mender"; \
-DEST_DIR="/var/www/localhost/htdocs/"; \
-FILE_NAME="index.html"; \
+ARTIFACT_NAME="${artifactName}" && \\
+DEVICE_TYPE="${deviceType}" && \\
+OUTPUT_PATH="${artifactName}.mender" && \\
+DEST_DIR="/var/www/localhost/htdocs/" && \\
+FILE_NAME="index.html" && \\
 ${artifactGenerator} -n \${ARTIFACT_NAME} \
 -t \${DEVICE_TYPE} -d \${DEST_DIR} -o \${OUTPUT_PATH} \
 \${FILE_NAME}
@@ -98,10 +98,10 @@ EOF
               </div>
               <p>{copied === 1 ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
             </li>
-          
+
             <li>
-              Next, create a new <i>index.html</i> file with the simple contents &apos;Hello world&apos;. This will be the web page of your updated application, so you&apos;ll be able to
-              easily see when your device has received the update. Copy and run the command:
+              Next, create a new <i>index.html</i> file with the simple contents &apos;Hello world&apos;. This will be the web page of your updated application,
+              so you&apos;ll be able to easily see when your device has received the update. Copy and run the command:
               <div className="code">
                 <CopyToClipboard text={file_modification} onCopy={() => self.copied(3)}>
                   <Button style={{ float: 'right', margin: '-20px 0 0 10px' }}>
@@ -114,8 +114,7 @@ EOF
               <p>{copied === 3 ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
             </li>
             <li>
-              Now you can create a new version of the demo webserver application with this <i>index.html</i> file. Generate a new Artifact by copying &
-              running:
+              Now you can create a new version of the demo webserver application with this <i>index.html</i> file. Generate a new Artifact by copying & running:
               <div className="code">
                 <CopyToClipboard text={artifactGenCode} onCopy={() => self.copied(2)}>
                   <Button style={{ float: 'right', margin: '-10px 0 0 10px' }}>

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.js
@@ -9,7 +9,7 @@ import HelpIcon from '@material-ui/icons/Help';
 
 import AutoSelect from '../forms/autoselect';
 import AppActions from '../../../actions/app-actions';
-import { findLocalIpAddress } from '../../../helpers';
+import { findLocalIpAddress, getDebConfigurationCode } from '../../../helpers';
 import { advanceOnboarding } from '../../../utils/onboardingmanager';
 import AppStore from '../../../stores/app-store';
 
@@ -49,28 +49,11 @@ export default class PhysicalDeviceOnboarding extends React.Component {
     const self = this;
     const { ipAddress, selection } = self.state;
     const { token } = self.props;
+    const isHosted = AppStore.getIsHosted();
+    const isEnterprise = AppStore.getIsEnterprise();
+    const debPackageVersion = AppStore.getMenderDebPackageVersion();
 
-    let connectionInstructions = `
-sed /etc/mender/mender.conf -i -e "/Paste your Hosted Mender token here/d;s/hosted.mender.io/docker.mender.io/;1 a \\ \\ \\"ServerCertificate\\": \\"/etc/mender/server.crt\\","
-wget -q -O /etc/mender/server.crt https://raw.githubusercontent.com/mendersoftware/meta-mender/master/meta-mender-demo/recipes-mender/mender/files/server.crt
-DOCKER_HOST_IP="${ipAddress || 'X.X.X.X'}"
-grep "\\ss3.docker.mender.io" /etc/hosts >/dev/null 2>&1 || echo "$DOCKER_HOST_IP s3.docker.mender.io # Added by mender" | tee -a /etc/hosts > /dev/null
-grep "\\sdocker.mender.io" /etc/hosts >/dev/null 2>&1 || echo "$DOCKER_HOST_IP docker.mender.io # Added by mender" | tee -a /etc/hosts > /dev/null
-`;
-    if (token) {
-      connectionInstructions = `
-TENANT_TOKEN="'${token}'"
-sed -i "s/Paste your Hosted Mender token here/$TENANT_TOKEN/" /etc/mender/mender.conf
-`;
-    }
-    let codeToCopy = `sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/${AppStore.getMenderDebPackageVersion()}/dist-packages/debian/armhf/mender-client_${AppStore.getMenderDebPackageVersion()}-1_armhf.deb
-dpkg -i mender-client_${AppStore.getMenderDebPackageVersion()}-1_armhf.deb
-cp /etc/mender/mender.conf.demo /etc/mender/mender.conf
-${connectionInstructions}
-mkdir -p /var/lib/mender
-echo "device_type=${selection}" | tee /var/lib/mender/device_type
-systemctl enable mender && systemctl restart mender'
-`;
+    const codeToCopy = getDebConfigurationCode(ipAddress, isHosted, isEnterprise, token, debPackageVersion, selection);
 
     const types = [
       {
@@ -135,7 +118,7 @@ systemctl enable mender && systemctl restart mender'
                 Copy to clipboard
               </Button>
             </CopyToClipboard>
-            <span style={{ wordBreak: 'break-word' }}>{codeToCopy}</span>
+            <span style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{codeToCopy}</span>
           </div>
           <p>{this.state.copied ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
           <p>This downloads the Mender client on the device, sets the configuration and starts the client.</p>

--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -22,10 +22,7 @@ exports[`renders correctly 1`] = `
     Installing and configuring the .deb package
   </h3>
   <p>
-    On the device, run the following commands:
-  </p>
-  <p>
-    Download the package:
+    The Mender package comes with a wizard that will let you easily configure and customize your installation. To install and configure Mender run the following command:
   </p>
   <div
     className="code"
@@ -77,92 +74,26 @@ exports[`renders correctly 1`] = `
         }
       }
     >
-      wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb
+      wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb &&
     sudo dpkg -i mender-client_master-1_armhf.deb
     </span>
   </div>
   <p />
   <p>
-    For demo purposes, copy the demo config file:
+    After the installation wizard is completed, Mender is correctly setup on your device and will automatically start in managed mode. Your device is now ready to authenticate with the server and start receiving updates.
   </p>
-  <div
-    className="code"
-  >
-    <button
-      className="MuiButtonBase-root MuiIconButton-root"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      style={
-        Object {
-          "float": "right",
-          "margin": "-20px 0 0 10px",
-        }
-      }
-      tabIndex={0}
-      type="button"
-    >
-      <span
-        className="MuiIconButton-label"
-      >
-        <svg
-          aria-hidden="true"
-          className="MuiSvgIcon-root"
-          focusable="false"
-          role="presentation"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-          />
-        </svg>
-      </span>
-    </button>
-    <span
-      style={
-        Object {
-          "wordBreak": "break-word",
-        }
-      }
-    >
-      sudo cp /etc/mender/mender.conf.demo /etc/mender/mender.conf
-    </span>
-  </div>
-  <p />
+  <h3>
+    Unattended installation
+  </h3>
   <p>
-    Or edit the config file yourself by
-     
-    <a
-      href="https://docs.mender.io/undefinedclient-configuration/configuration-file"
-      target="_blank"
-    >
-      following the docs
-    </a>
-    .
+    Alternatively to the above method, the package can be installed in a non-interactive way, suitable for scripts or other situations where no user input is desired. To learn about all configuration options, use \`mender setup --help\`.
   </p>
-  <br />
+  <p>
+    Use the below script to download and setup the Mender client for your Mender installation.
+  </p>
   <h4>
-    Setting the device type
+    Connecting to a demo server with demo settings
   </h4>
-  <p>
-    Create the Mender client state directory and set the device type on the device. This example uses 
-    <span
-      className="code"
-    >
-      generic-armv6
-    </span>
-    , but you can substitute your own specific device type:
-  </p>
   <div
     className="code"
   >
@@ -209,78 +140,21 @@ exports[`renders correctly 1`] = `
     <span
       style={
         Object {
+          "whiteSpace": "pre-wrap",
           "wordBreak": "break-word",
         }
       }
     >
-      sudo mkdir -p /var/lib/mender 
-echo "device_type=generic-armv6" | sudo tee /var/lib/mender/device_type
+      sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
+DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \\
+DEVICE_TYPE="generic-armv6" && \\ 
+mender setup \\
+  --device-type $DEVICE_TYPE \\
+  --demo  && \\
+systemctl restart mender-client'
+
     </span>
   </div>
   <p />
-  <br />
-  <h4>
-    Starting the client
-  </h4>
-  <p>
-    Enable and start the Mender client:
-  </p>
-  <div
-    className="code"
-  >
-    <button
-      className="MuiButtonBase-root MuiIconButton-root"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      style={
-        Object {
-          "float": "right",
-          "margin": "-20px 0 0 10px",
-        }
-      }
-      tabIndex={0}
-      type="button"
-    >
-      <span
-        className="MuiIconButton-label"
-      >
-        <svg
-          aria-hidden="true"
-          className="MuiSvgIcon-root"
-          focusable="false"
-          role="presentation"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-          />
-        </svg>
-      </span>
-    </button>
-    <span
-      style={
-        Object {
-          "wordBreak": "break-word",
-        }
-      }
-    >
-      sudo systemctl enable mender && sudo systemctl start mender
-    </span>
-  </div>
-  <p />
-  <p>
-    Once the client has started, your device will attempt to connect to the server. It will then appear in your Pending devices tab and you can continue.
-  </p>
 </div>
 `;

--- a/src/js/components/help/application-updates/mender-deb-package.js
+++ b/src/js/components/help/application-updates/mender-deb-package.js
@@ -2,6 +2,7 @@ import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import IconButton from '@material-ui/core/IconButton';
 import CopyPasteIcon from '@material-ui/icons/FileCopy';
+import AppActions from '../../../actions/app-actions';
 import AppStore from '../../../stores/app-store';
 import { findLocalIpAddress, getDebConfigurationCode } from '../../../helpers';
 
@@ -20,6 +21,9 @@ export default class DebPackage extends React.Component {
     if (!self.state.ipAddress || self.state.ipAddress === 'X.X.X.X') {
       findLocalIpAddress().then(ipAddress => self.setState({ ipAddress }));
     }
+    if (AppStore.hasMultitenancy() || AppStore.getIsEnterprise() || AppStore.getIsHosted()) {
+      AppActions.getUserOrganization().then(org => (org ? self.setState({ token: org.tenant_token }) : null));
+    }
   }
 
   _copied(ref) {
@@ -35,8 +39,7 @@ export default class DebPackage extends React.Component {
 
   render() {
     const self = this;
-    const { codeToCopyCopied, dpkgCodeCopied, ipAddress } = self.state;
-    const token = (self.props.org || {}).tenant_token;
+    const { codeToCopyCopied, dpkgCodeCopied, ipAddress, token } = self.state;
     const isHosted = AppStore.getIsHosted();
     const isEnterprise = AppStore.getIsEnterprise();
     const debPackageVersion = AppStore.getMenderDebPackageVersion();

--- a/src/js/components/help/application-updates/mender-deb-package.js
+++ b/src/js/components/help/application-updates/mender-deb-package.js
@@ -3,18 +3,23 @@ import CopyToClipboard from 'react-copy-to-clipboard';
 import IconButton from '@material-ui/core/IconButton';
 import CopyPasteIcon from '@material-ui/icons/FileCopy';
 import AppStore from '../../../stores/app-store';
-import { detectOsIdentifier } from '../../../helpers';
+import { findLocalIpAddress, getDebConfigurationCode } from '../../../helpers';
 
 export default class DebPackage extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      dpkgCode: false,
-      cpCode: false,
-      echoCode: false,
-      startCode: false,
-      tenantCode: false
+      codeToCopy: false,
+      dpkgCodeCopied: false,
+      ipAddress: AppStore.getHostAddress()
     };
+  }
+
+  componentDidMount() {
+    const self = this;
+    if (!self.state.ipAddress || self.state.ipAddress === 'X.X.X.X') {
+      findLocalIpAddress().then(ipAddress => self.setState({ ipAddress }));
+    }
   }
 
   _copied(ref) {
@@ -29,17 +34,23 @@ export default class DebPackage extends React.Component {
   }
 
   render() {
-    var tenantToken = (this.props.org || {}).tenant_token;
+    const self = this;
+    const { codeToCopyCopied, dpkgCodeCopied, ipAddress } = self.state;
+    const token = (self.props.org || {}).tenant_token;
+    const isHosted = AppStore.getIsHosted();
+    const isEnterprise = AppStore.getIsEnterprise();
+    const debPackageVersion = AppStore.getMenderDebPackageVersion();
+    const dpkgCode = `wget https://d1b0l86ne08fsf.cloudfront.net/${debPackageVersion}/dist-packages/debian/armhf/mender-client_${debPackageVersion}-1_armhf.deb &&
+    sudo dpkg -i mender-client_${debPackageVersion}-1_armhf.deb`;
 
-    var dpkgCode = `wget https://d1b0l86ne08fsf.cloudfront.net/${AppStore.getMenderDebPackageVersion()}/dist-packages/debian/armhf/mender-client_${AppStore.getMenderDebPackageVersion()}-1_armhf.deb
-    sudo dpkg -i mender-client_${AppStore.getMenderDebPackageVersion()}-1_armhf.deb`;
-    var cpCode = 'sudo cp /etc/mender/mender.conf.demo /etc/mender/mender.conf';
-    var echoCode = 'sudo mkdir -p /var/lib/mender \necho "device_type=generic-armv6" | sudo tee /var/lib/mender/device_type';
-    var startCode = 'sudo systemctl enable mender && sudo systemctl start mender';
-    var tenantCode = `TENANT_TOKEN="${tenantToken}" \nsudo sed -i ${
-      detectOsIdentifier() === 'MacOs' ? '""' : ''
-    } "s/Paste your Hosted Mender token here/$TENANT_TOKEN/" /etc/mender/mender.conf`;
-
+    const codeToCopy = getDebConfigurationCode(ipAddress, isHosted, isEnterprise, token, debPackageVersion);
+    let title = 'Connecting to a demo server with demo settings';
+    if (isEnterprise || isHosted) {
+      title = 'Connecting to an Enterprise server';
+      if (isHosted) {
+        title = 'Connecting to Mender Professional with demo settings';
+      }
+    }
     return (
       <div>
         <h2>Connecting your device using Mender .deb package</h2>
@@ -57,91 +68,41 @@ export default class DebPackage extends React.Component {
         </ul>
 
         <h3>Installing and configuring the .deb package</h3>
-        <p>On the device, run the following commands:</p>
-        <p>Download the package:</p>
+        <p>
+          The Mender package comes with a wizard that will let you easily configure and customize your installation. To install and configure Mender run the
+          following command:
+        </p>
         <div className="code">
-          <CopyToClipboard text={dpkgCode} onCopy={() => this._copied('dpkgCode')}>
+          <CopyToClipboard text={dpkgCode} onCopy={() => self._copied('dpkgCodeCopied')}>
             <IconButton style={{ float: 'right', margin: '-20px 0 0 10px' }}>
               <CopyPasteIcon />
             </IconButton>
           </CopyToClipboard>
           <span style={{ wordBreak: 'break-word' }}>{dpkgCode}</span>
         </div>
-        <p>{this.state.dpkgCode ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
+        <p>{dpkgCodeCopied ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
 
-        <p>For demo purposes, copy the demo config file:</p>
+        <p>
+          After the installation wizard is completed, Mender is correctly setup on your device and will automatically start in managed mode. Your device is now
+          ready to authenticate with the server and start receiving updates.
+        </p>
+
+        <h3>Unattended installation</h3>
+        <p>
+          Alternatively to the above method, the package can be installed in a non-interactive way, suitable for scripts or other situations where no user input
+          is desired. To learn about all configuration options, use `mender setup --help`.
+        </p>
+        <p>Use the below script to download and setup the Mender client for your Mender installation.</p>
+        <h4>{title}</h4>
         <div className="code">
-          <CopyToClipboard text={cpCode} onCopy={() => this._copied('cpCode')}>
+          <CopyToClipboard text={codeToCopy} onCopy={() => self._copied('codeToCopyCopied')}>
             <IconButton style={{ float: 'right', margin: '-20px 0 0 10px' }}>
               <CopyPasteIcon />
             </IconButton>
           </CopyToClipboard>
-          <span style={{ wordBreak: 'break-word' }}>{cpCode}</span>
+          <span style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{codeToCopy}</span>
         </div>
-        <p>{this.state.cpCode ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
-        <p>
-          Or edit the config file yourself by{' '}
-          <a href={`https://docs.mender.io/${this.props.docsVersion}client-configuration/configuration-file`} target="_blank">
-            following the docs
-          </a>
-          .
-        </p>
-
-        <br />
-
-        {this.props.isHosted ? (
-          <div>
-            <h4>Configuration for Hosted Mender server</h4>
-            <p>
-              To configure the Mender client for Hosted Mender, you need to edit <span className="code">&#47;etc&#47;mender&#47;mender.conf</span> and insert
-              your Tenant Token where it says &quot;Paste your Hosted Mender token here&quot;.
-            </p>
-
-            <p>Set the TENANT_TOKEN variable and update the configuration file:</p>
-            <div className="code">
-              <CopyToClipboard text={tenantCode} onCopy={() => this._copied('tenantCode')}>
-                <IconButton style={{ float: 'right', margin: '-20px 0 0 10px' }}>
-                  <CopyPasteIcon />
-                </IconButton>
-              </CopyToClipboard>
-              <span style={{ wordBreak: 'break-word' }}>{tenantCode}</span>
-            </div>
-            <p>{this.state.tenantCode ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
-            <br />
-          </div>
-        ) : null}
-
-        <h4>Setting the device type</h4>
-        <p>
-          Create the Mender client state directory and set the device type on the device. This example uses <span className="code">generic-armv6</span>, but you
-          can substitute your own specific device type:
-        </p>
-        <div className="code">
-          <CopyToClipboard text={echoCode} onCopy={() => this._copied('echoCode')}>
-            <IconButton style={{ float: 'right', margin: '-20px 0 0 10px' }}>
-              <CopyPasteIcon />
-            </IconButton>
-          </CopyToClipboard>
-          <span style={{ wordBreak: 'break-word' }}>{echoCode}</span>
-        </div>
-        <p>{this.state.echoCode ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
-        <br />
-
-        <h4>Starting the client</h4>
-        <p>Enable and start the Mender client:</p>
-        <div className="code">
-          <CopyToClipboard text={startCode} onCopy={() => this._copied('startCode')}>
-            <IconButton style={{ float: 'right', margin: '-20px 0 0 10px' }}>
-              <CopyPasteIcon />
-            </IconButton>
-          </CopyToClipboard>
-          <span style={{ wordBreak: 'break-word' }}>{startCode}</span>
-        </div>
-        <p>{this.state.startCode ? <span className="green fadeIn">Copied to clipboard.</span> : null}</p>
-
-        <p>
-          Once the client has started, your device will attempt to connect to the server. It will then appear in your Pending devices tab and you can continue.
-        </p>
+        <p>{codeToCopyCopied && <span className="green fadeIn">Copied to clipboard.</span>}</p>
       </div>
     );
   }

--- a/src/js/components/help/releases-and-artifacts/__snapshots__/build-demo-artifact.test.js.snap
+++ b/src/js/components/help/releases-and-artifacts/__snapshots__/build-demo-artifact.test.js.snap
@@ -77,7 +77,7 @@ exports[`renders correctly 1`] = `
         }
       >
         
-sudo chmod +x mender-artifact
+sudo chmod +x mender-artifact && \\
 sudo mv mender-artifact /usr/local/bin
       </span>
     </div>
@@ -144,7 +144,7 @@ sudo mv mender-artifact /usr/local/bin
         }
       >
         
-wget https://raw.githubusercontent.com/mendersoftware/mender/master/support/modules-artifact-gen/single-file-artifact-gen
+wget https://raw.githubusercontent.com/mendersoftware/mender/master/support/modules-artifact-gen/single-file-artifact-gen && \\
 sudo chmod +x single-file-artifact-gen
       </span>
     </div>
@@ -316,7 +316,12 @@ EOF
         }
       >
         
-ARTIFACT_NAME="demo-webserver-updated"; DEVICE_TYPE="generic_x86"; OUTPUT_PATH="demo-webserver-updated.mender"; DEST_DIR="/var/www/localhost/htdocs/"; FILE_NAME="index.html"; ./single-file-artifact-gen -n \${ARTIFACT_NAME} -t \${DEVICE_TYPE} -d \${DEST_DIR} -o \${OUTPUT_PATH} \${FILE_NAME}
+ARTIFACT_NAME="demo-webserver-updated" && \\
+DEVICE_TYPE="generic_x86" && \\
+OUTPUT_PATH="demo-webserver-updated.mender" && \\
+DEST_DIR="/var/www/localhost/htdocs/" && \\
+FILE_NAME="index.html" && \\
+./single-file-artifact-gen -n \${ARTIFACT_NAME} -t \${DEVICE_TYPE} -d \${DEST_DIR} -o \${OUTPUT_PATH} \${FILE_NAME}
 
       </span>
     </div>

--- a/src/js/components/help/releases-and-artifacts/build-demo-artifact.js
+++ b/src/js/components/help/releases-and-artifacts/build-demo-artifact.js
@@ -36,21 +36,21 @@ export default class BuildDemoArtifact extends React.Component {
 
   render() {
     var executable = `
-sudo chmod +x mender-artifact
+sudo chmod +x mender-artifact && \\
 sudo mv mender-artifact /usr/local/bin`;
     const artifactGenerator = 'single-file-artifact-gen';
     const artifactName = 'demo-webserver-updated';
 
     const file_install = `
-wget https://raw.githubusercontent.com/mendersoftware/mender/${AppStore.getMenderVersion()}/support/modules-artifact-gen/${artifactGenerator}
+wget https://raw.githubusercontent.com/mendersoftware/mender/${AppStore.getMenderVersion()}/support/modules-artifact-gen/${artifactGenerator} && \\
 sudo chmod +x ${artifactGenerator}`;
 
     const generate = `
-ARTIFACT_NAME="${artifactName}"; \
-DEVICE_TYPE="generic_x86"; \
-OUTPUT_PATH="${artifactName}.mender"; \
-DEST_DIR="/var/www/localhost/htdocs/"; \
-FILE_NAME="index.html"; \
+ARTIFACT_NAME="${artifactName}" && \\
+DEVICE_TYPE="generic_x86" && \\
+OUTPUT_PATH="${artifactName}.mender" && \\
+DEST_DIR="/var/www/localhost/htdocs/" && \\
+FILE_NAME="index.html" && \\
 ./${artifactGenerator} -n \${ARTIFACT_NAME} \
 -t \${DEVICE_TYPE} -d \${DEST_DIR} -o \${OUTPUT_PATH} \
 \${FILE_NAME}

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -13,3 +13,11 @@ window.mender_environment = {
     inventoryVersion: null
   }
 };
+
+window.RTCPeerConnection = () => {
+  return {
+    createOffer: () => {},
+    setLocalDescription: () => {},
+    createDataChannel: () => {}
+  };
+};


### PR DESCRIPTION
this should now lead onboarding users to use `mender setup` and also show the relevant config method in the help section (using `mender setup`).
the resulting commands for

professional:
```
sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \
DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \
DEVICE_TYPE="generic-armv6" && \ 
TENANT_TOKEN=eyJhbGciOiJSU.........G8T7A9a5j && \
mender setup \
  --device-type $DEVICE_TYPE \
  --mender-professional \
  --tenant-token $TENANT_TOKEN \
  --retry-poll 30 \
  --update-poll 5 \
  --inventory-poll 5 && \
systemctl restart mender-client'
```
enterprise:
```
sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \
DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \
DEVICE_TYPE="generic-armv6" && \ 
TENANT_TOKEN=eyJhbGciOiJSU.........G8T7A9a5j && \
mender setup \
  --device-type $DEVICE_TYPE \
  --server-url 192.168.10.189 --server-cert="" \
  --tenant-token $TENANT_TOKEN \
  --retry-poll 30 \
  --update-poll 5 \
  --inventory-poll 5 && \
systemctl restart mender-client'
```
and default:
```
sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \
DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \
DEVICE_TYPE="generic-armv6" && \ 
mender setup \
  --device-type $DEVICE_TYPE \
  --demo --server-ip 192.168.10.189 && \
systemctl restart mender-client'
```
