### PR TITLE
added check for tenant addons in auditlogs

### DIFF
--- a/src/js/components/auditlogs/auditlogs.js
+++ b/src/js/components/auditlogs/auditlogs.js
@@ -14,6 +14,7 @@ import TimeframePicker from '../common/timeframe-picker';
 import TimerangePicker from '../common/timerange-picker';
 import { AUDIT_LOGS_TYPES } from '../../constants/organizationConstants';
 import { UNGROUPED_GROUP } from '../../constants/deviceConstants';
+import { getTenantCapabilities } from '../../selectors';
 import AuditLogsList, { defaultRowsPerPage } from './auditlogslist';
 
 const today = new Date(new Date().setHours(0, 0, 0));
@@ -230,6 +231,7 @@ const mapStateToProps = state => {
     count: state.organization.eventsTotal || state.organization.events.length,
     events: state.organization.events,
     groups: ['All devices', ...Object.keys(groups).sort()],
+    tenantCapabilties: getTenantCapabilities(state),
     users: state.users.byId
   };
 };

--- a/src/js/components/auditlogs/auditlogslist.js
+++ b/src/js/components/auditlogs/auditlogslist.js
@@ -77,7 +77,19 @@ const auditLogColumns = [
   { title: 'Time', sortable: true, render: TimeWrapper }
 ];
 
-export const AuditLogsList = ({ count, items, loading, locationChange, onChangePage, onChangeRowsPerPage, onChangeSorting, page, perPage, sortDirection }) => {
+export const AuditLogsList = ({
+  count,
+  items,
+  loading,
+  locationChange,
+  onChangePage,
+  onChangeRowsPerPage,
+  onChangeSorting,
+  page,
+  perPage,
+  sortDirection,
+  tenantCapabilties
+}) => {
   const [selectedItem, setSelectedItem] = useState();
 
   useEffect(() => {
@@ -103,7 +115,7 @@ export const AuditLogsList = ({ count, items, loading, locationChange, onChangeP
         </div>
         <div className="auditlogs-list">
           {items.map(item => {
-            const allowsExpansion = !!item.change || item.action.includes('terminal');
+            const allowsExpansion = !!item.change || (tenantCapabilties.hasDeviceConnect && item.action.includes('terminal'));
             return (
               <div
                 className={`auditlogs-list-item ${allowsExpansion ? 'clickable' : ''}`}


### PR DESCRIPTION
to not show session details for users who no longer have the troubleshoot addon

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>