### PR TITLE
Cherry-picks needed for 2.1.1 release

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,8 @@ cat >/var/www/mender-gui/dist/env.js <<EOF
       isEnterprise: "$HAVE_ENTERPRISE",
       isHosted: "$MENDER_HOSTED"
     },
-    menderVersion: "$INTEGRATION_VERSION",
+    integrationVersion: "$INTEGRATION_VERSION",
+    menderVersion: "$MENDER_VERSION",
     menderArtifactVersion: "$MENDER_ARTIFACT_VERSION",
     menderDebPackageVersion: "$MENDER_DEB_PACKAGE_VERSION",
     metaMenderVersion: "$META_MENDER_VERSION",

--- a/src/js/components/app.js
+++ b/src/js/components/app.js
@@ -34,7 +34,7 @@ class AppRoot extends React.Component {
     super(props, context);
     this.state = {
       artifactProgress: 0,
-      version: AppStore.getMenderVersion(),
+      version: AppStore.getIntegrationVersion(),
       docsVersion: AppStore.getDocsVersion(),
       timeout: 900000, // 15 minutes idle time,
       uploadArtifact: (meta, file) => this._uploadArtifact(meta, file),

--- a/src/js/stores/app-store.js
+++ b/src/js/stores/app-store.js
@@ -38,6 +38,7 @@ var _groups = [];
 var _releasesRepo = [];
 var _uploadInProgress = false;
 const _hostAddress = mender_environment && mender_environment.hostAddress ? mender_environment.hostAddress : null;
+const _IntegrationVersion = mender_environment && mender_environment.integrationVersion ? mender_environment.integrationVersion : 'master';
 const _MenderVersion = mender_environment && mender_environment.menderVersion ? mender_environment.menderVersion : 'master';
 const _menderArtifactVersion = mender_environment && mender_environment.menderArtifactVersion ? mender_environment.menderArtifactVersion : 'master';
 const _menderDebPackageVersion = mender_environment && mender_environment.menderDebPackageVersion ? mender_environment.menderDebPackageVersion : 'master';
@@ -45,7 +46,8 @@ var _demoArtifactPort = mender_environment && mender_environment.demoArtifactPor
 var _globalSettings = {};
 
 const _versionInformation = {
-  Mender: mender_environment.menderVersion,
+  Integration: mender_environment.integrationVersion,
+  'Mender-Client': mender_environment.menderVersion,
   'Mender-Artifact': mender_environment.menderArtifactVersion,
   'Meta-Mender': mender_environment.metaMenderVersion,
   Deployments: mender_environment.services.deploymentsVersion,
@@ -682,6 +684,16 @@ var AppStore = Object.assign({}, EventEmitter.prototype, {
   getShowConnectDeviceDialog: () => _showConnectDeviceDialog,
 
   getShowCreateArtifactDialog: () => _showCreateArtifactDialog,
+
+  getIntegrationVersion: function() {
+    // return version number
+    var version = '';
+    if (_IntegrationVersion) {
+      // if first character NaN, is master branch
+      version = isNaN(_IntegrationVersion.charAt(0)) ? 'master' : _IntegrationVersion;
+    }
+    return version;
+  },
 
   getMenderVersion: function() {
     // return version number


### PR DESCRIPTION
```
Integration and mender client version are not equal anymore.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 6f9115516c760b3776b73319c0e17c3eef685e2e)
```