### PR TITLE
Dynamic deployments improvements

### DIFF
--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -125,6 +125,7 @@ export class CreateDialog extends React.Component {
           </Stepper>
           <ComponentToShow
             deploymentAnchor={this.deploymentRef}
+            filters={deploymentSettings.filterId ? groups[deploymentObject.group || group].filters : undefined}
             {...self.props}
             {...self.state}
             {...deploymentSettings}

--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -124,7 +124,6 @@ export class CreateDialog extends React.Component {
             ))}
           </Stepper>
           <ComponentToShow
-            disableSchedule={self.state.disableSchedule}
             deploymentAnchor={this.deploymentRef}
             {...self.props}
             {...self.state}

--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -99,7 +99,7 @@ export class CreateDialog extends React.Component {
   render() {
     const self = this;
     const { device, deploymentObject, groups, open, release } = self.props;
-    const { activeStep, deploymentDeviceIds, group, phases, retries, steps } = self.state;
+    const { activeStep, deploymentDeviceIds, disableSchedule, group, phases, retries, steps } = self.state;
     const ComponentToShow = steps[activeStep].component;
     const deploymentSettings = {
       deploymentDeviceIds: deploymentObject.deploymentDeviceIds || deploymentDeviceIds,
@@ -109,7 +109,8 @@ export class CreateDialog extends React.Component {
       release: deploymentObject.release || release || self.state.release,
       retries: deploymentObject.retries || retries
     };
-    const disabled = activeStep === 0 ? !(deploymentSettings.release && deploymentSettings.deploymentDeviceIds.length) : self.state.disableSchedule;
+    const disabled =
+      activeStep === 0 ? !(deploymentSettings.release && (deploymentSettings.deploymentDeviceIds.length || deploymentSettings.filterId)) : disableSchedule;
     const finalStep = activeStep === steps.length - 1;
     return (
       <Dialog open={open || false} fullWidth={false} maxWidth="md">

--- a/src/js/components/deployments/deployment-report/overview.js
+++ b/src/js/components/deployments/deployment-report/overview.js
@@ -8,7 +8,7 @@ import isEqual from 'lodash.isequal';
 import { Button, Tooltip } from '@material-ui/core';
 import { Block as BlockIcon, Timelapse as TimelapseIcon, Refresh as RefreshIcon } from '@material-ui/icons';
 
-import { formatTime, generateDeploymentGroupDetails } from '../../../helpers';
+import { formatTime } from '../../../helpers';
 import ExpandableAttribute from '../../common/expandable-attribute';
 import Pagination from '../../common/pagination';
 
@@ -97,12 +97,7 @@ export default class DeploymentOverview extends React.Component {
                 dividerDisabled={true}
                 style={{ marginBottom: -15 }}
               />
-              <ExpandableAttribute
-                primary="Device group:"
-                secondary={generateDeploymentGroupDetails(deployment.filter, deployment.name)}
-                dividerDisabled={true}
-                style={{ marginBottom: -15 }}
-              />
+              <ExpandableAttribute primary="Device group:" secondary={deployment.name} dividerDisabled={true} style={{ marginBottom: -15 }} />
             </div>
             <ExpandableAttribute primary="Status:" secondary={statusDescription} dividerDisabled={true} style={{ marginBottom: -15 }} />
           </div>

--- a/src/js/components/deployments/deployment-report/overview.js
+++ b/src/js/components/deployments/deployment-report/overview.js
@@ -8,8 +8,7 @@ import isEqual from 'lodash.isequal';
 import { Button, Tooltip } from '@material-ui/core';
 import { Block as BlockIcon, Timelapse as TimelapseIcon, Refresh as RefreshIcon } from '@material-ui/icons';
 
-import { formatTime } from '../../../helpers';
-import { DEVICE_FILTERING_OPTIONS } from '../../../constants/deviceConstants';
+import { formatTime, generateDeploymentGroupDetails } from '../../../helpers';
 import ExpandableAttribute from '../../common/expandable-attribute';
 import Pagination from '../../common/pagination';
 
@@ -83,9 +82,6 @@ export default class DeploymentOverview extends React.Component {
       </div>
     );
 
-    const deviceGroupDetails = deployment.filter
-      ? deployment.filter.terms.map(filter => `${filter.attribute} ${DEVICE_FILTERING_OPTIONS[filter.type].shortform} ${filter.value}`).join(', ')
-      : deployment.name;
     return (
       <div>
         <div className="report-container">
@@ -101,7 +97,12 @@ export default class DeploymentOverview extends React.Component {
                 dividerDisabled={true}
                 style={{ marginBottom: -15 }}
               />
-              <ExpandableAttribute primary="Device group:" secondary={deviceGroupDetails} dividerDisabled={true} style={{ marginBottom: -15 }} />
+              <ExpandableAttribute
+                primary="Device group:"
+                secondary={generateDeploymentGroupDetails(deployment.filter, deployment.name)}
+                dividerDisabled={true}
+                style={{ marginBottom: -15 }}
+              />
             </div>
             <ExpandableAttribute primary="Status:" secondary={statusDescription} dividerDisabled={true} style={{ marginBottom: -15 }} />
           </div>

--- a/src/js/components/deployments/deployment-wizard/review.js
+++ b/src/js/components/deployments/deployment-wizard/review.js
@@ -7,9 +7,9 @@ import { Chip, List } from '@material-ui/core';
 import EnterpriseNotification from '../../common/enterpriseNotification';
 import ExpandableAttribute from '../../common/expandable-attribute';
 import { PLANS as plans } from '../../../constants/appConstants';
-import { formatTime, getRemainderPercent } from '../../../helpers';
+import { formatTime, generateDeploymentGroupDetails, getRemainderPercent } from '../../../helpers';
 
-const Review = ({ deployment = {}, deploymentDeviceIds, device, group, isEnterprise, isHosted, phases, plan, release, retries = 0 }) => {
+const Review = ({ deployment = {}, deploymentDeviceIds, device, filters, group, isEnterprise, isHosted, phases, plan, release, retries = 0 }) => {
   // Create 'phases' for view only
   const deploymentPhases = phases || [{ batch_size: 100 }];
   const start_time = deploymentPhases[0].start_ts || deployment.created || new Date().toISOString();
@@ -19,7 +19,10 @@ const Review = ({ deployment = {}, deploymentDeviceIds, device, group, isEnterpr
     General: [
       { primary: 'Release', secondary: release.Name },
       { primary: 'Device types compatible', secondary: release.device_types_compatible.join(', ') },
-      { primary: `Device${device ? '' : ' group'}`, secondary: device ? device.id : group },
+      {
+        primary: `Device${device ? '' : ' group'}`,
+        secondary: device ? device.id : generateDeploymentGroupDetails(deployment.filter || { terms: filters }, group)
+      },
       { primary: 'Number of retries', secondary: retries }
     ],
     Schedule: [

--- a/src/js/components/deployments/deployment-wizard/softwaredevices.js
+++ b/src/js/components/deployments/deployment-wizard/softwaredevices.js
@@ -67,7 +67,7 @@ export class SoftwareDevices extends React.Component {
 
   render() {
     const self = this;
-    const { device, deploymentAnchor, deploymentObject, group, groups, hasDevices, hasPending, release, releases } = self.props;
+    const { device, deploymentAnchor, deploymentObject, group, groups, hasDevices, hasDynamicGroups, hasPending, release, releases } = self.props;
     const { deploymentDeviceIds } = self.state;
 
     const selectedRelease = deploymentObject.release ? deploymentObject.release : release;
@@ -158,11 +158,11 @@ export class SoftwareDevices extends React.Component {
                     errorText="Please select a group from the list"
                     value={group}
                     items={groupItems}
-                    disabled={!hasDevices}
+                    disabled={!(hasDevices || hasDynamicGroups)}
                     onChange={item => self.deploymentSettingsUpdate(item, 'group')}
                     style={styles.textField}
                   />
-                  {hasDevices ? null : (
+                  {!(hasDevices || hasDynamicGroups) && (
                     <p className="info" style={{ marginTop: '10px' }}>
                       <ErrorOutlineIcon style={{ marginRight: '4px', fontSize: '18px', top: '4px', color: 'rgb(171, 16, 0)', position: 'relative' }} />
                       There are no connected devices.{' '}
@@ -214,6 +214,7 @@ const mapStateToProps = state => {
     device: state.devices.selectedDevice ? state.devices.byId[state.devices.selectedDevice] : null,
     groups: state.devices.groups.byId,
     hasDevices: state.devices.byStatus.accepted.total || state.devices.byStatus.accepted.deviceIds.length > 0,
+    hasDynamicGroups: Object.values(state.devices.groups.byId).some(group => !!group.id),
     hasPending: state.devices.byStatus.pending.total || state.devices.byStatus.pending.deviceIds.length > 0,
     releases: Object.values(state.releases.byId)
   };

--- a/src/js/components/deployments/progressChart.js
+++ b/src/js/components/deployments/progressChart.js
@@ -48,8 +48,9 @@ export default class ProgressChart extends React.Component {
   }
 
   render() {
-    const { created, currentProgressCount, id, totalDeviceCount, totalFailureCount, totalSuccessCount, status } = this.props;
+    const { className = '', created, currentProgressCount, id, totalDeviceCount, totalFailureCount, totalSuccessCount } = this.props;
     const { time } = this.state;
+    const status = this.props.status === 'pending' && this.props.currentProgressCount === 0 ? 'queued' : this.props.status;
     let phases = this.props.phases;
     phases = phases && phases.length ? phases : [{ id, device_count: totalSuccessCount, batch_size: totalDeviceCount, start_ts: created }];
 
@@ -101,7 +102,7 @@ export default class ProgressChart extends React.Component {
         <span className="margin-left-small">{statusMap[status].description()}</span>
       </div>
     ) : (
-      <div className={`flexbox column progress-chart-container ${this.props.className || ''}`}>
+      <div className={`flexbox column progress-chart-container ${className}`}>
         {statusMap[status] && (
           <span className="flexbox small text-muted" style={{ alignItems: 'center' }}>
             {statusMap[status].icon}

--- a/src/js/components/devices/filteritem.js
+++ b/src/js/components/devices/filteritem.js
@@ -129,7 +129,7 @@ export default class FilterItem extends React.Component {
         </Select>
         <TextField
           label="Value"
-          value={value || ''}
+          value={value}
           onChange={e => self.updateFilterValue(e.target.value)}
           InputLabelProps={{ shrink: !!value }}
           style={textFieldStyle}

--- a/src/js/components/devices/filteritem.js
+++ b/src/js/components/devices/filteritem.js
@@ -3,13 +3,15 @@ import React from 'react';
 // material ui
 import { IconButton, MenuItem, Select, TextField } from '@material-ui/core';
 import { HighlightOff as HighlightOffIcon } from '@material-ui/icons';
-import { Autocomplete } from '@material-ui/lab';
+import { Autocomplete, createFilterOptions } from '@material-ui/lab';
 
 import { DEVICE_FILTERING_OPTIONS } from '../../constants/deviceConstants';
 import Loader from '../common/loader';
 
 import { emptyFilter } from './filters';
 import { filtersCompare } from '../../helpers';
+
+const filter = createFilterOptions();
 
 const textFieldStyle = { marginTop: 0, marginBottom: 15 };
 
@@ -19,6 +21,8 @@ const filterOptionsByPlan = {
   enterprise: DEVICE_FILTERING_OPTIONS
 };
 
+const defaultScope = 'inventory';
+
 export default class FilterItem extends React.Component {
   constructor(props, context) {
     super(props, context);
@@ -26,7 +30,7 @@ export default class FilterItem extends React.Component {
       key: props.filter.key, // this refers to the selected filter with key as the id
       value: props.filter.value, // while this is the value that is applied with the filter
       operator: props.filter.operator || '$eq',
-      scope: props.filter.scope || 'inventory',
+      scope: props.filter.scope || defaultScope,
       reset: true
     };
   }
@@ -110,11 +114,30 @@ export default class FilterItem extends React.Component {
           autoComplete
           freeSolo
           filterSelectedOptions
+          filterOptions={(options, params) => {
+            const filtered = filter(options, params);
+            if (filtered.length !== 1 && params.inputValue !== '') {
+              filtered.push({
+                inputValue: params.inputValue,
+                key: 'custom',
+                value: `Use "${params.inputValue}"`,
+                category: 'custom',
+                priority: 99
+              });
+            }
+            return filtered;
+          }}
           groupBy={option => option.category}
-          getOptionLabel={option => option.value || ''}
+          getOptionLabel={option => option.value || option.key || option}
           id={`filter-selection-${index}`}
           includeInputInList={true}
-          onChange={(e, changedValue) => self.updateFilterKey(changedValue ? changedValue.key : changedValue)}
+          onChange={(e, changedValue) => {
+            if (changedValue && changedValue.inputValue) {
+              // only circumvent updateFilterKey if we deal with a custom attribute - those will be treated as inventory attributes
+              return self.setState({ key: changedValue.inputValue, scope: defaultScope }, () => self.notifyFilterUpdate());
+            }
+            self.updateFilterKey(changedValue && changedValue.key ? changedValue.key : changedValue);
+          }}
           options={filters.sort((a, b) => a.priority - b.priority)}
           renderInput={params => <TextField {...params} label="Attribute" style={textFieldStyle} />}
           key={reset}

--- a/src/js/components/devices/filters.js
+++ b/src/js/components/devices/filters.js
@@ -12,7 +12,7 @@ import FilterItem from './filteritem';
 
 import { DEVICE_FILTERING_OPTIONS } from '../../constants/deviceConstants';
 
-export const emptyFilter = { key: undefined, value: undefined, operator: '$eq', scope: 'inventory' };
+export const emptyFilter = { key: null, value: '', operator: '$eq', scope: 'inventory' };
 
 const MAX_PREVIOUS_FILTERS_COUNT = 3;
 

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import store from './reducers';
 import appConstants from './constants/appConstants';
+import { DEVICE_FILTERING_OPTIONS } from './constants/deviceConstants';
 
 export function isEncoded(uri) {
   uri = uri || '';
@@ -288,6 +289,13 @@ export const unionizeStrings = (someStrings, someOtherStrings) => {
     : startingPoint;
   return [...uniqueStrings];
 };
+
+export const generateDeploymentGroupDetails = (filter, groupName) =>
+  filter && filter.terms
+    ? `${groupName} (${filter.terms
+        .map(filter => `${filter.attribute || filter.key} ${DEVICE_FILTERING_OPTIONS[filter.type || filter.operator].shortform} ${filter.value}`)
+        .join(', ')})`
+    : groupName;
 
 export const tryMapDeployments = (accu, id) => {
   if (accu.state.deployments.byId[id]) {


### PR DESCRIPTION
this should allow creation of dynamics groups without devices present, also with custom attributes (custom as in: not known to the gui) + dynamic deployments should see their status reflected better in the pending deployments list + the group name should now detail the filter that belongs to the group, if the group is a dynamic one