### PR TITLE
Cherry-pick deployment report changes to 2.3.x

### DIFF
--- a/src/js/components/deployments/deployments.js
+++ b/src/js/components/deployments/deployments.js
@@ -241,9 +241,9 @@ export class Deployments extends React.Component {
       .abortDeployment(id)
       .then(() => {
         clearTimeout(self.dynamicTimer);
-        self._refreshDeployments();
-        self.setState({ createDialog: false, doneLoading: false });
+        self.setState({ createDialog: false, reportDialog: false, doneLoading: false });
         self.props.setSnackbar('The deployment was successfully aborted');
+        self._refreshDeployments();
       })
       .catch(err => {
         console.log(err);

--- a/src/js/components/deployments/deploymentstatus.js
+++ b/src/js/components/deployments/deploymentstatus.js
@@ -24,9 +24,7 @@ export default class DeploymentStatus extends React.PureComponent {
     }
     // isActive has changed
     if (!prevProps.isActiveTab && self.props.isActiveTab && self.props.refresh) {
-      self.timer = setInterval(() => {
-        self.props.refreshStatus(self.props.id);
-      }, 10000);
+      self.timer = setInterval(() => self.props.refreshStatus(self.props.id), 10000);
     }
     if (
       prevProps.stats !== self.props.stats &&
@@ -41,9 +39,7 @@ export default class DeploymentStatus extends React.PureComponent {
   componentDidMount() {
     var self = this;
     if (self.props.refresh) {
-      self.timer = setInterval(() => {
-        self.props.refreshStatus(self.props.id);
-      }, 10000);
+      self.timer = setInterval(() => self.props.refreshStatus(self.props.id), 10000);
     }
     self.props.refreshStatus(self.props.id);
   }

--- a/src/js/components/deployments/report.js
+++ b/src/js/components/deployments/report.js
@@ -83,7 +83,9 @@ export class DeploymentReport extends React.Component {
   }
   refreshDeploymentDevices() {
     var self = this;
-
+    if (!self.props.deployment.id) {
+      return;
+    }
     return self.props.getSingleDeploymentDevices(self.props.deployment.id).then(() => self._handlePageChange(self.state.currentPage));
   }
   _getDeviceAttribute(device, attributeName) {
@@ -270,7 +272,7 @@ export class DeploymentReport extends React.Component {
                   vertical={true}
                   id={deployment.id}
                   stats={stats}
-                  refreshStatus={id => self.props.getSingleDeploymentStats(id)}
+                  refreshStatus={id => (id ? self.props.getSingleDeploymentStats(id) : null)}
                 />
               </div>
 
@@ -329,13 +331,14 @@ export class DeploymentReport extends React.Component {
 const actionCreators = { getDeviceAuth, getDeviceById, getDeviceLog, getSingleDeploymentDevices, getSingleDeploymentStats };
 
 const mapStateToProps = state => {
-  const allDevices = sortDeploymentDevices(Object.values(state.deployments.byId[state.deployments.selectedDeployment].devices || {}));
+  const devices = state.deployments.byId[state.deployments.selectedDeployment]?.devices || {};
+  const allDevices = sortDeploymentDevices(Object.values(devices));
   return {
     acceptedDevicesCount: state.devices.byStatus.accepted.total,
     allDevices,
     deviceCount: allDevices.length,
     devicesById: state.devices.byId,
-    deployment: state.deployments.byId[state.deployments.selectedDeployment]
+    deployment: state.deployments.byId[state.deployments.selectedDeployment] || {}
   };
 };
 


### PR DESCRIPTION
+ added safeguards to handle timing issues on abort in the report
the issue arose when the selected deployment in the report was already aborted
but the underlying data structure was still active in the dialog

Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>