### PR TITLE
improved deployment creation for large device fleets

### DIFF
--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -9,11 +9,11 @@ import ScheduleRollout from './deployment-wizard/schedulerollout';
 import Review from './deployment-wizard/review';
 
 import { createDeployment } from '../../actions/deploymentActions';
-import { getAllDevicesByStatus, selectDevice } from '../../actions/deviceActions';
+import { selectDevice } from '../../actions/deviceActions';
 import { selectRelease } from '../../actions/releaseActions';
 import { advanceOnboarding } from '../../actions/onboardingActions';
 import { saveGlobalSettings } from '../../actions/userActions';
-import { DEVICE_STATES, UNGROUPED_GROUP } from '../../constants/deviceConstants';
+import { UNGROUPED_GROUP } from '../../constants/deviceConstants';
 import { onboardingSteps } from '../../constants/onboardingConstants';
 import { getIsEnterprise, getOnboardingState } from '../../selectors';
 
@@ -64,7 +64,6 @@ export class CreateDialog extends React.Component {
       return accu;
     }, []);
     self.setState({ steps });
-    self.props.getAllDevicesByStatus(DEVICE_STATES.accepted);
   }
 
   componentDidUpdate(prevProps) {
@@ -104,6 +103,7 @@ export class CreateDialog extends React.Component {
       artifact_name: release.Name,
       devices: filterId || (group && group !== allDevices) ? undefined : deploymentDeviceIds,
       filter_id: filterId,
+      all_devices: !filterId && group === allDevices,
       group: group === allDevices ? undefined : group,
       name: device?.id || (group ? decodeURIComponent(group) : 'All devices'),
       phases: phases
@@ -205,14 +205,14 @@ export class CreateDialog extends React.Component {
   }
 }
 
-const actionCreators = { advanceOnboarding, createDeployment, getAllDevicesByStatus, saveGlobalSettings, selectDevice, selectRelease };
+const actionCreators = { advanceOnboarding, createDeployment, saveGlobalSettings, selectDevice, selectRelease };
 
 export const mapStateToProps = state => {
   const { plan = 'os' } = state.organization.organization;
   // eslint-disable-next-line no-unused-vars
   const { [UNGROUPED_GROUP.id]: ungrouped, ...groups } = state.devices.groups.byId;
   return {
-    acceptedDevices: state.devices.byStatus.accepted.deviceIds,
+    acceptedDeviceCount: state.devices.byStatus.accepted.total,
     createdGroup: Object.values(state.devices.groups.byId)[1],
     device: state.devices.selectedDevice ? state.devices.byId[state.devices.selectedDevice] : null,
     globalSettings: state.users.globalSettings,

--- a/src/js/components/deployments/createdeployment.test.js
+++ b/src/js/components/deployments/createdeployment.test.js
@@ -80,11 +80,14 @@ describe('CreateDeployment Component', () => {
     userEvent.click(screen.getAllByText('Next')[0]);
     userEvent.click(screen.getByText('Create'));
     expect(createDeployment).toHaveBeenCalledWith({
+      all_devices: true,
       artifact_name: defaultState.releases.byId.a1.Name,
-      devices: defaultState.devices.byStatus.accepted.deviceIds,
+      devices: [],
       filter_id: undefined,
       group: undefined,
-      name: 'All devices'
+      name: 'All devices',
+      phases: undefined,
+      retries: undefined
     });
     await waitFor(() => expect(submitCheck).toHaveBeenCalled());
   });
@@ -185,8 +188,9 @@ describe('CreateDeployment Component', () => {
     const secondBatchDate = new Date(new Date(mockDate).setMinutes(mockDate.getMinutes() + 30));
     const thirdBatchDate = new Date(new Date(secondBatchDate).setDate(secondBatchDate.getDate() + 25));
     expect(createDeployment).toHaveBeenCalledWith({
+      all_devices: true,
       artifact_name: defaultState.releases.byId.a1.Name,
-      devices: [...Object.keys(defaultState.devices.byId), 'test1', 'test2'],
+      devices: [],
       filter_id: undefined,
       group: undefined,
       name: 'All devices',

--- a/src/js/components/deployments/deployment-wizard/softwaredevices.js
+++ b/src/js/components/deployments/deployment-wizard/softwaredevices.js
@@ -24,7 +24,7 @@ const styles = {
 export class SoftwareDevices extends React.PureComponent {
   deploymentSettingsUpdate(value, property) {
     const {
-      acceptedDevices,
+      acceptedDeviceCount,
       advanceOnboarding,
       deploymentDeviceCount,
       deploymentDeviceIds = [],
@@ -39,13 +39,15 @@ export class SoftwareDevices extends React.PureComponent {
     let deviceIds = deploymentDeviceIds;
     let deviceCount = deploymentDeviceCount;
     if ((device || state.group) && state.release) {
-      deviceIds = state.group === allDevices ? acceptedDevices : [];
+      deviceIds = [];
       deviceCount = deviceIds.length;
       if (device) {
         deviceIds = [device.id];
         deviceCount = deviceIds.length;
       } else if (state.group !== allDevices) {
         deviceCount = groups[state.group].total;
+      } else {
+        deviceCount = acceptedDeviceCount;
       }
       advanceOnboarding(onboardingSteps.SCHEDULING_GROUP_SELECTION);
     }
@@ -216,7 +218,7 @@ export class SoftwareDevices extends React.PureComponent {
               {(deploymentDeviceIds.length > 0 || group) && (
                 <p className="info">
                   {group ? (
-                    <>All devices in this group</>
+                    <>All devices{group !== allDevices ? ' in this group' : null}</>
                   ) : (
                     <>
                       {deploymentDeviceIds.length} {pluralize('devices', deploymentDeviceIds.length)}


### PR DESCRIPTION
- removed need to retrieve all device ids on deployment creation for all device

Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>