### PR TITLE
prevented misleading success responses on missing auditlog config from breaking the UI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ cat >/var/www/mender-gui/dist/env.js <<EOF
     isDemoMode: "$DEMO",
     features: {
       hasAddons: "$HAVE_ADDONS",
+      hasAuditlogs: "$HAVE_AUDITLOGS",
       hasDeviceConfig: "$HAVE_DEVICECONFIG",
       hasDeviceConnect: "$HAVE_DEVICECONNECT",
       hasMultitenancy: "$HAVE_MULTITENANT",

--- a/src/js/actions/organizationActions.js
+++ b/src/js/actions/organizationActions.js
@@ -3,6 +3,7 @@ import Cookies from 'universal-cookie';
 import { commonErrorHandler, setSnackbar } from './appActions';
 import Api, { headerNames } from '../api/general-api';
 import OrganizationConstants from '../constants/organizationConstants';
+import { getTenantCapabilities } from '../selectors';
 
 const cookies = new Cookies();
 const apiUrlv1 = '/api/management/v1';
@@ -83,7 +84,11 @@ export const completeUpgrade = (tenantId, plan) => dispatch =>
     .catch(err => commonErrorHandler(err, `There was an error upgrading your account:`, dispatch))
     .then(() => Promise.resolve(dispatch(getUserOrganization())));
 
-export const getAuditLogs = (page, perPage, startDate, endDate, userId, type, detail, sort = 'desc') => dispatch => {
+export const getAuditLogs = (page, perPage, startDate, endDate, userId, type, detail, sort = 'desc') => (dispatch, getState) => {
+  const { hasAuditlogs } = getTenantCapabilities(getState());
+  if (!hasAuditlogs) {
+    return Promise.resolve();
+  }
   const createdAfter = startDate ? `&created_after=${Math.round(Date.parse(startDate) / 1000)}` : '';
   const createdBefore = endDate ? `&created_before=${Math.round(Date.parse(endDate) / 1000)}` : '';
   const typeSearch = type ? `&object_type=${type}` : '';

--- a/src/js/actions/organizationActions.test.js
+++ b/src/js/actions/organizationActions.test.js
@@ -183,7 +183,16 @@ describe('organization actions', () => {
   });
 
   it('should handle auditlog retrieval', async () => {
-    const store = mockStore({ ...defaultState });
+    const store = mockStore({
+      ...defaultState,
+      app: {
+        ...defaultState.app,
+        features: {
+          ...defaultState.app.features,
+          hasAuditlogs: true
+        }
+      }
+    });
     expect(store.getActions()).toHaveLength(0);
     const expectedActions = [
       {

--- a/src/js/reducers/appReducer.js
+++ b/src/js/reducers/appReducer.js
@@ -5,6 +5,7 @@ const menderEnvironment = {
   hostAddress: null,
   features: {
     hasAddons: false,
+    hasAuditlogs: false,
     hasMultitenancy: false,
     isHosted: false,
     isEnterprise: false,
@@ -40,6 +41,7 @@ export const initialState = {
   // return boolean rather than organization details
   features: {
     hasAddons: stringToBoolean(menderEnvironment.features.hasAddons),
+    hasAuditlogs: stringToBoolean(menderEnvironment.features.hasAuditlogs),
     hasMultitenancy: stringToBoolean(menderEnvironment.features.hasMultitenancy),
     hasDeviceConfig: stringToBoolean(menderEnvironment.features.hasDeviceConfig),
     hasDeviceConnect: stringToBoolean(menderEnvironment.features.hasDeviceConnect),

--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -77,9 +77,9 @@ export const getUserRoles = createSelector(
 
 export const getTenantCapabilities = createSelector(
   [getFeatures, getOrganization],
-  ({ hasDeviceConfig: isDeviceConfigEnabled, hasDeviceConnect: isDeviceConnectEnabled, isHosted }, { addons = [] }) => {
+  ({ hasAuditlogs, hasDeviceConfig: isDeviceConfigEnabled, hasDeviceConnect: isDeviceConnectEnabled, isHosted }, { addons = [] }) => {
     const hasDeviceConfig = (!isHosted && isDeviceConfigEnabled) || addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled));
     const hasDeviceConnect = (!isHosted && isDeviceConnectEnabled) || addons.some(addon => addon.name === 'troubleshoot' && Boolean(addon.enabled));
-    return { hasDeviceConfig, hasDeviceConnect };
+    return { hasAuditlogs, hasDeviceConfig, hasDeviceConnect };
   }
 );


### PR DESCRIPTION

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>