### PR TITLE
allowed filters containing duplicate keys with differing scopes

### DIFF
--- a/src/js/components/devices/filteritem.js
+++ b/src/js/components/devices/filteritem.js
@@ -62,13 +62,13 @@ export default class FilterItem extends React.Component {
     return !(nextState.key === this.state.key && nextState.value === this.state.value && nextState.operator === this.state.operator);
   }
 
-  updateFilterKey(value) {
+  updateFilterKey(value, selectedScope) {
     const self = this;
     if (!value) {
       return self._removeFilter();
     }
-    const { key, scope } = self.props.filters.find(filter => filter.key === value);
-    self.setState({ key, scope }, () => self.notifyFilterUpdate());
+    const { key, scope: fallbackScope } = self.props.filters.find(filter => filter.key === value);
+    self.setState({ key, scope: selectedScope || fallbackScope }, () => self.notifyFilterUpdate());
   }
 
   updateFilterOperator(value) {
@@ -139,11 +139,12 @@ export default class FilterItem extends React.Component {
             id="filter-selection"
             includeInputInList={true}
             onChange={(e, changedValue) => {
-              if (changedValue && changedValue.inputValue) {
+              const { inputValue, key = changedValue, scope } = changedValue || {};
+              if (inputValue) {
                 // only circumvent updateFilterKey if we deal with a custom attribute - those will be treated as inventory attributes
-                return self.setState({ key: changedValue.inputValue, scope: defaultScope }, () => self.notifyFilterUpdate());
+                return self.setState({ key: inputValue, scope: defaultScope }, () => self.notifyFilterUpdate());
               }
-              self.updateFilterKey(changedValue && changedValue.key ? changedValue.key : changedValue);
+              self.updateFilterKey(key, scope);
             }}
             options={filters.sort((a, b) => a.priority - b.priority)}
             renderInput={params => <TextField {...params} label="Attribute" style={textFieldStyle} />}

--- a/src/js/components/devices/filters.js
+++ b/src/js/components/devices/filters.js
@@ -214,7 +214,7 @@ const mapStateToProps = (state, ownProps) => {
     ];
   }
   return {
-    attributes: attributes.filter((item, index, array) => array.findIndex(filter => filter.key === item.key) == index),
+    attributes: attributes.filter((item, index, array) => array.findIndex(filter => filter.key === item.key && filter.scope === item.scope) == index),
     canFilterMultiple: state.app.features.isEnterprise || (state.app.features.isHosted && plan !== 'os'),
     filters: ownProps.filters || state.devices.filters || [],
     isHosted: state.app.features.isHosted,


### PR DESCRIPTION
- on selection the differing scope will stay visible in the scope category if one of the 2 instances is listed as a recent filter
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>