### PR TITLE
fixed device list sorting, broken while enabling id sorts

### DIFF
--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -220,11 +220,10 @@ export class Authorized extends React.Component {
 
   onSortChange(attribute) {
     const self = this;
-    let state = { sortCol: attribute.name, sortDown: !self.state.sortDown, sortScope: attribute.scope };
+    let state = { sortCol: attribute.name === 'Device ID' ? 'id' : attribute.name, sortDown: !self.state.sortDown, sortScope: attribute.scope };
     if (attribute.name !== self.state.sortCol) {
       state.sortDown = true;
     }
-    state.sortCol = attribute.name === 'Device ID' ? 'id' : self.state.sortCol;
     self.setState(state, () => self._getDevices(true));
   }
 


### PR DESCRIPTION
- sorting column wasn't set unless you sorted by id at some point
- as it would always fallback to the undefined column

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>