### PR TITLE
2.4.x: MEN-3600: Fix incorrect installation instructions for Enterprise demo.

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -519,18 +519,22 @@ export const getDebInstallationCode = (
 ${noninteractive ? 'DEBIAN_FRONTEND=noninteractive' : 'sudo'} dpkg -i --force-confdef --force-confold mender-client_${packageVersion}-1_armhf.deb`;
 
 export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, token, packageVersion, deviceType = 'generic-armv6') => {
-  let connectionInstructions = `  --quiet --demo ${ipAddress ? `--server-ip ${ipAddress}` : ''}`;
+  let connectionInstructions = ``;
+  let demoSettings = `  --quiet --demo ${ipAddress ? `--server-ip ${ipAddress}` : ''}`;
   if (isEnterprise || isHosted) {
-    const enterpriseSettings = `  --tenant-token $TENANT_TOKEN \\
+    const enterpriseSettings = `  --tenant-token $TENANT_TOKEN`;
+    if (isHosted) {
+      connectionInstructions = `  --quiet --hosted-mender \\
+${enterpriseSettings} \\
   --retry-poll 30 \\
   --update-poll 5 \\
   --inventory-poll 5`;
-    connectionInstructions = `--quiet ${ipAddress ? `  --server-url ${ipAddress}` : ' '} \\
-    --server-cert="" ${enterpriseSettings}`;
-    if (isHosted) {
-      connectionInstructions = `  --quiet --hosted-mender \\
+    } else {
+      connectionInstructions = `${demoSettings} \\
 ${enterpriseSettings}`;
     }
+  } else {
+      connectionInstructions = `${demoSettings}`;
   }
   const debInstallationCode = getDebInstallationCode(packageVersion, true);
   let codeToCopy = `sudo bash -c '${debInstallationCode} && \\

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -534,7 +534,7 @@ ${enterpriseSettings} \\
 ${enterpriseSettings}`;
     }
   } else {
-      connectionInstructions = `${demoSettings}`;
+    connectionInstructions = `${demoSettings}`;
   }
   const debInstallationCode = getDebInstallationCode(packageVersion, true);
   let codeToCopy = `sudo bash -c '${debInstallationCode} && \\

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -111,11 +111,8 @@ DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\
---quiet   --server-url 192.168.7.41 \\
-    --server-cert=""   --tenant-token $TENANT_TOKEN \\
-  --retry-poll 30 \\
-  --update-poll 5 \\
-  --inventory-poll 5 && \\
+  --quiet --demo --server-ip 192.168.7.41 \\
+  --tenant-token $TENANT_TOKEN && \\
 systemctl restart mender-client'`
     );
   });


### PR DESCRIPTION
The demo for Enterprise is not officially supported, but we use it for
internal testing, therefore this is important.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit aa4c06f6b39ccc47544f0c4c5597ef8767f829ee)