### PR TITLE
Increase attribute parsing robustness

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -254,6 +254,9 @@ const reduceReceivedDevices = (devices, ids, state, status) =>
       } else {
         const attributes = mapDeviceAttributes(device.attributes);
         device.attributes = stateDevice ? { ...stateDevice.attributes, ...attributes } : attributes;
+        device.status = status ? status : device.status || device.attributes.status;
+        device.created_ts = device.attributes.created_ts ? device.attributes.created_ts : device.created_ts;
+        device.updated_ts = device.attributes.updated_ts ? device.attributes.updated_ts : device.updated_ts;
       }
       accu.devicesById[device.id] = { ...stateDevice, ...device };
       accu.ids.push(device.id);
@@ -341,6 +344,7 @@ export const getDeviceById = id => dispatch =>
   DevicesApi.get(`${inventoryApiUrl}/devices/${id}`)
     .then(res => {
       const device = { ...res.body, attributes: mapDeviceAttributes(res.body.attributes) };
+      delete device.updated_ts;
       dispatch({
         type: DeviceConstants.RECEIVE_DEVICE,
         device

--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -504,8 +504,9 @@ export const getDevicesByStatus = (status, page = defaultPage, perPage = default
   }
   return query.then(response => {
     let tasks = [];
+    const deviceAccu = reduceReceivedDevices(response.body, [], getState(), status);
     if (response.body.length < 200) {
-      tasks.push(dispatch(setFilterAttributes(deriveAttributesFromDevices(response.body))));
+      tasks.push(dispatch(setFilterAttributes(deriveAttributesFromDevices(Object.values(deviceAccu.devicesById)))));
     }
     if (!status) {
       tasks.push(
@@ -515,7 +516,6 @@ export const getDevicesByStatus = (status, page = defaultPage, perPage = default
         })
       );
     } else {
-      const deviceAccu = reduceReceivedDevices(response.body, [], getState(), status);
       let total;
       if (getState().devices.byStatus[status].total === deviceAccu.ids.length) {
         total = deviceAccu.ids.length;

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -311,7 +311,15 @@ export const mapAttributesToAggregator = item =>
   }, {});
 
 export const mapDeviceAttributes = (attributes = []) =>
-  attributes.reduce((accu, attribute) => ({ ...accu, [attribute.name]: attribute.value }), { device_type: '', artifact_name: '' });
+  attributes.reduce(
+    (accu, attribute) => {
+      if (!(attribute.value && attribute.name)) {
+        return accu;
+      }
+      return { ...accu, [attribute.name]: attribute.value };
+    },
+    { device_type: '', artifact_name: '' }
+  );
 
 const deriveAttributePopularity = (accu, sourceObject = {}) =>
   Object.keys(sourceObject).reduce((keyAccu, key) => {


### PR DESCRIPTION
This should prevent undefined attributes from getting into the gui state and align the check in timestamps shown on the device lists with the updated inventory structure