### PR TITLE
Remote terminal: mask the unknown status with the not connected icon

### DIFF
--- a/src/js/components/devices/__snapshots__/expanded-device.test.js.snap
+++ b/src/js/components/devices/__snapshots__/expanded-device.test.js.snap
@@ -191,16 +191,21 @@ exports[`ExpandedDevice Component renders correctly 1`] = `
             }
           }
         >
-          <img
+          <svg
             aria-hidden={true}
-            className="material-icons MuiIcon-root"
-            src="pending_status.png"
+            className="MuiSvgIcon-root red"
+            focusable="false"
             style={
               Object {
                 "margin": 12,
               }
             }
-          />
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z"
+            />
+          </svg>
           <span
             className="inline-block"
           >
@@ -224,7 +229,7 @@ exports[`ExpandedDevice Component renders correctly 1`] = `
                 }
               }
             >
-              Unknown
+              Not connected
             </p>
           </span>
         </span>

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -51,11 +51,11 @@ const connectStates = {
   },
   [DEVICE_CONNECT_STATES.disconnected]: {
     icon: <BlockIcon className="red" style={iconStyle} />,
-    title: 'Disconnected'
+    title: 'Not connected'
   },
   [DEVICE_CONNECT_STATES.unknown]: {
-    icon: <Icon style={iconStyle} component="img" src={pendingIcon} />,
-    title: 'Unknown'
+    icon: <BlockIcon className="red" style={iconStyle} />,
+    title: 'Not connected'
   }
 };
 


### PR DESCRIPTION
It may be confusing for users to understand the difference between the
connection statuses unknown and disconnected. For this reason, we use in
both cases the "Not connected" message.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>