### PR TITLE
e2e tests: adjusted unknown path check to work with nicer redirects

### DIFF
--- a/tests/e2e_tests/cypress/integration/01-login.spec.js
+++ b/tests/e2e_tests/cypress/integration/01-login.spec.js
@@ -38,7 +38,8 @@ context('Login', () => {
         failOnStatusCode: false
       })
         .its('status')
-        .should('equal', 404);
+        .should('equal', 200);
+      cy.contains('Log in').should('be.visible');
     });
 
     it('Does not log in with invalid password', () => {


### PR DESCRIPTION
This is required since the traefik routing will redirect to the UI, even if an unknown subpath is queried, whereas nginx would return a 404.

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>