### PR TITLE
allowed device details to show a single config setting as teaser

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -747,8 +747,8 @@ export const setDeviceConfig = (deviceId, config) => dispatch =>
     .catch(err => commonErrorHandler(err, `There was an error setting the configuration for device ${deviceId}.`, dispatch, 'Please check your connection.'))
     .then(() => Promise.resolve(dispatch(getDeviceConfig(deviceId))));
 
-export const applyDeviceConfig = (deviceId, config, isDefault) => (dispatch, getState) =>
-  GeneralApi.post(`${deviceConfig}/${deviceId}/deploy`, config)
+export const applyDeviceConfig = (deviceId, configDeploymentConfiguration, isDefault, config) => (dispatch, getState) =>
+  GeneralApi.post(`${deviceConfig}/${deviceId}/deploy`, configDeploymentConfiguration)
     .catch(err => commonErrorHandler(err, `There was an error deploying the configuration to device ${deviceId}.`, dispatch, 'Please check your connection.'))
     .then(({ data }) => {
       let tasks = [dispatch(getSingleDeployment(data.deployment_id))];

--- a/src/js/components/devices/device-details/__snapshots__/configuration.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/configuration.test.js.snap
@@ -74,7 +74,28 @@ exports[`Configuration Component renders correctly 1`] = `
       />
     </button>
   </div>
-  <div />
+  <div>
+    <div
+      class="break-all two-columns column-data  margin-top"
+      style="margin-bottom: 10px;"
+    >
+      <div
+        class="align-right key text-muted"
+      >
+        <b>
+          uiPasswordRequired
+        </b>
+      </div>
+      <div
+        class="flexbox "
+      >
+        true
+      </div>
+    </div>
+    <a>
+      show more
+    </a>
+  </div>
   <hr
     class="MuiDivider-root"
     style="margin-top: 24px;"

--- a/src/js/components/devices/device-details/configuration.js
+++ b/src/js/components/devices/device-details/configuration.js
@@ -241,7 +241,8 @@ export const DeviceConfiguration = ({
   const onSubmit = () => {
     setIsUpdatingConfig(true);
     setUpdateFailed(false);
-    return Promise.all([setDeviceConfig(device.id, changedConfig), applyDeviceConfig(device.id, changedConfig, isSetAsDefault)])
+    return setDeviceConfig(device.id, changedConfig)
+      .then(() => applyDeviceConfig(device.id, { retries: 0 }, isSetAsDefault, changedConfig))
       .then(() => {
         setUpdateFailed(false);
       })

--- a/src/js/components/devices/device-details/configuration.js
+++ b/src/js/components/devices/device-details/configuration.js
@@ -307,8 +307,20 @@ export const DeviceConfiguration = ({
     return accu;
   }, {});
 
+  const visibleConfigKey = Object.keys(reported).length ? Object.keys(reported)[0] : '';
+  const { [visibleConfigKey]: visibleConfig, ...remainderReported } = reported;
+  const extendedContentLength = Object.keys(remainderReported).length;
   return (
     <DeviceDataCollapse
+      header={
+        visibleConfig &&
+        !isEditingConfig && (
+          <>
+            <ConfigurationObject className="margin-top" config={{ [visibleConfigKey]: visibleConfig }} setSnackbar={setSnackbar} style={{ marginBottom: 10 }} />
+            {!open && !!extendedContentLength && <a onClick={setOpen}>show more</a>}
+          </>
+        )
+      }
       isOpen={open}
       onClick={setOpen}
       title={
@@ -340,11 +352,12 @@ export const DeviceConfiguration = ({
           showHelptips={showHelptips}
         />
       ) : (
-        hasDeviceConfig && <ConfigurationObject className="margin-top" config={reported} setSnackbar={setSnackbar} />
+        hasDeviceConfig && <ConfigurationObject config={remainderReported} setSnackbar={setSnackbar} />
       )}
       <div className="flexbox margin-bottom margin-top" style={{ alignItems: 'center' }}>
         {footer}
       </div>
+      {hasDeviceConfig && !isEditingConfig && <a onClick={() => setOpen(false)}>show less</a>}
       {showLog && <LogDialog logData={updateLog} onClose={() => setShowLog(false)} type="configUpdateLog" />}
       {showConfigImport && <ConfigImportDialog onCancel={() => setShowConfigImport(false)} onSubmit={onConfigImport} />}
     </DeviceDataCollapse>

--- a/src/js/components/devices/device-details/configuration.test.js
+++ b/src/js/components/devices/device-details/configuration.test.js
@@ -94,7 +94,7 @@ describe('Configuration Component', () => {
     expect(screen.getByText(/Configuration could not be updated on device/i)).toBeInTheDocument();
     act(() => userEvent.click(screen.getByRole('button', { name: /Retry/i })));
     expect(submitMock).toHaveBeenLastCalledWith(defaultState.devices.byId.a1.id, { testKey: 'testValue' });
-    expect(applyMock).toHaveBeenLastCalledWith(defaultState.devices.byId.a1.id, { testKey: 'testValue' }, true);
+    expect(applyMock).toHaveBeenLastCalledWith(defaultState.devices.byId.a1.id, { retries: 0 }, true, { testKey: 'testValue' });
     device.config = {
       configured: { test: true, something: 'else', aNumber: 42 },
       reported: { test: true, something: 'else', aNumber: 42 },


### PR DESCRIPTION
- unlike for the rest of the device details sections we can't make an informed selection
- thus bluntly pick a single one and hide the rest
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>