### PR TITLE
CI: Allow test:staging-deployments job to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,6 +120,8 @@ test-prep:
     expire_in: 30 days
 
 test:staging-deployment:
+  # Allow failure until timing issues are resolved
+  allow_failure: true
   image:
     name: cypress/included:5.4.0
     # cypress/included images have entrypoint set to "cypress"


### PR DESCRIPTION
The job has known issues, let's keep monitoring the job until the issue
is resolved.