### PR TITLE
fixed an error that prevented empty group selection from being seen as that

### DIFF
--- a/src/js/reducers/deviceReducer.js
+++ b/src/js/reducers/deviceReducer.js
@@ -38,7 +38,7 @@ export const initialState = {
       // groupName: { deviceIds: [], total: 0, filters: [] },
       // dynamo: { deviceIds: [], total: 3, filters: [{ a: 1 }] }
     },
-    selectedGroup: null
+    selectedGroup: undefined
   }
 };
 
@@ -93,7 +93,7 @@ const deviceReducer = (state = initialState, action) => {
           [action.group]: group
         };
       } else if (state.groups.selectedGroup === action.group) {
-        selectedGroup = null;
+        selectedGroup = undefined;
         // eslint-disable-next-line no-unused-vars
         const { [action.group]: removal, ...remainingById } = state.groups.byId;
         byId = remainingById;

--- a/tests/mockData.js
+++ b/tests/mockData.js
@@ -186,7 +186,7 @@ export const defaultState = {
           filters: [{ scope: 'system', key: 'group', operator: '$eq', value: 'things' }]
         }
       },
-      selectedGroup: null
+      selectedGroup: undefined
     },
     limit: 500
   },


### PR DESCRIPTION
- this is due to a misalignment in null/undefined for device group selections

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>