### PR TITLE
Remove trailing white space in tutorial shell snippet

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -147,7 +147,7 @@ exports[`renders correctly 1`] = `
     >
       sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
 DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \\
-DEVICE_TYPE="generic-armv6" && \\ 
+DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\
   --demo  && \\

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -451,7 +451,7 @@ ${enterpriseSettings}`;
   }
   let codeToCopy = `sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/${packageVersion}/dist-packages/debian/armhf/mender-client_${packageVersion}-1_armhf.deb && \\
 DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_${packageVersion}-1_armhf.deb && \\
-DEVICE_TYPE="${deviceType}" && \\ ${
+DEVICE_TYPE="${deviceType}" && \\${
   token
     ? `
 TENANT_TOKEN=${token} && \\`


### PR DESCRIPTION
Remove trailing white space in shell snippet

This was resulting in a `bash: line 2:  : command not found` error.