### PR TITLE
MEN-3611 added blunt display of provides metadata information in artifact details

### DIFF
--- a/src/js/components/artifacts/selectedartifact.js
+++ b/src/js/components/artifacts/selectedartifact.js
@@ -112,8 +112,25 @@ export class SelectedArtifact extends React.Component {
           return accu;
         }, [])
       : [];
+    const provides = artifact.artifact_provides
+      ? Object.entries(artifact.artifact_provides).reduce((accu, [key, value]) => {
+          if (!Array.isArray(value)) {
+            accu.push(<ExpandableAttribute key={key} primary={key} secondary={value} />);
+          } else if (!key.startsWith('device_type')) {
+            // we can expect this to be an array of artifacts or artifact groups this artifact depends on
+            const dependencies = value.reduce((dependencies, dependency, index) => {
+              const dependencyKey = value.length > 1 ? `${key}-${index + 1}` : key;
+              dependencies.push(<ExpandableAttribute key={dependencyKey} primary={dependencyKey} secondary={dependency} />);
+              return dependencies;
+            }, []);
+            accu = [...accu, ...dependencies];
+          }
+          return accu;
+        }, [])
+      : [];
     const artifactMetaInfo = [
       { title: 'Artifact dependencies', content: depends },
+      { title: 'Artifact provides', content: provides },
       { title: 'Artifact metadata', content: metaData }
     ];
     return (


### PR DESCRIPTION
This is required for 2.4 and needs to be picked into the 2.4.x branch (via #819).

I will followed this up with a second PR to remove the code duplication in the `SelectedArtifact` component - to minimize the cherry-picked changes, the updated appearance will not make it to 2.4 though. 

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>