### PR TITLE
Generate the disclaimer via Dockerfile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,11 +93,13 @@ publish:image:
     - docker
 
 publish:disclaimer:
-  image: node:12.14.0-alpine
   stage: publish
+  services:
+    - docker:dind
   script:
-    - npm ci
-    - npm run disclaim
+    - docker build -f Dockerfile.disclaimer -t disclaimer .
+    - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/extract disclaimer -c "cp disclaimer.txt /extract/"
+    - docker image rm disclaimer
   artifacts:
     expire_in: 2w
     paths:

--- a/Dockerfile.disclaimer
+++ b/Dockerfile.disclaimer
@@ -1,0 +1,7 @@
+FROM node:12.14.0-alpine AS build
+WORKDIR /usr/src/app
+COPY package-lock.json package.json ./
+RUN npm ci
+COPY . ./
+RUN npm run build
+RUN npm run disclaim


### PR DESCRIPTION
Generate the disclaimer via Dockerfile

So that it can easily be generated externally (i.e. through the release
tool).

The release tool relied on this file being copied all the way to the
nginx server, which does not happen anymore after e2c48bd.