### PR TITLE
prevented untested images from getting published

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,6 +172,18 @@ test:staging-deployment:
       - logs
     when: on_failure
 
+publish:image:
+  needs:
+    - job: build:docker
+      artifacts: true
+    - job: test:acceptance
+
+publish:image:mender:
+  needs:
+    - job: build:docker
+      artifacts: true
+    - job: test:acceptance
+
 publish:tests:
   stage: publish
   except:


### PR DESCRIPTION
Not entirely sure if the combination of needs + dependencies works in the resulting pipeline, but unlike the other repos the gui repo runs the tests against the actual image that is pushed, so we can't rely solely on the `build:image` job here...

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>