### PR TITLE
Adjustments to offer announcement banner for hosted Mender

### DIFF
--- a/src/js/components/__snapshots__/app.test.js.snap
+++ b/src/js/components/__snapshots__/app.test.js.snap
@@ -31,7 +31,7 @@ exports[`App Component renders correctly 1`] = `
            feature for free on your current plan until March 31st. 
         </span>
         <a
-          href="https://docs.mender.io/add-ons/remote-terminal"
+          href="https://docs.mender.io/development/add-ons/remote-terminal"
           rel="noreferrer"
           target="_blank"
         >

--- a/src/js/components/__snapshots__/app.test.js.snap
+++ b/src/js/components/__snapshots__/app.test.js.snap
@@ -4,10 +4,51 @@ exports[`App Component renders correctly 1`] = `
 <body>
   <div>
     <div
-      class="MuiToolbar-root MuiToolbar-regular header MuiToolbar-gutters"
+      class="MuiToolbar-root MuiToolbar-regular header banner MuiToolbar-gutters"
       id="fixedHeader"
       style="background-color: rgb(255, 255, 255); min-height: unset; padding-left: 32px; padding-right: 40px;"
     >
+      <div
+        class="offerBox"
+        id="offerHeader"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          style="margin-right: 2px; height: 16px; vertical-align: bottom;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z"
+          />
+        </svg>
+        <span>
+          Try out the new 
+          <b>
+            Remote terminal
+          </b>
+           feature for free on your current plan until March 31st. 
+        </span>
+        <a
+          href="https://docs.mender.io/add-ons/remote-terminal"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Read the documentation to learn how to enable it
+        </a>
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          style="margin-left: 4px; height: 16px; cursor: pointer;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+          />
+        </svg>
+      </div>
       <div
         class="flexbox"
       >

--- a/src/js/components/header/__snapshots__/offerheader.test.js.snap
+++ b/src/js/components/header/__snapshots__/offerheader.test.js.snap
@@ -24,7 +24,7 @@ exports[`DeviceNotifications Component renders correctly 1`] = `
      feature for free on your current plan until March 31st. 
   </span>
   <a
-    href="https://docs.mender.io/add-ons/remote-terminal"
+    href="https://docs.mender.io/undefinedadd-ons/remote-terminal"
     rel="noreferrer"
     target="_blank"
   >

--- a/src/js/components/header/__snapshots__/offerheader.test.js.snap
+++ b/src/js/components/header/__snapshots__/offerheader.test.js.snap
@@ -17,13 +17,29 @@ exports[`DeviceNotifications Component renders correctly 1`] = `
     />
   </svg>
   <span>
-    End of year offer – receive 20% discount for 6 months when you upgrade to a paid Mender plan before Dec 31.
-     
-    <a
-      href="/settings/upgrade"
-    >
-      Learn more and upgrade now
-    </a>
+    Try out the new 
+    <b>
+      Remote terminal
+    </b>
+     feature for free on your current plan until March 31st. 
   </span>
