### PR TITLE
Fixed deployment device list page length changing and device ids

### DIFF
--- a/src/js/components/common/pagination.js
+++ b/src/js/components/common/pagination.js
@@ -15,9 +15,8 @@ const paginationIndex = 1;
 class TablePaginationActions extends React.Component {
   constructor(props, context) {
     super(props, context);
-    this.state = {
-      pageNo: 1
-    };
+    const pageNo = props.page ? props.page + paginationIndex : 1;
+    this.state = { pageNo };
   }
 
   componentDidUpdate(prevProps) {
@@ -53,8 +52,7 @@ class TablePaginationActions extends React.Component {
   };
 
   onPaging = newPage => {
-    this.setState({ pageNo: newPage });
-    return this.props.onChangePage(newPage);
+    return this.setState({ pageNo: newPage }, this.props.onChangePage(newPage));
   };
 
   render() {

--- a/src/js/components/common/pagination.js
+++ b/src/js/components/common/pagination.js
@@ -52,7 +52,7 @@ class TablePaginationActions extends React.Component {
   };
 
   onPaging = newPage => {
-    return this.setState({ pageNo: newPage }, this.props.onChangePage(newPage));
+    return this.setState({ pageNo: newPage }, () => this.props.onChangePage(newPage));
   };
 
   render() {

--- a/src/js/components/deployments/deploymentdevicelist.js
+++ b/src/js/components/deployments/deploymentdevicelist.js
@@ -15,32 +15,26 @@ const stateTitleMap = {
 };
 
 export default class ProgressDeviceList extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {
-      globalSettings: AppStore.getGlobalSettings() || {}
-    };
-  }
-  shouldComponentUpdate(nextProps, nextState) {
-    return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState);
+  shouldComponentUpdate(nextProps) {
+    return !isEqual(this.props, nextProps);
   }
   render() {
     var self = this;
     var intervalsSinceStart = Math.floor((Date.now() - Date.parse(self.props.created)) / (1000 * 20));
-    const { globalSettings } = self.state;
+    const globalSettings = AppStore.getGlobalSettings();
 
     var deviceList = [];
     var currentArtifactLink;
     if (this.props.devices) {
       deviceList = this.props.devices.map((device, index) => {
         var encodedDevice = `id=${device.id}`;
-        var id_attribute = device.id;
 
-        if (globalSettings.id_attribute && globalSettings.id_attribute !== 'Device ID') {
+        let id_attribute = device.id;
+        if (globalSettings && globalSettings.id_attribute && globalSettings.id_attribute !== 'Device ID') {
           // if global setting is not "Device Id"
-          if ((self.props.deviceIdentity || {})[device.id]) {
+          if ((self.props.deviceInventory || {})[device.id] && (self.props.deviceInventory || {})[device.id].identity_data) {
             // if device identity data is available, set custom attribute
-            id_attribute = self.props.deviceIdentity[device.id][globalSettings.id_attribute];
+            id_attribute = self.props.deviceInventory[device.id].identity_data[globalSettings.id_attribute];
           } else {
             id_attribute = '-';
           }

--- a/src/js/components/deployments/report.js
+++ b/src/js/components/deployments/report.js
@@ -380,7 +380,7 @@ export default class DeploymentReport extends React.Component {
             <Pagination
               count={allDevices.length}
               rowsPerPage={self.state.perPage}
-              onChangeRowsPerPage={perPage => self.setState({ currentPage: 1, perPage })}
+              onChangeRowsPerPage={perPage => self.setState({ perPage }, () => self._handlePageChange(1))}
               page={self.state.currentPage}
               onChangePage={page => self._handlePageChange(page)}
             />

--- a/src/js/components/devices/preauthorize-devices.js
+++ b/src/js/components/devices/preauthorize-devices.js
@@ -304,6 +304,7 @@ export default class Preauthorize extends React.Component {
               columnHeaders={columnHeaders}
               limitMaxed={limitMaxed}
               onPageChange={e => self._handlePageChange(e)}
+              onChangeRowsPerPage={pageLength => self.setState({ pageNo: 1, pageLength })}
               pageTotal={self.state.count}
               refreshDevices={() => self._getDevices()}
             />

--- a/src/js/components/devices/rejected-devices.js
+++ b/src/js/components/devices/rejected-devices.js
@@ -122,6 +122,7 @@ export default class Rejected extends React.Component {
               columnHeaders={columnHeaders}
               limitMaxed={limitMaxed}
               onPageChange={e => self._handlePageChange(e)}
+              onChangeRowsPerPage={pageLength => self.setState({ pageNo: 1, pageLength })}
               pageTotal={self.state.count}
               refreshDevices={() => self._getDevices()}
             />


### PR DESCRIPTION
this includes the fixes from #601

targeting 2.2.x since this is the closest to the currently deployed version on MP (which runs 2.2.0) and thus should be tested & deployed if it is considered merge worthy.