### PR TITLE
cherry-pick for 2.3.x - allowing e2e to run

### DIFF
--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -16,9 +16,9 @@ services:
       - mender-inventory
       - mender-useradm
       - mender-mongo
-      - mender-conductor
-      - mender-elasticsearch
-      - mender-redis
+      - mender-workflows-server
+      - mender-workflows-worker
+      - mender-create-artifact-worker
       - minio
     volumes:
       - ${GUI_REPOSITORY}/tests/e2e_tests/cypress/screenshots:/etc/cypress/screenshots


### PR DESCRIPTION
Update docker-composition for e2e-tests
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>