### PR TITLE
switched e2e tests to shared docker client with addons

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,6 @@ test:acceptance:
     - export SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}
     - apk add --no-cache bash git wget
     - wget -qP tests/e2e_tests/cypress/fixtures "https://dgsbl4vditpls.cloudfront.net/mender-demo-artifact.mender"
-    - docker load -i clientImage.tar
   script:
     - docker load -i image.tar
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:pr
@@ -124,12 +123,9 @@ test-prep:
     - docker:19.03.5-dind
   script:
     - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/extract mendersoftware/mender-stress-test-client -c "cp mender-stress-test-client /extract/"
-    - docker build -f tests/e2e_tests/dockerClient/Dockerfile.client -t mendersoftware/mender-client-docker:connect tests/e2e_tests/dockerClient
-    - docker save mendersoftware/mender-client-docker:connect > clientImage.tar
   artifacts:
     paths:
       - mender-stress-test-client
-      - clientImage.tar
     expire_in: 30 days
 
 test:staging-deployment:
@@ -155,7 +151,6 @@ test:staging-deployment:
     DEVICE_TYPE: qemux86-64
   before_script:
     - curl -fsSL https://get.docker.com | sh
-    - docker load -i clientImage.tar
     - mv mender-stress-test-client tests/e2e_tests/ && cd tests/e2e_tests
     - wget -qP cypress/fixtures "https://dgsbl4vditpls.cloudfront.net/mender-demo-artifact.mender"
     - touch hosted.pem && true | openssl s_client -connect staging.hosted.mender.io:443 2>/dev/null | openssl x509 > hosted.pem

--- a/tests/e2e_tests/cypress/integration/02-layoutAssertions.spec.js
+++ b/tests/e2e_tests/cypress/integration/02-layoutAssertions.spec.js
@@ -35,7 +35,6 @@ context('Layout assertions', () => {
           cy.task('startDockerClient', { token, backend: Cypress.config().baseUrl, count: 1 });
         });
       });
-      skipOn('staging', () => cy.task('startDockerClient', { backend: Cypress.config().baseUrl, count: 1 }));
       cy.get('a').contains('Devices').click().end();
       cy.get('a').contains('Pending').click().end();
       cy.get('.deviceListItem', { timeout: 60000 });

--- a/tests/e2e_tests/cypress/plugins/index.js
+++ b/tests/e2e_tests/cypress/plugins/index.js
@@ -9,8 +9,8 @@ const updateConfigFileWithUrl = (fileName, serverUrl = 'https://docker.mender.io
   const connectConfigFile = fs.readFileSync(`dockerClient/${fileName}.json`);
   let connectConfig = JSON.parse(connectConfigFile);
   connectConfig.ServerURL = serverUrl;
+  connectConfig.ServerCertificate = '/certs/hosted.pem';
   if (token) {
-    connectConfig.ServerCertificate = '/certs/hosted.pem';
     connectConfig.TenantToken = token;
   }
   fs.writeFileSync(`${projectRoot}/dockerClient/${fileName}-test.json`, JSON.stringify(connectConfig));
@@ -65,7 +65,7 @@ module.exports = (on, config) => {
         `${config.projectRoot}/dockerClient/mender-test.json:/etc/mender/mender.conf`,
         '-v',
         `${config.projectRoot}/dockerClient/mender-connect-test.json:/etc/mender/mender-connect.conf`,
-        'mendersoftware/mender-client-docker:connect'
+        'mendersoftware/mender-client-docker-addons:master'
       ];
       console.log(`starting with: ${token}`);
       console.log(`starting using: docker ${args.join(' ')}`);

--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -27,9 +27,12 @@ services:
       - ${GUI_REPOSITORY}/logs:/root/.npm/_logs
 
   mender-client:
-    image: mendersoftware/mender-client-docker:connect
+    image: mendersoftware/mender-client-docker-addons:master
     volumes:
-      - ${INTEGRATION_PATH}/certs/api-gateway/cert.crt:/certs/hosted.pem
+      - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/artifact_info:/etc/mender/artifact_info
+      - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/device_type:/var/lib/mender/device_type
+      - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender.json:/etc/mender/mender.conf
+      - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf
 
     ##
     ## to execute or edit the tests locally:

--- a/tests/e2e_tests/dockerClient/mender-connect.json
+++ b/tests/e2e_tests/dockerClient/mender-connect.json
@@ -4,7 +4,7 @@
     "Certificate": "/certs/cert.pem",
     "Key": "/keys/key.pem"
   },
-  "ServerCertificate": "/certs/hosted.pem",
+  "ServerCertificate": "/usr/share/doc/mender-client/examples/demo.crt",
   "ShellCommand": "/bin/bash",
   "ServerURL": "https://docker.mender.io",
   "User": "root",


### PR DESCRIPTION
depends on: https://github.com/mendersoftware/integration/pull/1216

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>