### PR TITLE
Fix build failure by restoring less variable

### DIFF
--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -18,6 +18,7 @@
 @placeholder: #e7e7e7;
 @mendergreen: #015969;
 @mendermaroon: #5d0f43;
+@menderwarning: rgb(225, 0, 80);
 @text: #404041;
 @textsecondary: #decfd9;
 @textmuted: rgba(0, 0, 0, 0.54);


### PR DESCRIPTION
Fix build failure by restoring less variable

The warning variable in variables.less sees to have been removed in
commit d8fc98b during PR #592 (by mistake?).

Mysteriously, the builds passed for this PR, but it was after the merge
of the next PR #591 that the build started failing. Furthermore, this
second PR #591 was also passing in isolation, but a local experiment
rebasing it on top of the previous one shows the build failure.