### PR TITLE
MEN-4259: update demo bash snippet with the mender-shell installation

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -148,7 +148,14 @@ sudo bash -c 'DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\
   --quiet --demo  && \\
-systemctl restart mender-client'
+systemctl restart mender-client && \\
+(cat &gt; /etc/mender/mender-shell.conf &lt;&lt; EOF
+{
+  "ServerURL": "http://localhost",
+  "User": "pi"
+}
+EOF
+) && systemctl restart mender-shell'
 
     </span>
   </div>

--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -74,8 +74,7 @@ exports[`DebPackage Component renders correctly 1`] = `
         }
       }
     >
-      wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
-sudo dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb
+      wget -q -O- https://get.mender.io/ | sudo bash
     </span>
   </div>
   <p />
@@ -144,9 +143,8 @@ sudo dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb
         }
       }
     >
-      sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
-DEBIAN_FRONTEND=noninteractive dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb && \\
-DEVICE_TYPE="generic-armv6" && \\
+      wget -q -O- https://get.mender.io/ | sudo bash && \\
+sudo bash -c 'DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\
   --quiet --demo  && \\

--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -74,7 +74,7 @@ exports[`DebPackage Component renders correctly 1`] = `
         }
       }
     >
-      wget -q -O- https://get.mender.io/ | sudo bash
+      wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental
     </span>
   </div>
   <p />
@@ -143,7 +143,7 @@ exports[`DebPackage Component renders correctly 1`] = `
         }
       }
     >
-      wget -q -O- https://get.mender.io/ | sudo bash && \\
+      wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental && \\
 sudo bash -c 'DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\

--- a/src/js/components/help/application-updates/mender-deb-package.js
+++ b/src/js/components/help/application-updates/mender-deb-package.js
@@ -5,7 +5,7 @@ import CopyCode from '../../common/copy-code';
 
 const DebPackage = ({ menderDebPackageVersion, ipAddress, isHosted, isEnterprise, org }) => {
   const token = (org || {}).tenant_token;
-  const dpkgCode = getDebInstallationCode(menderDebPackageVersion);
+  const dpkgCode = getDebInstallationCode();
   const codeToCopy = getDebConfigurationCode(ipAddress, isHosted, isEnterprise, token, menderDebPackageVersion);
   let title = 'Connecting to a demo server with demo settings';
   if (isEnterprise) {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -427,11 +427,7 @@ export const standardizePhases = phases =>
     return standardizedPhase;
   });
 
-export const getDebInstallationCode = (
-  packageVersion,
-  noninteractive = false
-) => `wget https://d1b0l86ne08fsf.cloudfront.net/${packageVersion}/dist-packages/debian/armhf/mender-client_${packageVersion}-1_armhf.deb && \\
-${noninteractive ? 'DEBIAN_FRONTEND=noninteractive' : 'sudo'} dpkg -i --force-confdef --force-confold mender-client_${packageVersion}-1_armhf.deb`;
+export const getDebInstallationCode = () => `wget -q -O- https://get.mender.io/ | sudo bash`;
 
 export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, token, packageVersion, deviceType = 'generic-armv6') => {
   let connectionInstructions = ``;
@@ -451,9 +447,9 @@ ${enterpriseSettings}`;
   } else {
     connectionInstructions = `${demoSettings}`;
   }
-  const debInstallationCode = getDebInstallationCode(packageVersion, true);
-  let codeToCopy = `sudo bash -c '${debInstallationCode} && \\
-DEVICE_TYPE="${deviceType}" && \\${
+  const debInstallationCode = getDebInstallationCode();
+  let codeToCopy = `${debInstallationCode} && \\
+sudo bash -c 'DEVICE_TYPE="${deviceType}" && \\${
     token
       ? `
 TENANT_TOKEN="${token}" && \\`

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -427,7 +427,7 @@ export const standardizePhases = phases =>
     return standardizedPhase;
   });
 
-export const getDebInstallationCode = () => `wget -q -O- https://get.mender.io/ | sudo bash`;
+export const getDebInstallationCode = () => `wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental`;
 
 export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, token, packageVersion, deviceType = 'generic-armv6') => {
   let connectionInstructions = ``;

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -458,7 +458,14 @@ TENANT_TOKEN="${token}" && \\`
 mender setup \\
   --device-type $DEVICE_TYPE \\
 ${connectionInstructions} && \\
-systemctl restart mender-client'
+systemctl restart mender-client && \\
+(cat > /etc/mender/mender-shell.conf << EOF
+{
+  "ServerURL": "${document.location.origin}",
+  "User": "pi"
+}
+EOF
+) && systemctl restart mender-shell'
 `;
   return codeToCopy;
 };

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -84,13 +84,10 @@ describe('stringToBoolean function', () => {
 
 describe('getDebInstallationCode function', () => {
   it('should not contain any template string leftovers', () => {
-    expect(getDebInstallationCode('master')).not.toMatch(/\{([^}]+)\}/);
+    expect(getDebInstallationCode()).not.toMatch(/\{([^}]+)\}/);
   });
   it('should return a sane result', () => {
-    expect(getDebInstallationCode('master')).toMatch(
-      `wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
-sudo dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb`
-    );
+    expect(getDebInstallationCode()).toMatch(`wget -q -O- https://get.mender.io/ | sudo bash`);
   });
 });
 
@@ -104,9 +101,8 @@ describe('getDebConfigurationCode function', () => {
   });
   it('should return a sane result', () => {
     expect(code).toMatch(
-      `sudo bash -c 'wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb && \\
-DEBIAN_FRONTEND=noninteractive dpkg -i --force-confdef --force-confold mender-client_master-1_armhf.deb && \\
-DEVICE_TYPE="raspberrypi3" && \\
+      `wget -q -O- https://get.mender.io/ | sudo bash && \\
+sudo bash -c 'DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -87,7 +87,7 @@ describe('getDebInstallationCode function', () => {
     expect(getDebInstallationCode()).not.toMatch(/\{([^}]+)\}/);
   });
   it('should return a sane result', () => {
-    expect(getDebInstallationCode()).toMatch(`wget -q -O- https://get.mender.io/ | sudo bash`);
+    expect(getDebInstallationCode()).toMatch(`wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental`);
   });
 });
 
