### PR TITLE
explicitly close event details on device listing click

### DIFF
--- a/src/js/components/auditlogs/eventdetails/terminalsession.js
+++ b/src/js/components/auditlogs/eventdetails/terminalsession.js
@@ -17,7 +17,7 @@ momentDurationFormatSetup(moment);
 
 const BEGINNING_OF_TIME = '2020-01-01T00:00:00.000Z';
 
-export const TerminalSession = ({ device, idAttribute, item, getDeviceById, getSessionDetails }) => {
+export const TerminalSession = ({ device, idAttribute, item, getDeviceById, getSessionDetails, onClose }) => {
   const [sessionDetails, setSessionDetails] = useState();
 
   useEffect(() => {
@@ -51,7 +51,11 @@ export const TerminalSession = ({ device, idAttribute, item, getDeviceById, getS
     ),
     'Device type': device_type,
     'System software version': device['rootfs-image.version'] || artifact_name || '-',
-    ' ': <Link to={`/auditlog?object_type=device&object_id=${item.object.id}&start_date=${BEGINNING_OF_TIME}`}>List all log entries for this device</Link>
+    ' ': (
+      <Link to={`/auditlog?object_type=device&object_id=${item.object.id}&start_date=${BEGINNING_OF_TIME}`} onClick={onClose}>
+        List all log entries for this device
+      </Link>
+    )
   };
 
   const sessionMeta = {

--- a/src/js/components/auditlogs/eventdetailsdrawer.js
+++ b/src/js/components/auditlogs/eventdetailsdrawer.js
@@ -32,7 +32,7 @@ export const EventDetailsDrawer = ({ eventItem = {}, onClose, open }) => {
         <HelpOutlineIcon />
       </div>
       <Divider />
-      <Component item={eventItem} />
+      <Component item={eventItem} onClose={onClose} />
       <Divider light style={{ marginTop: theme.spacing(2) }} />
     </Drawer>
   );


### PR DESCRIPTION
- this is needed to also close the drawer if the resulting location doesn't differ

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>