### PR TITLE
We introduced "retry" as a concept after this label, which was a

### DIFF
--- a/src/js/components/deployments/deployment-report/overview.js
+++ b/src/js/components/deployments/deployment-report/overview.js
@@ -182,7 +182,7 @@ export const DeploymentOverview = ({
               placement="bottom"
             >
               <Button color="secondary" startIcon={<RefreshIcon fontSize="small" />} onClick={onRetryClick} style={{ alignSelf: 'baseline', marginTop: 45 }}>
-                Retry deployment?
+                Recreate deployment?
               </Button>
             </Tooltip>
           )


### PR DESCRIPTION
short-term solution. Recreate deployment should better explain
what it does vs. today's per-device automatic retry.