### PR TITLE
In onboarding, use snapshot link instead of dated link to

### DIFF
--- a/src/js/components/helptips/__snapshots__/onboardingcompletetip.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/onboardingcompletetip.test.js.snap
@@ -79,7 +79,7 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
     What next?
     <div>
       <a
-        href="https://docs.mender.io/getting-started/on-premise-installation/deploy-a-system-update-demo"
+        href="https://docs.mender.io/artifacts/snapshots"
         target="_blank"
       >
         Learn about full-image updates

--- a/src/js/components/helptips/onboardingcompletetip.js
+++ b/src/js/components/helptips/onboardingcompletetip.js
@@ -78,7 +78,7 @@ export class OnboardingCompleteTip extends React.Component {
           <p>{`If you used one of our pre-built images you can start using full-image${hasDeltaAccess ? ` and delta` : ''} updates right away.`}</p>
           What next?
           <div>
-            <a href={`https://docs.mender.io/${docsVersion}getting-started/on-premise-installation/deploy-a-system-update-demo`} target="_blank">
+            <a href={`https://docs.mender.io/${docsVersion}artifacts/snapshots`} target="_blank">
               Learn about full-image updates
             </a>{' '}
             or{' '}


### PR DESCRIPTION
dummy system update demo.