### PR TITLE
fix: removed superfluous ' around tenant token in device config code

### DIFF
--- a/src/js/components/common/dialogs/physicaldeviceonboarding.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.js
@@ -59,7 +59,7 @@ grep "\\sdocker.mender.io" /etc/hosts >/dev/null 2>&1 || echo "$DOCKER_HOST_IP d
 `;
     if (token) {
       connectionInstructions = `
-TENANT_TOKEN="'${token}'"
+TENANT_TOKEN="${token}"
 sed -i "s/Paste your Hosted Mender token here/$TENANT_TOKEN/" /etc/mender/mender.conf
 `;
     }


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>