### PR TITLE
Add flags for deb package script to handle existing conf

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -75,7 +75,7 @@ exports[`DebPackage Component renders correctly 1`] = `
       }
     >
       wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb &&
-    sudo dpkg -i mender-client_master-1_armhf.deb
+    sudo dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb
     </span>
   </div>
   <p />

--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -74,8 +74,8 @@ exports[`DebPackage Component renders correctly 1`] = `
         }
       }
     >
-      wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb &&
-    sudo dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb
+      wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
+sudo dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb
     </span>
   </div>
   <p />
@@ -146,7 +146,7 @@ exports[`DebPackage Component renders correctly 1`] = `
       }
     >
       sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
-DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb && \\
+DEBIAN_FRONTEND=noninteractive dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb && \\
 DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\

--- a/src/js/components/help/application-updates/mender-deb-package.js
+++ b/src/js/components/help/application-updates/mender-deb-package.js
@@ -2,7 +2,7 @@ import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import IconButton from '@material-ui/core/IconButton';
 import CopyPasteIcon from '@material-ui/icons/FileCopy';
-import { getDebConfigurationCode } from '../../../helpers';
+import { getDebConfigurationCode, getDebInstallationCode } from '../../../helpers';
 
 export default class DebPackage extends React.Component {
   constructor(props, context) {
@@ -36,8 +36,7 @@ export default class DebPackage extends React.Component {
     const { codeToCopyCopied, dpkgCodeCopied } = self.state;
     const { debPackageVersion, ipAddress, isHosted, isEnterprise, org } = self.props;
     const token = (org || {}).tenant_token;
-    const dpkgCode = `wget https://d1b0l86ne08fsf.cloudfront.net/${debPackageVersion}/dist-packages/debian/armhf/mender-client_${debPackageVersion}-1_armhf.deb &&
-    sudo dpkg -i mender-client_${debPackageVersion}-1_armhf.deb`;
+    const dpkgCode = getDebInstallationCode(debPackageVersion);
     const codeToCopy = getDebConfigurationCode(ipAddress, isHosted, isEnterprise, token, debPackageVersion);
     let title = 'Connecting to a demo server with demo settings';
     if (isEnterprise) {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -524,6 +524,12 @@ export const matchFilters = (device, filters = store.getState().devices.filterin
     return accu;
   }, true);
 
+export const getDebInstallationCode = (
+  packageVersion,
+  noninteractive = false
+) => `wget https://d1b0l86ne08fsf.cloudfront.net/${packageVersion}/dist-packages/debian/armhf/mender-client_${packageVersion}-1_armhf.deb && \\
+${noninteractive ? 'DEBIAN_FRONTEND=noninteractive' : 'sudo'} dpkg -i --force-confdef --force-confold mender-client_${packageVersion}-1_armhf.deb`;
+
 export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, token, packageVersion, deviceType = 'generic-armv6') => {
   let connectionInstructions = `  --quiet --demo ${ipAddress ? `--server-ip ${ipAddress}` : ''}`;
   if (isEnterprise || isHosted) {
@@ -538,8 +544,8 @@ export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, token
 ${enterpriseSettings}`;
     }
   }
-  let codeToCopy = `sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/${packageVersion}/dist-packages/debian/armhf/mender-client_${packageVersion}-1_armhf.deb && \\
-DEBIAN_FRONTEND=noninteractive dpkg -i --force-confdef --force-confold mender-client_${packageVersion}-1_armhf.deb && \\
+  const debInstallationCode = getDebInstallationCode(packageVersion, true);
+  let codeToCopy = `sudo bash -c '${debInstallationCode} && \\
 DEVICE_TYPE="${deviceType}" && \\${
     token
       ? `

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -539,7 +539,7 @@ ${enterpriseSettings}`;
     }
   }
   let codeToCopy = `sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/${packageVersion}/dist-packages/debian/armhf/mender-client_${packageVersion}-1_armhf.deb && \\
-DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_${packageVersion}-1_armhf.deb && \\
+DEBIAN_FRONTEND=noninteractive dpkg -i --force-confdef --force-confold mender-client_${packageVersion}-1_armhf.deb && \\
 DEVICE_TYPE="${deviceType}" && \\${
     token
       ? `


### PR DESCRIPTION
In case the device has an existing conf file (which is the case for the
new Raspbian image), dpkg will prompt the user what to do with the
existing conf file (i.e. `/etc/mender/artifact_info`).

These flags will make dpkg keep the existing file.