### PR TITLE
Set default shell to /bin/bash in mender-connect.conf during onboarding

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -152,7 +152,8 @@ systemctl restart mender-client && \\
 (cat &gt; /etc/mender/mender-connect.conf &lt;&lt; EOF
 {
   "ServerURL": "http://localhost",
-  "User": "pi"
+  "User": "pi",
+  "ShellCommand": "/bin/bash"
 }
 EOF
 ) && systemctl restart mender-connect'

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -500,7 +500,8 @@ ${
 (cat > /etc/mender/mender-connect.conf << EOF
 {
   "ServerURL": "${document.location.origin}",
-  "User": "pi"
+  "User": "pi",
+  "ShellCommand": "/bin/bash"
 }
 EOF
 ) && systemctl restart mender-connect'`

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -130,7 +130,8 @@ systemctl restart mender-client && \\
 (cat > /etc/mender/mender-connect.conf << EOF
 {
   "ServerURL": "http://localhost",
-  "User": "pi"
+  "User": "pi",
+  "ShellCommand": "/bin/bash"
 }
 EOF
 ) && systemctl restart mender-connect'`


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>