### PR TITLE
Rename hosted mender setup flag and make setup quiet

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -150,7 +150,7 @@ DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \\
 DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\
-  --demo  && \\
+  --quiet --demo  && \\
 systemctl restart mender-client'
 
     </span>

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -436,16 +436,16 @@ export const standardizePhases = phases =>
   });
 
 export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, token, packageVersion, deviceType = 'generic-armv6') => {
-  let connectionInstructions = `  --demo ${ipAddress ? `--server-ip ${ipAddress}` : ''}`;
+  let connectionInstructions = `  --quiet --demo ${ipAddress ? `--server-ip ${ipAddress}` : ''}`;
   if (isEnterprise || isHosted) {
     const enterpriseSettings = `  --tenant-token $TENANT_TOKEN \\
   --retry-poll 30 \\
   --update-poll 5 \\
   --inventory-poll 5`;
-    connectionInstructions = `${ipAddress ? `  --server-url ${ipAddress}` : ' '} --server-cert="" \\
-${enterpriseSettings}`;
+    connectionInstructions = `--quiet ${ipAddress ? `  --server-url ${ipAddress}` : ' '} \\
+    --server-cert="" {enterpriseSettings}`;
     if (isHosted) {
-      connectionInstructions = `  --mender-professional \\
+      connectionInstructions = `  --quiet --hosted-mender \\
 ${enterpriseSettings}`;
     }
   }


### PR DESCRIPTION
As part of [MEN-2929](https://tracker.mender.io/browse/MEN-2929), we're renaming the `--mender-professional` flag to `--hosted-mender` for the client setup command.

This PR depends on [PR: 457](https://github.com/mendersoftware/mender/pull/457) in the mender repository.

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>