### PR TITLE
Revert "Enable get.mender.io `--demo` flag only on staging for now."

### DIFF
--- a/src/js/components/common/dialogs/__snapshots__/physicaldeviceonboarding.test.js.snap
+++ b/src/js/components/common/dialogs/__snapshots__/physicaldeviceonboarding.test.js.snap
@@ -1993,7 +1993,7 @@ exports[`PhysicalDeviceOnboarding Component tiny onboarding tips renders Install
           <span
             style="white-space: pre-wrap; word-break: break-word;"
           >
-            wget -q -O- https://get.mender.io/ | sudo bash -s && \\
+            wget -q -O- https://get.mender.io/ | sudo bash -s -- --demo && \\
 sudo bash -c 'DEVICE_TYPE="raspberrypi7" && \\
 TENANT_TOKEN="testtoken" && \\
 echo "Running mender setup for localhost" && \\

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -488,7 +488,7 @@ ${enterpriseSettings}`;
   }
   const debInstallationCode = `wget -q -O- https://get.mender.io/${
     isPreRelease && window.location.hostname.includes('staging') ? 'staging' : ''
-  } | sudo bash -s${isPreRelease && window.location.hostname.includes('staging') ? ' -- --demo' : ''}`;
+  } | sudo bash -s -- --demo`;
   let codeToCopy = `${debInstallationCode} && \\
 sudo bash -c 'DEVICE_TYPE="${deviceType}" && \\${
     token

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -105,7 +105,7 @@ describe('getDebConfigurationCode function', () => {
   });
   it('should return a sane result', async () => {
     expect(code).toMatch(
-      `wget -q -O- https://get.mender.io/ | sudo bash -s && \\
+      `wget -q -O- https://get.mender.io/ | sudo bash -s -- --demo && \\
 sudo bash -c 'DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 echo "Running mender setup for localhost" && \\
@@ -149,7 +149,7 @@ echo "Done!"'
     it('should contain sane information for hosted calls', async () => {
       code = getDebConfigurationCode(undefined, true, false, 'token', 'raspberrypi3');
       expect(code).toMatch(
-        `wget -q -O- https://get.mender.io/ | sudo bash -s && \\
+        `wget -q -O- https://get.mender.io/ | sudo bash -s -- --demo && \\
 sudo bash -c 'DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 echo "Running mender setup for hosted.mender.io" && \\
@@ -192,7 +192,7 @@ echo "Done!"'
     it('should contain sane information for staging calls', async () => {
       code = getDebConfigurationCode(undefined, true, false, 'token', 'raspberrypi3');
       expect(code).toMatch(
-        `wget -q -O- https://get.mender.io/ | sudo bash -s && \\
+        `wget -q -O- https://get.mender.io/ | sudo bash -s -- --demo && \\
 sudo bash -c 'DEVICE_TYPE="raspberrypi3" && \\
 TENANT_TOKEN="token" && \\
 echo "Running mender setup for staging.hosted.mender.io" && \\


### PR DESCRIPTION
Fixes MEN-4499.

This reverts commit a77d02cafa0050ccde8ac88aef57a2b963278ed9.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit f95fb0cfdea3fda6c371fa5aeaad342f3e526e2d)