@@ -101,7 +101,7 @@ describe('getDebConfigurationCode function', () => {
   });
   it('should return a sane result', () => {
     expect(code).toMatch(
-      `wget -q -O- https://get.mender.io/ | sudo bash && \\
+      `wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental && \\
 sudo bash -c 'DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 mender setup \\

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -84,7 +84,7 @@ describe('stringToBoolean function', () => {
 
 describe('getDebInstallationCode function', () => {
   it('should not contain any template string leftovers', () => {
-    expect(getDebInstallationCode()).not.toMatch(/\{([^}]+)\}/);
+    expect(getDebInstallationCode()).not.toMatch(/\$\{([^}]+)\}/);
   });
   it('should return a sane result', () => {
     expect(getDebInstallationCode()).toMatch(`wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental`);
@@ -97,7 +97,7 @@ describe('getDebConfigurationCode function', () => {
     code = getDebConfigurationCode('192.168.7.41', false, true, 'token', 'master', 'raspberrypi3');
   });
   it('should not contain any template string leftovers', () => {
-    expect(code).not.toMatch(/\{([^}]+)\}/);
+    expect(code).not.toMatch(/\$\{([^}]+)\}/);
   });
   it('should return a sane result', () => {
     expect(code).toMatch(
@@ -108,7 +108,14 @@ mender setup \\
   --device-type $DEVICE_TYPE \\
   --quiet --demo --server-ip 192.168.7.41 \\
   --tenant-token $TENANT_TOKEN && \\
-systemctl restart mender-client'`
+systemctl restart mender-client && \\
+(cat > /etc/mender/mender-shell.conf << EOF
+{
+  "ServerURL": "http://localhost",
+  "User": "pi"
+}
+EOF
+) && systemctl restart mender-shell'`
     );
   });
   it('should not contain tenant information for OS calls', () => {
@@ -122,9 +129,9 @@ describe('getDemoDeviceCreationCommand function', () => {
   const token = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZW5kZXIudGVuYW50IjoiNWY5YWI0ZWQ4ZjhhMzc0NmYwYTIxNjU1IiwiaXNzIjoiTWVuZGVyIiwic3`;
   it('should not contain any template string leftovers', () => {
     let code = getDemoDeviceCreationCommand();
-    expect(code).not.toMatch(/\{([^}]+)\}/);
+    expect(code).not.toMatch(/\$\{([^}]+)\}/);
     code = getDemoDeviceCreationCommand(token);
-    expect(code).not.toMatch(/\{([^}]+)\}/);
+    expect(code).not.toMatch(/\$\{([^}]+)\}/);
   });
   it('should return a sane result', () => {
     let code = getDemoDeviceCreationCommand();


### PR DESCRIPTION
This PR reintroduces get.mender.io support to install the Mender client and the Mender shell add-on.
These changes were reverted in master.