+  <a
+    href="https://docs.mender.io/add-ons/remote-terminal"
+    rel="noreferrer"
+    target="_blank"
+  >
+    Read the documentation to learn how to enable it
+  </a>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    style="margin-left: 4px; height: 16px; cursor: pointer;"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+    />
+  </svg>
 </div>
 `;

--- a/src/js/components/header/header.js
+++ b/src/js/components/header/header.js
@@ -142,7 +142,7 @@ export class Header extends React.Component {
         className={showOffer ? 'header banner' : 'header'}
         style={{ backgroundColor: '#fff', minHeight: 'unset', paddingLeft: 32, paddingRight: 40 }}
       >
-        {showOffer && <OfferHeader organization={organization} onHide={() => self.setHideOffer()} />}
+        {showOffer && <OfferHeader docsVersion={docsVersion} organization={organization} onHide={() => self.setHideOffer()} />}
         <div className="flexbox">
           <Link to="/">
             <img id="logo" src={isEnterprise ? enterpriseLogo : logo} />

--- a/src/js/components/header/header.js
+++ b/src/js/components/header/header.js
@@ -33,6 +33,16 @@ import enterpriseLogo from '../../../assets/img/headerlogo-enterprise.png';
 
 const menuButtonColor = colors.grey;
 
+// Change this when a new feature/offer is introduced
+const currentOffer = {
+  name: 'remote',
+  expires: '2021-04-01',
+  trial: true,
+  os: true,
+  professional: true,
+  enterprise: true
+};
+
 export class Header extends React.Component {
   constructor(props, context) {
     super(props, context);
@@ -62,6 +72,7 @@ export class Header extends React.Component {
 
   componentDidMount() {
     this._updateUsername();
+    this._offerBannerCookie();
   }
 
   _updateUsername() {
@@ -83,9 +94,21 @@ export class Header extends React.Component {
     );
   }
 
+  _offerBannerCookie() {
+    const self = this;
+    const offerCookie = this.cookies.get('offer') === currentOffer.name;
+    self.setState({ offerCookie: offerCookie });
+  }
+
   onLogoutClick() {
     this.setState({ gettingUser: false, loggingOut: true, anchorEl: null });
     this.props.logoutUser();
+  }
+
+  setHideOffer() {
+    const self = this;
+    this.cookies.set('offer', 'remote', { path: '/', maxAge: 2629746 });
+    self._offerBannerCookie();
   }
 
   render() {
@@ -108,15 +131,18 @@ export class Header extends React.Component {
       toggleHelptips,
       user
     } = self.props;
-    const offerValid = moment().isBefore('2021-01-01');
 
+    const showOffer =
+      moment().isBefore(currentOffer.expires) &&
+      (organization && organization.trial ? currentOffer.trial : currentOffer[organization.plan]) &&
+      !self.state.offerCookie;
     return (
       <Toolbar
         id="fixedHeader"
-        className={organization && organization.trial && offerValid ? 'header banner' : 'header'}
+        className={showOffer ? 'header banner' : 'header'}
         style={{ backgroundColor: '#fff', minHeight: 'unset', paddingLeft: 32, paddingRight: 40 }}
       >
-        {organization && organization.trial && offerValid && <OfferHeader />}
+        {showOffer && <OfferHeader organization={organization} onHide={() => self.setHideOffer()} />}
         <div className="flexbox">
           <Link to="/">
             <img id="logo" src={isEnterprise ? enterpriseLogo : logo} />

--- a/src/js/components/header/header.js
+++ b/src/js/components/header/header.js
@@ -107,7 +107,7 @@ export class Header extends React.Component {
 
   setHideOffer() {
     const self = this;
-    this.cookies.set('offer', 'remote', { path: '/', maxAge: 2629746 });
+    this.cookies.set('offer', currentOffer.name, { path: '/', maxAge: 2629746 });
     self._offerBannerCookie();
   }
 

--- a/src/js/components/header/offerheader.js
+++ b/src/js/components/header/offerheader.js
@@ -1,14 +1,22 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import LocalOfferIcon from '@material-ui/icons/LocalOffer';
+import { LocalOffer as LocalOfferIcon, Close as CloseIcon } from '@material-ui/icons';
 
-const OfferHeader = () => (
+const OfferHeader = ({ organization, onHide }) => (
   <div id="offerHeader" className="offerBox">
     <LocalOfferIcon style={{ marginRight: '2px', height: '16px', verticalAlign: 'bottom' }} />
-    <span>
-      End of year offer – receive 20% discount for 6 months when you upgrade to a paid Mender plan before Dec 31.{' '}
-      <Link to="/settings/upgrade">Learn more and upgrade now</Link>
-    </span>
+    {organization && organization.trial ? (
+      <span>
+        Try out the new <b>Remote terminal</b> feature for free with your current trial.&nbsp;
+      </span>
+    ) : (
+      <span>
+        Try out the new <b>Remote terminal</b> feature for free on your current plan until March 31st.&nbsp;
+      </span>
+    )}
+    <a href="https://docs.mender.io/add-ons/remote-terminal" target="_blank" rel="noreferrer">
+      Read the documentation to learn how to enable it
+    </a>
+    <CloseIcon style={{ marginLeft: '4px', height: '16px', cursor: 'pointer' }} onClick={onHide} />
   </div>
 );
 

--- a/src/js/components/header/offerheader.js
+++ b/src/js/components/header/offerheader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { LocalOffer as LocalOfferIcon, Close as CloseIcon } from '@material-ui/icons';
 
-const OfferHeader = ({ organization, onHide }) => (
+const OfferHeader = ({ docsVersion, organization, onHide }) => (
   <div id="offerHeader" className="offerBox">
     <LocalOfferIcon style={{ marginRight: '2px', height: '16px', verticalAlign: 'bottom' }} />
     {organization && organization.trial ? (
@@ -13,7 +13,7 @@ const OfferHeader = ({ organization, onHide }) => (
         Try out the new <b>Remote terminal</b> feature for free on your current plan until March 31st.&nbsp;
       </span>
     )}
-    <a href="https://docs.mender.io/add-ons/remote-terminal" target="_blank" rel="noreferrer">
+    <a href={`https://docs.mender.io/${docsVersion}add-ons/remote-terminal`} target="_blank" rel="noreferrer">
       Read the documentation to learn how to enable it
     </a>
     <CloseIcon style={{ marginLeft: '4px', height: '16px', cursor: 'pointer' }} onClick={onHide} />


### PR DESCRIPTION
Updated with Remote terminal link, and it should now be possible to hide/show for different plans + trial tier if needed.