### PR TITLE
removed scroll breaking overflow limitation as the corresponding area is protected otherwise already

### DIFF
--- a/src/less/main.less
+++ b/src/less/main.less
@@ -518,7 +518,6 @@ ul.link-list {
 
 .flexbox {
   display: flex;
-  overflow: hidden;
   &.centered {
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
unfortunately the presence of the overflow stop breaks scrolling the auditlog on HM atm


Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>