### PR TITLE
MEN-4360, MEN-4361: update onboarding snippet for mender-connect

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -151,12 +151,13 @@ mender setup \\
 systemctl restart mender-client && \\
 (cat &gt; /etc/mender/mender-connect.conf &lt;&lt; EOF
 {
-  "ServerURL": "http://localhost",
+  "ServerCertificate": "/usr/share/doc/mender-client/examples/demo.crt",
   "User": "pi",
   "ShellCommand": "/bin/bash"
 }
 EOF
-) && systemctl restart mender-connect'
+) && chmod 0600 /etc/mender/mender-connect.conf && \\
+systemctl restart mender-connect'
 
     </span>
   </div>

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -499,12 +499,13 @@ ${
     ? `systemctl restart mender-client && \\
 (cat > /etc/mender/mender-connect.conf << EOF
 {
-  "ServerURL": "${document.location.origin}",
+  "ServerCertificate": "/usr/share/doc/mender-client/examples/demo.crt",
   "User": "pi",
   "ShellCommand": "/bin/bash"
 }
 EOF
-) && systemctl restart mender-connect'`
+) && chmod 0600 /etc/mender/mender-connect.conf && \\
+systemctl restart mender-connect'`
     : `systemctl restart mender-client'`
 }
 `;

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -129,12 +129,13 @@ mender setup \\
 systemctl restart mender-client && \\
 (cat > /etc/mender/mender-connect.conf << EOF
 {
-  "ServerURL": "http://localhost",
+  "ServerCertificate": "/usr/share/doc/mender-client/examples/demo.crt",
   "User": "pi",
   "ShellCommand": "/bin/bash"
 }
 EOF
-) && systemctl restart mender-connect'`
+) && chmod 0600 /etc/mender/mender-connect.conf && \\
+systemctl restart mender-connect'`
     );
   });
   it('should return a sane result for old installations', async () => {


### PR DESCRIPTION
- Set ServerURL to https://docker.mender.io for on-prem onboarding
- Set permissions of /etc/mender/mender-connect.conf to 0600

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>