### PR TITLE
Fix for additional redirect after deployment creation

### DIFF
--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -60,7 +60,7 @@ export class CreateDialog extends React.Component {
     this.props.selectDevice();
     this.props.selectRelease();
     const location = window.location.hash.substring(0, window.location.hash.indexOf('?'));
-    window.location.replace(location);
+    return location.length ? window.location.replace(location) : null;
   }
 
   onScheduleSubmit(settings) {


### PR DESCRIPTION
the redirect was applied if deployments were created from the finished deployment tab
- on the active deployments tab it would redirect to home

Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>