### PR TITLE
explicitly retrieved full device details on onboardingtip creation

### DIFF
--- a/src/js/components/helptips/deploymentcompletetip.js
+++ b/src/js/components/helptips/deploymentcompletetip.js
@@ -6,15 +6,27 @@ import ReactTooltip from 'react-tooltip';
 import Button from '@material-ui/core/Button';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 
+import { getDeviceById, getDevicesByStatus } from '../../actions/deviceActions';
 import { advanceOnboarding, setOnboardingComplete, setShowCreateArtifactDialog } from '../../actions/onboardingActions';
+import DeviceConstants from '../../constants/deviceConstants';
 import { onboardingSteps } from '../../constants/onboardingConstants';
 import { getDemoDeviceAddress } from '../../selectors';
 import Loader from '../common/loader';
 
-export const DeploymentCompleteTip = ({ advanceOnboarding, anchor, setShowCreateArtifactDialog, setOnboardingComplete, url }) => {
+export const DeploymentCompleteTip = ({
+  advanceOnboarding,
+  anchor,
+  getDeviceById,
+  getDevicesByStatus,
+  setShowCreateArtifactDialog,
+  setOnboardingComplete,
+  url
+}) => {
   const tipRef = useRef(null);
+
   useEffect(() => {
     ReactTooltip.show(tipRef.current);
+    getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted).then(tasks => tasks[tasks.length - 1].deviceAccu.ids.map(getDeviceById));
   }, []);
 
   const onClick = () => {
@@ -44,7 +56,7 @@ export const DeploymentCompleteTip = ({ advanceOnboarding, anchor, setShowCreate
 };
 
 const mapDispatchToProps = dispatch => {
-  return bindActionCreators({ advanceOnboarding, setOnboardingComplete, setShowCreateArtifactDialog }, dispatch);
+  return bindActionCreators({ advanceOnboarding, getDeviceById, getDevicesByStatus, setOnboardingComplete, setShowCreateArtifactDialog }, dispatch);
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/js/components/helptips/onboardingcompletetip.js
+++ b/src/js/components/helptips/onboardingcompletetip.js
@@ -3,21 +3,23 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 
-import Button from '@material-ui/core/Button';
-import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import { Button } from '@material-ui/core';
+import { CheckCircle as CheckCircleIcon } from '@material-ui/icons';
 
-import { getDevicesByStatus } from '../../actions/deviceActions';
+import { getDeviceById, getDevicesByStatus } from '../../actions/deviceActions';
 import { setOnboardingComplete } from '../../actions/onboardingActions';
-import * as DeviceConstants from '../../constants/deviceConstants';
+import DeviceConstants from '../../constants/deviceConstants';
 import { getDemoDeviceAddress, getDocsVersion } from '../../selectors';
 import Loader from '../common/loader';
 
-export const OnboardingCompleteTip = ({ anchor, docsVersion, getDevicesByStatus, setOnboardingComplete, url }) => {
+export const OnboardingCompleteTip = ({ anchor, docsVersion, getDeviceById, getDevicesByStatus, setOnboardingComplete, url }) => {
   const tipRef = useRef(null);
 
   useEffect(() => {
     ReactTooltip.show(tipRef.current);
-    getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted).finally(() => setTimeout(() => setOnboardingComplete(true), 120000));
+    getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted)
+      .then(tasks => tasks[tasks.length - 1].deviceAccu.ids.map(getDeviceById))
+      .finally(() => setTimeout(() => setOnboardingComplete(true), 120000));
     return () => {
       setOnboardingComplete(true);
     };
@@ -76,7 +78,7 @@ export const OnboardingCompleteTip = ({ anchor, docsVersion, getDevicesByStatus,
 };
 
 const mapDispatchToProps = dispatch => {
-  return bindActionCreators({ getDevicesByStatus, setOnboardingComplete }, dispatch);
+  return bindActionCreators({ getDeviceById, getDevicesByStatus, setOnboardingComplete }, dispatch);
 };
 
 const mapStateToProps = (state, ownProps) => {


### PR DESCRIPTION
- this should get the full attribute list incl. device ips irrespective of the way to the dialog
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>