### PR TITLE
forced rerender when stripe dependencies are loaded

### DIFF
--- a/src/js/components/settings/settings.js
+++ b/src/js/components/settings/settings.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { NavLink, withRouter } from 'react-router-dom';
 
@@ -19,12 +19,19 @@ import Upgrade from './upgrade';
 let stripePromise = null;
 
 export const Settings = ({ allowUserManagement, currentUser, hasMultitenancy, history, isAdmin, isEnterprise, match, stripeAPIKey, trial }) => {
+  const [loadingFinished, setLoadingFinished] = useState(!stripeAPIKey);
+
   useEffect(() => {
     // Make sure to call `loadStripe` outside of a component’s render to avoid recreating
     // the `Stripe` object on every render - but don't initialize twice.
     if (!stripePromise) {
       import(/* webpackChunkName: "stripe" */ '@stripe/stripe-js').then(({ loadStripe }) => {
-        stripePromise = stripeAPIKey ? loadStripe(stripeAPIKey) : null;
+        if (stripeAPIKey) {
+          stripePromise = loadStripe(stripeAPIKey).then(args => {
+            setLoadingFinished(true);
+            return Promise.resolve(args);
+          });
+        }
       });
     }
   }, []);
@@ -91,7 +98,7 @@ export const Settings = ({ allowUserManagement, currentUser, hasMultitenancy, hi
         </List>
       </div>
       <div className="rightFluid padding-right">
-        <Elements stripe={stripePromise}>{getCurrentSection(sectionMap, match.params.section).component}</Elements>
+        {loadingFinished && <Elements stripe={stripePromise}>{getCurrentSection(sectionMap, match.params.section).component}</Elements>}
       </div>
     </div>
   );


### PR DESCRIPTION
this is to ensure the stripe elements are also visible on first visit to the settings
that is not the case on slow connections
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>