### PR TITLE
Fix/admin role listing

### DIFF
--- a/src/js/actions/userActions.js
+++ b/src/js/actions/userActions.js
@@ -124,9 +124,10 @@ export const getRoles = () => (dispatch, getState) =>
             accu.groups.push(permission.object.value);
           }
           if (
-            permission.action == rolesByName.userManagement.action &&
-            permission.object.type == rolesByName.userManagement.object.type &&
-            permission.object.value == rolesByName.userManagement.object.value
+            role.name === rolesByName.admin ||
+            (permission.action == rolesByName.userManagement.action &&
+              permission.object.type == rolesByName.userManagement.object.type &&
+              permission.object.value == rolesByName.userManagement.object.value)
           ) {
             accu.allowUserManagement = true;
           }

--- a/src/js/components/settings/__snapshots__/organization.test.js.snap
+++ b/src/js/components/settings/__snapshots__/organization.test.js.snap
@@ -69,16 +69,15 @@ exports[`MyOrganization Component renders correctly 1`] = `
                 className="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
               >
                 <div>
-                  <h4
+                  <span
                     style={
                       Object {
-                        "display": "inline",
-                        "paddingRight": "10px",
+                        "paddingRight": 10,
                       }
                     }
                   >
                     Token
-                  </h4>
+                  </span>
                   <div
                     className="tooltip info"
                     data-event="click focus"

--- a/src/js/components/settings/organization.js
+++ b/src/js/components/settings/organization.js
@@ -79,7 +79,7 @@ export class MyOrganization extends React.Component {
     };
     const orgHeader = (
       <div>
-        <h4 style={{ display: 'inline', paddingRight: '10px' }}>Token</h4>
+        <span style={{ paddingRight: 10 }}>Token</span>
         <div
           id="token-info"
           className="tooltip info"

--- a/src/js/themes/mender-theme.js
+++ b/src/js/themes/mender-theme.js
@@ -175,7 +175,8 @@ export default createMuiTheme({
         height: '48px'
       },
       head: {
-        height: '56px'
+        height: '56px',
+        lineHeight: '1.15rem'
       },
       paddingCheckbox: {
         padding: '0 0 0 6px',


### PR DESCRIPTION
admins were listed as unable to manage users + the headers in the roles table looked a bit odd due to the headers spanning 2 lines.. also: a tiny fix for the tenant token, which had a differing heading than the other items in the organization settings page

thanks to @oleorhagen for the pointers!