### PR TITLE
made running requirement to run acceptance tests optional before publishing images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,12 +177,14 @@ publish:image:
     - job: build:docker
       artifacts: true
     - job: test:acceptance
+      optional: true
 
 publish:image:mender:
   needs:
     - job: build:docker
       artifacts: true
     - job: test:acceptance
+      optional: true
 
 publish:tests:
   stage: publish


### PR DESCRIPTION
- the requirement is needed to prevent untested images from being published
- however, due to the reliance on the imported templates, we can't switch to dependencies, thus making the acceptance test need optional
=> hoping that this still requires them to run if the job is applicable (not excluded by only/except)

==> NB! we need to double check (after merging this) if the publish job also runs if the acceptance test job fails (based on the [suggested implementation in Gitlab](https://gitlab.com/gitlab-org/gitlab/-/issues/30680#note_514181529) I think it would run)... if it runs I honestly would suggest reverting to dependencies for the publishing jobs in the template @lluiscampos.

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>