### PR TITLE
fix: added missing quotation marks around tenant token in deb config code

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -454,7 +454,7 @@ DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_${packageVersion}-1_armhf.d
 DEVICE_TYPE="${deviceType}" && \\${
   token
     ? `
-TENANT_TOKEN=${token} && \\`
+TENANT_TOKEN="${token}" && \\`
     : ''
 }
 mender setup \\


### PR DESCRIPTION
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>