### PR TITLE
corrected faulty check for docs version, to not always point to development

### DIFF
--- a/src/js/reducers/appReducer.js
+++ b/src/js/reducers/appReducer.js
@@ -41,11 +41,11 @@ const initialState = {
   },
   hostedAnnouncement: menderEnvironment.hostedAnnouncement,
   docsVersion: isNaN(menderEnvironment.menderVersion.charAt(0))
-    ? menderEnvironment.menderVersion
+    ? ''
+    : menderEnvironment.menderVersion
         .split('.')
         .slice(0, 2)
-        .join('.')
-    : '',
+        .join('.'),
   menderDebPackageVersion: menderEnvironment.menderDebPackageVersion || 'master',
   versionInformation: {
     Integration: isNaN(menderEnvironment.integrationVersion.charAt(0)) ? 'master' : menderEnvironment.integrationVersion,


### PR DESCRIPTION
The parsing condition was plainly in the wrong order
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>