### PR TITLE
fix for coveralls failing to report PR coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,17 +178,19 @@ test:staging-deployment:
 publish:tests:
   stage: publish
   except:
-    - /^saas-[a-zA-Z0-9.]+$/
+    - /^(staging|saas-[a-zA-Z0-9.]+)$/
   dependencies:
     - test:unit
-  script:
+  before_script:
     - export CI_BUILD_REF=${CI_COMMIT_SHA}
     - export CI_BUILD_REF_NAME=${CI_COMMIT_REF_NAME}
     - export CI_BUILD_NAME=${CI_JOB_NAME}
     - export CI_BUILD_ID=${CI_JOB_ID}
     - export CI_MERGE_REQUEST_IID=${CI_COMMIT_BRANCH#pr_}
     - export COVERALLS_FLAG_NAME=unittests
+    - apk add --no-cache git
     - npm i -g coveralls
+  script:
     - coveralls < coverage/lcov.info
 
 publish:disclaimer:


### PR DESCRIPTION
my best guess is that the lack of git information disturbed the PR association + the dotfile for good measure (based on the comments in the referenced coveralls issue), however I'm not super confident that this fixes the issue...

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>