### PR TITLE
made static device group count rely entirely on backend information

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -223,7 +223,7 @@ export const selectGroup = (group, filters = []) => (dispatch, getState) => {
     tasks.push(dispatch(setDeviceFilters(cleanedFilters)));
   } else {
     tasks.push(dispatch(setDeviceFilters(filters)));
-    tasks.push(dispatch(getAllGroupDevices(groupName, true)));
+    tasks.push(dispatch(getGroupDevices(groupName, { perPage: 1, shouldIncludeAllStates: true })));
   }
   const selectedGroupName = selectedGroup || !Object.keys(state.devices.groups.byId).length ? groupName : undefined;
   tasks.push(dispatch({ type: DeviceConstants.SELECT_GROUP, group: selectedGroupName }));
@@ -274,8 +274,11 @@ const reduceReceivedDevices = (devices, ids, state, status) =>
     { ids, devicesById: {} }
   );
 
-export const getGroupDevices = (group, options) => (dispatch, getState) =>
-  Promise.resolve(dispatch(getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted, { ...options, group }))).then(results => {
+export const getGroupDevices = (group, options = {}) => (dispatch, getState) => {
+  const { shouldIncludeAllStates, ...remainder } = options;
+  return Promise.resolve(
+    dispatch(getDevicesByStatus(shouldIncludeAllStates ? undefined : DeviceConstants.DEVICE_STATES.accepted, { ...remainder, group }))
+  ).then(results => {
     if (!group) {
       return Promise.resolve();
     }
@@ -297,6 +300,7 @@ export const getGroupDevices = (group, options) => (dispatch, getState) =>
       })
     );
   });
+};
 
 export const getAllGroupDevices = (group, shouldIncludeAllStates) => (dispatch, getState) => {
   if (!group || (!!group && (!getState().devices.groups.byId[group] || getState().devices.groups.byId[group].filters.length))) {

--- a/src/js/actions/deviceActions.test.js
+++ b/src/js/actions/deviceActions.test.js
@@ -101,9 +101,10 @@ describe('selecting things', () => {
     const expectedActions = [
       { type: DeviceConstants.SELECT_GROUP, group: groupName },
       { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: { ...expectedDevice, attributes } } },
+      { type: DeviceConstants.RECEIVE_DEVICE_AUTH, device: expectedDevice },
       {
         type: DeviceConstants.RECEIVE_GROUP_DEVICES,
-        group: { filters: [], deviceIds: [defaultState.devices.byId.a1.id], total: 1 },
+        group: { filters: [], deviceIds: [defaultState.devices.byId.a1.id, defaultState.devices.byId.b1.id], total: 2 },
         groupName
       }
     ];
@@ -356,6 +357,7 @@ describe('static grouping related actions', () => {
       { type: DeviceConstants.SELECT_DEVICE, deviceId: undefined },
       { type: DeviceConstants.SELECT_GROUP, group: undefined },
       { type: AppConstants.SET_SNACKBAR, snackbar: { message: 'The group was updated successfully' } },
+      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: {} },
       { type: DeviceConstants.RECEIVE_GROUPS, groups: { testGroup: defaultState.devices.groups.byId.testGroup } },
       {
         type: DeviceConstants.ADD_DYNAMIC_GROUP,
@@ -522,7 +524,8 @@ describe('dynamic grouping related actions', () => {
         group: { deviceIds: [], total: 0, filters: [{ key: 'group', operator: '$nin', scope: 'system', value: ['testGroup'] }] }
       },
       { type: DeviceConstants.SELECT_GROUP, group: undefined },
-      { type: AppConstants.SET_SNACKBAR, snackbar: { message: 'The group was updated successfully' } }
+      { type: AppConstants.SET_SNACKBAR, snackbar: { message: 'The group was updated successfully' } },
+      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: {} }
     ];
     await store.dispatch(addDynamicGroup(groupName, [{ key: 'group', operator: '$nin', scope: 'system', value: ['testGroup'] }]));
     const storeActions = store.getActions();


### PR DESCRIPTION
- previously this was still calculated based on the entire group device list being retrieved

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>