### PR TITLE
master: Switch to APT stable channel from get.mender.io

### DIFF
--- a/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
+++ b/src/js/components/help/application-updates/__snapshots__/mender-deb-package.test.js.snap
@@ -74,7 +74,7 @@ exports[`DebPackage Component renders correctly 1`] = `
         }
       }
     >
-      wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental
+      wget -q -O- https://get.mender.io/ | sudo bash -s
     </span>
   </div>
   <p />
@@ -143,7 +143,7 @@ exports[`DebPackage Component renders correctly 1`] = `
         }
       }
     >
-      wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental && \\
+      wget -q -O- https://get.mender.io/ | sudo bash -s && \\
 sudo bash -c 'DEVICE_TYPE="generic-armv6" && \\
 mender setup \\
   --device-type $DEVICE_TYPE \\

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -459,7 +459,7 @@ export const standardizePhases = phases =>
 
 export const getDebInstallationCode = (packageVersion, noninteractive = false, hasMenderShellSupport) =>
   hasMenderShellSupport
-    ? `wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental`
+    ? `wget -q -O- https://get.mender.io/ | sudo bash -s`
     : `${
         noninteractive ? `sudo bash -c '` : ''
       }wget https://d1b0l86ne08fsf.cloudfront.net/${packageVersion}/dist-packages/debian/armhf/mender-client_${packageVersion}-1_armhf.deb && \\

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -100,7 +100,7 @@ describe('getDebInstallationCode function', () => {
     expect(getDebInstallationCode()).not.toMatch(/\$\{([^}]+)\}/);
   });
   it('should return a sane result', () => {
-    expect(getDebInstallationCode(undefined, undefined, true)).toMatch(`wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental`);
+    expect(getDebInstallationCode(undefined, undefined, true)).toMatch(`wget -q -O- https://get.mender.io/ | sudo bash -s`);
   });
   it('should return a sane result for old installations', async () => {
     expect(getDebInstallationCode('master'))
@@ -119,7 +119,7 @@ describe('getDebConfigurationCode function', () => {
   });
   it('should return a sane result', async () => {
     expect(code).toMatch(
-      `wget -q -O- https://get.mender.io/ | sudo bash -s -- -c experimental && \\
+      `wget -q -O- https://get.mender.io/ | sudo bash -s && \\
 sudo bash -c 'DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 mender setup \\


### PR DESCRIPTION
By removing the -c experimental flag from the bash snippets

(cherry picked from commit 8af20b4a28951ecaeb4420f8387027ca093a67a5)