### PR TITLE
MEN-4755 - device tags & device name

### DIFF
--- a/src/js/actions/appActions.test.js
+++ b/src/js/actions/appActions.test.js
@@ -203,7 +203,8 @@ describe('app actions', () => {
             showHelptips: true
           }
         }
-      }
+      },
+      { type: UserConstants.SET_GLOBAL_SETTINGS, settings: { ...defaultState.users.globalSettings, id_attribute: { attribute: 'mac', scope: 'identity' } } }
     ];
     await store.dispatch(initializeAppData());
     const storeActions = store.getActions();

--- a/src/js/actions/appActions.test.js
+++ b/src/js/actions/appActions.test.js
@@ -67,7 +67,8 @@ describe('app actions', () => {
             'network_interfaces',
             'os',
             'rootfs_type'
-          ]
+          ],
+          tagAttributes: []
         }
       },
       {

--- a/src/js/actions/appActions.test.js
+++ b/src/js/actions/appActions.test.js
@@ -101,6 +101,7 @@ describe('app actions', () => {
               return accu;
             }, {}),
             identity_data: { ...defaultState.devices.byId.a1.identity_data, status: 'accepted' },
+            tags: {},
             updated_ts: inventoryDevice.updated_ts
           }
         }
@@ -124,6 +125,7 @@ describe('app actions', () => {
             }, {}),
             identity_data: { ...defaultState.devices.byId.a1.identity_data, status: 'accepted' },
             status: 'pending',
+            tags: {},
             updated_ts: inventoryDevice.updated_ts
           }
         }

--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -144,25 +144,27 @@ const mapFiltersToTerms = filters =>
 const mapTermsToFilters = terms => terms.map(term => ({ scope: term.scope, key: term.attribute, operator: term.type, value: term.value }));
 
 export const getDynamicGroups = () => (dispatch, getState) =>
-  GeneralApi.get(`${inventoryApiUrlV2}/filters?per_page=${MAX_PAGE_SIZE}`).then(({ data: filters }) => {
-    const state = getState().devices.groups.byId;
-    const groups = (filters || []).reduce((accu, filter) => {
-      accu[filter.name] = {
-        deviceIds: [],
-        total: 0,
-        ...state[filter.name],
-        id: filter.id,
-        filters: mapTermsToFilters(filter.terms)
-      };
-      return accu;
-    }, {});
-    return Promise.resolve(
-      dispatch({
-        type: DeviceConstants.RECEIVE_DYNAMIC_GROUPS,
-        groups
-      })
-    );
-  });
+  GeneralApi.get(`${inventoryApiUrlV2}/filters?per_page=${MAX_PAGE_SIZE}`)
+    .then(({ data: filters }) => {
+      const state = getState().devices.groups.byId;
+      const groups = (filters || []).reduce((accu, filter) => {
+        accu[filter.name] = {
+          deviceIds: [],
+          total: 0,
+          ...state[filter.name],
+          id: filter.id,
+          filters: mapTermsToFilters(filter.terms)
+        };
+        return accu;
+      }, {});
+      return Promise.resolve(
+        dispatch({
+          type: DeviceConstants.RECEIVE_DYNAMIC_GROUPS,
+          groups
+        })
+      );
+    })
+    .catch(() => console.log('Dynamic group retrieval failed - likely accessing a non-enterprise backend'));
 
 export const addDynamicGroup = (groupName, filterPredicates) => (dispatch, getState) =>
   GeneralApi.post(`${inventoryApiUrlV2}/filters`, { name: groupName, terms: mapFiltersToTerms(filterPredicates) })

--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -595,7 +595,7 @@ export const getAllDevicesByStatus = status => (dispatch, getState) => {
 const ATTRIBUTE_LIST_CUTOFF = 100;
 export const getDeviceAttributes = () => dispatch =>
   GeneralApi.get(`${inventoryApiUrlV2}/filters/attributes`).then(({ data }) => {
-    const { inventory: inventoryAttributes, identity: identityAttributes } = (data || []).slice(0, ATTRIBUTE_LIST_CUTOFF).reduce(
+    const { inventory: inventoryAttributes, identity: identityAttributes, tags: tagAttributes } = (data || []).slice(0, ATTRIBUTE_LIST_CUTOFF).reduce(
       (accu, item) => {
         if (!accu[item.scope]) {
           accu[item.scope] = [];
@@ -603,11 +603,11 @@ export const getDeviceAttributes = () => dispatch =>
         accu[item.scope].push(item.name);
         return accu;
       },
-      { inventory: [], identity: [] }
+      { inventory: [], identity: [], tags: [] }
     );
     return dispatch({
       type: DeviceConstants.SET_FILTER_ATTRIBUTES,
-      attributes: { identityAttributes, inventoryAttributes }
+      attributes: { identityAttributes, inventoryAttributes, tagAttributes }
     });
   });
 

--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -397,7 +397,7 @@ export const getDeviceById = id => (dispatch, getState) =>
   GeneralApi.get(`${inventoryApiUrl}/devices/${id}`)
     .then(res => {
       const device = reduceReceivedDevices([res.data], [], getState()).devicesById[id];
-      device.etag = res.headers['ETag'];
+      device.etag = res.headers.etag;
       delete device.updated_ts;
       dispatch({ type: DeviceConstants.RECEIVE_DEVICE, device });
       return Promise.resolve(device);

--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -10,6 +10,7 @@ import AppConstants from '../constants/appConstants';
 import DeviceConstants, { DEVICE_STATES, DEVICE_LIST_DEFAULTS } from '../constants/deviceConstants';
 
 import { deepCompare, extractErrorMessage, getSnackbarMessage, mapDeviceAttributes } from '../helpers';
+import { getIdAttribute } from '../selectors';
 
 const { page: defaultPage, perPage: defaultPerPage } = DEVICE_LIST_DEFAULTS;
 
@@ -310,7 +311,7 @@ export const getAllGroupDevices = (group, shouldIncludeAllStates) => (dispatch, 
   if (!group || (!!group && (!getState().devices.groups.byId[group] || getState().devices.groups.byId[group].filters.length))) {
     return Promise.resolve();
   }
-  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getState().users.globalSettings.id_attribute || 'id' }];
+  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getIdAttribute(getState()).attribute || 'id' }];
   let filters = [{ key: 'group', value: group, operator: '$eq', scope: 'system' }];
   if (!shouldIncludeAllStates) {
     filters.push({ key: 'status', value: DeviceConstants.DEVICE_STATES.accepted, operator: '$eq', scope: 'identity' });
@@ -356,7 +357,7 @@ export const getAllDynamicGroupDevices = group => (dispatch, getState) => {
     ...getState().devices.groups.byId[group].filters,
     { key: 'status', value: DeviceConstants.DEVICE_STATES.accepted, operator: '$eq', scope: 'identity' }
   ]);
-  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getState().users.globalSettings.id_attribute || 'id' }];
+  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getIdAttribute(getState()).attribute || 'id' }];
   const getAllDevices = (perPage = MAX_PAGE_SIZE, page = defaultPage, devices = []) =>
     GeneralApi.post(`${inventoryApiUrlV2}/filters/search`, { page, per_page: perPage, filters, attributes }).then(res => {
       const state = getState();
@@ -490,7 +491,7 @@ export const getDevicesByStatus = (status, options = {}) => (dispatch, getState)
   if (typeof group === 'string' && !applicableFilters.length) {
     applicableFilters = [{ key: 'group', value: group, operator: '$eq', scope: 'system' }];
   }
-  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getState().users.globalSettings.id_attribute || 'id' }];
+  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getIdAttribute(getState()).attribute || 'id' }];
   const effectiveFilters = status ? [...applicableFilters, { key: 'status', value: status, operator: '$eq', scope: 'identity' }] : applicableFilters;
   return GeneralApi.post(`${inventoryApiUrlV2}/filters/search`, {
     page,
@@ -553,7 +554,7 @@ export const getDevicesByStatus = (status, options = {}) => (dispatch, getState)
 };
 
 export const getAllDevicesByStatus = status => (dispatch, getState) => {
-  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getState().users.globalSettings.id_attribute || 'id' }];
+  const attributes = [...defaultAttributes, { scope: 'identity', attribute: getIdAttribute(getState()).attribute || 'id' }];
   const getAllDevices = (perPage = MAX_PAGE_SIZE, page = 1, devices = []) =>
     GeneralApi.post(`${inventoryApiUrlV2}/filters/search`, {
       page,

--- a/src/js/actions/deviceActions.test.js
+++ b/src/js/actions/deviceActions.test.js
@@ -205,7 +205,7 @@ describe('overall device information retrieval', () => {
     expect(storeActions.length).toEqual(expectedActions.length);
     expectedActions.map((action, index) => expect(storeActions[index]).toMatchObject(action));
     const receivedAttributes = storeActions.find(item => item.type === DeviceConstants.SET_FILTER_ATTRIBUTES).attributes;
-    expect(Object.keys(receivedAttributes)).toHaveLength(2);
+    expect(Object.keys(receivedAttributes)).toHaveLength(3);
     Object.entries(receivedAttributes).forEach(([key, value]) => {
       expect(key).toBeTruthy();
       expect(value).toBeTruthy();

--- a/src/js/actions/userActions.js
+++ b/src/js/actions/userActions.js
@@ -181,40 +181,42 @@ export const disableUser2fa = (userId = OWN_USER_ID) => dispatch =>
     .then(() => Promise.resolve(dispatch(getUser(userId))));
 
 export const getRoles = () => (dispatch, getState) =>
-  GeneralApi.get(`${useradmApiUrl}/roles`).then(({ data: roles }) => {
-    const rolesState = getState().users.rolesById;
-    const rolesById = roles.reduce((accu, role) => {
-      const { allowUserManagement, groups } = role.permissions.reduce(
-        (accu, permission) => {
-          if (permission.action === rolesByName.deploymentCreation.action && permission.object.type === rolesByName.deploymentCreation.object.type) {
-            accu.groups.push(permission.object.value);
-          }
-          if (
-            role.name === rolesByName.admin ||
-            (permission.action == rolesByName.userManagement.action &&
-              permission.object.type == rolesByName.userManagement.object.type &&
-              permission.object.value == rolesByName.userManagement.object.value)
-          ) {
-            accu.allowUserManagement = true;
-          }
-          return accu;
-        },
-        { allowUserManagement: false, groups: [] }
-      );
-      accu[role.name] = {
-        ...emptyRole,
-        ...rolesState[role.name],
-        groups,
-        description: rolesState[role.name] && rolesState[role.name].description ? rolesState[role.name].description : role.description,
-        editable: rolesState[role.name] && typeof rolesState[role.name].editable !== 'undefined' ? rolesState[role.name].editable : true,
-        title: rolesState[role.name] && rolesState[role.name].title ? rolesState[role.name].title : role.name,
-        permissions: role.permissions,
-        allowUserManagement: allowUserManagement
-      };
-      return accu;
-    }, {});
-    return dispatch({ type: UserConstants.RECEIVED_ROLES, rolesById });
-  });
+  GeneralApi.get(`${useradmApiUrl}/roles`)
+    .then(({ data: roles }) => {
+      const rolesState = getState().users.rolesById;
+      const rolesById = roles.reduce((accu, role) => {
+        const { allowUserManagement, groups } = role.permissions.reduce(
+          (accu, permission) => {
+            if (permission.action === rolesByName.deploymentCreation.action && permission.object.type === rolesByName.deploymentCreation.object.type) {
+              accu.groups.push(permission.object.value);
+            }
+            if (
+              role.name === rolesByName.admin ||
+              (permission.action == rolesByName.userManagement.action &&
+                permission.object.type == rolesByName.userManagement.object.type &&
+                permission.object.value == rolesByName.userManagement.object.value)
+            ) {
+              accu.allowUserManagement = true;
+            }
+            return accu;
+          },
+          { allowUserManagement: false, groups: [] }
+        );
+        accu[role.name] = {
+          ...emptyRole,
+          ...rolesState[role.name],
+          groups,
+          description: rolesState[role.name] && rolesState[role.name].description ? rolesState[role.name].description : role.description,
+          editable: rolesState[role.name] && typeof rolesState[role.name].editable !== 'undefined' ? rolesState[role.name].editable : true,
+          title: rolesState[role.name] && rolesState[role.name].title ? rolesState[role.name].title : role.name,
+          permissions: role.permissions,
+          allowUserManagement: allowUserManagement
+        };
+        return accu;
+      }, {});
+      return dispatch({ type: UserConstants.RECEIVED_ROLES, rolesById });
+    })
+    .catch(() => console.log('Role retrieval failed - likely accessing a non-RBAC backend'));
 
 const transformRoleDataToRole = roleData => {
   let permissions = roleData.groups.reduce(

--- a/src/js/api/general-api.js
+++ b/src/js/api/general-api.js
@@ -27,12 +27,12 @@ authenticatedRequest.interceptors.request.use(
 );
 
 const Api = {
-  get: url => authenticatedRequest.get(url),
+  get: authenticatedRequest.get,
   delete: (url, data) => authenticatedRequest.request({ method: 'delete', url, data }),
-  patch: (url, data) => authenticatedRequest.patch(url, data),
-  post: (url, data) => authenticatedRequest.post(url, data),
-  postUnauthorized: (url, data) => axios.post(url, data, commonRequestConfig),
-  put: (url, data) => authenticatedRequest.put(url, data),
+  patch: authenticatedRequest.patch,
+  post: authenticatedRequest.post,
+  postUnauthorized: (url, data, config = {}) => axios.post(url, data, { ...commonRequestConfig, ...config }),
+  put: authenticatedRequest.put,
   upload: (url, formData, progress, cancelToken) => authenticatedRequest.post(url, formData, { onUploadProgress: progress, timeout: 0, cancelToken }),
   uploadPut: (url, formData, progress, cancelToken) => authenticatedRequest.put(url, formData, { onUploadProgress: progress, timeout: 0, cancelToken })
 };

--- a/src/js/components/auditlogs/eventdetails/__snapshots__/deviceconfiguration.test.js.snap
+++ b/src/js/components/auditlogs/eventdetails/__snapshots__/deviceconfiguration.test.js.snap
@@ -31,9 +31,9 @@ exports[`DeviceConfiguration Component renders correctly 1`] = `
           href="/devices?id=a1"
           style="color: rgba(0, 0, 0, 0.54); font-weight: initial;"
         >
-          <span>
+          <div>
             a1
-          </span>
+          </div>
           <svg
             aria-hidden="true"
             class="MuiSvgIcon-root margin-left-small link-color MuiSvgIcon-fontSizeSmall"

--- a/src/js/components/auditlogs/eventdetails/__snapshots__/devicedetails.test.js.snap
+++ b/src/js/components/auditlogs/eventdetails/__snapshots__/devicedetails.test.js.snap
@@ -27,9 +27,9 @@ exports[`DeviceDetails Component renders correctly 1`] = `
         href="/devices?id=a1"
         style="color: rgba(0, 0, 0, 0.54); font-weight: initial;"
       >
-        <span>
+        <div>
           a1
-        </span>
+        </div>
         <svg
           aria-hidden="true"
           class="MuiSvgIcon-root margin-left-small link-color MuiSvgIcon-fontSizeSmall"

--- a/src/js/components/auditlogs/eventdetails/__snapshots__/filetransfer.test.js.snap
+++ b/src/js/components/auditlogs/eventdetails/__snapshots__/filetransfer.test.js.snap
@@ -31,9 +31,9 @@ exports[`FileTransfer Component renders correctly 1`] = `
           href="/devices?id=a1"
           style="color: rgba(0, 0, 0, 0.54); font-weight: initial;"
         >
-          <span>
+          <div>
             a1
-          </span>
+          </div>
           <svg
             aria-hidden="true"
             class="MuiSvgIcon-root margin-left-small link-color MuiSvgIcon-fontSizeSmall"

--- a/src/js/components/auditlogs/eventdetails/__snapshots__/portforward.test.js.snap
+++ b/src/js/components/auditlogs/eventdetails/__snapshots__/portforward.test.js.snap
@@ -31,9 +31,9 @@ exports[`PortForward Component renders correctly 1`] = `
           href="/devices?id=a1"
           style="color: rgba(0, 0, 0, 0.54); font-weight: initial;"
         >
-          <span>
+          <div>
             a1
-          </span>
+          </div>
           <svg
             aria-hidden="true"
             class="MuiSvgIcon-root margin-left-small link-color MuiSvgIcon-fontSizeSmall"

--- a/src/js/components/auditlogs/eventdetails/__snapshots__/terminalsession.test.js.snap
+++ b/src/js/components/auditlogs/eventdetails/__snapshots__/terminalsession.test.js.snap
@@ -207,9 +207,9 @@ exports[`TerminalSession Component renders correctly 1`] = `
             href="/devices?id=a1"
             style="color: rgba(0, 0, 0, 0.54); font-weight: initial;"
           >
-            <span>
+            <div>
               a1
-            </span>
+            </div>
             <svg
               aria-hidden="true"
               class="MuiSvgIcon-root margin-left-small link-color MuiSvgIcon-fontSizeSmall"

--- a/src/js/components/auditlogs/eventdetails/deviceconfiguration.js
+++ b/src/js/components/auditlogs/eventdetails/deviceconfiguration.js
@@ -44,7 +44,7 @@ const mapStateToProps = (state, ownProps) => {
   const deviceId = item.object.id;
   return {
     device: state.devices.byId[deviceId],
-    idAttribute: getIdAttribute(state)
+    idAttribute: getIdAttribute(state).attribute
   };
 };
 

--- a/src/js/components/auditlogs/eventdetails/devicedetails.js
+++ b/src/js/components/auditlogs/eventdetails/devicedetails.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Launch as LaunchIcon } from '@material-ui/icons';
 
 import theme, { colors } from '../../../themes/mender-theme';
+import DeviceIdentityDisplay from '../../common/deviceidentity';
 
 const BEGINNING_OF_TIME = '2020-01-01T00:00:00.000Z';
 
@@ -33,7 +34,7 @@ export const DeviceDetails = ({ device, idAttribute, onClose }) => {
     ...nameContainer,
     [usesId ? 'Device ID' : idAttribute]: (
       <Link className="flexbox center-aligned" style={{ color: colors.disabledColor, fontWeight: 'initial' }} to={`/devices?id=${device.id}`}>
-        <span>{usesId ? device.id : (device.identity_data || {})[idAttribute]}</span>
+        <DeviceIdentityDisplay device={device} idAttribute={idAttribute} isEditable={false} />
         <LaunchIcon className="margin-left-small link-color" fontSize="small" />
       </Link>
     ),

--- a/src/js/components/auditlogs/eventdetails/filetransfer.js
+++ b/src/js/components/auditlogs/eventdetails/filetransfer.js
@@ -43,7 +43,7 @@ const mapStateToProps = (state, ownProps) => {
   const deviceId = item.object.id;
   return {
     device: state.devices.byId[deviceId],
-    idAttribute: getIdAttribute(state)
+    idAttribute: getIdAttribute(state).attribute
   };
 };
 

--- a/src/js/components/auditlogs/eventdetails/portforward.js
+++ b/src/js/components/auditlogs/eventdetails/portforward.js
@@ -56,7 +56,7 @@ const mapStateToProps = (state, ownProps) => {
   const deviceId = item.object.id;
   return {
     device: state.devices.byId[deviceId],
-    idAttribute: getIdAttribute(state)
+    idAttribute: getIdAttribute(state).attribute
   };
 };
 

--- a/src/js/components/auditlogs/eventdetails/terminalsession.js
+++ b/src/js/components/auditlogs/eventdetails/terminalsession.js
@@ -60,7 +60,7 @@ const mapStateToProps = (state, ownProps) => {
   const deviceId = item.object.id;
   return {
     device: state.devices.byId[deviceId],
-    idAttribute: getIdAttribute(state)
+    idAttribute: getIdAttribute(state).attribute
   };
 };
 

--- a/src/js/components/common/__snapshots__/deviceidentity.test.js.snap
+++ b/src/js/components/common/__snapshots__/deviceidentity.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeviceIdentityDisplay Component renders correctly 1`] = `
+<div>
+  a1
+</div>
+`;

--- a/src/js/components/common/__snapshots__/devicenameinput.test.js.snap
+++ b/src/js/components/common/__snapshots__/devicenameinput.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeviceNameInput Component renders correctly 1`] = `
+<div
+  class="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-adornedEnd"
+  style="font-size: 0.8125rem;"
+>
+  <input
+    class="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled MuiInputBase-inputAdornedEnd"
+    disabled=""
+    id="a1-id-input"
+    type="text"
+    value="a1"
+  />
+  <div
+    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+  >
+    <button
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          style="font-size: 1.25rem;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/src/js/components/common/__snapshots__/devicenameinput.test.js.snap
+++ b/src/js/components/common/__snapshots__/devicenameinput.test.js.snap
@@ -9,8 +9,9 @@ exports[`DeviceNameInput Component renders correctly 1`] = `
     class="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled MuiInputBase-inputAdornedEnd"
     disabled=""
     id="a1-id-input"
+    placeholder="a1"
     type="text"
-    value="a1"
+    value=""
   />
   <div
     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"

--- a/src/js/components/common/deviceidentity.js
+++ b/src/js/components/common/deviceidentity.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import DeviceNameInput from './devicenameinput';
+
+const DeviceIdComponent = ({ style, value }) => <div style={style}>{value}</div>;
+
+const attributeComponentMap = {
+  default: DeviceIdComponent,
+  name: DeviceNameInput
+};
+
+export const DeviceIdentityDisplay = props => {
+  const { device, idAttribute, isEditable = true } = props;
+  const { identity_data = {}, id } = device;
+  // eslint-disable-next-line no-unused-vars
+  const { status, ...remainingIds } = identity_data;
+  const nonIdKey = Object.keys(remainingIds)[0];
+  const idValue = !idAttribute || idAttribute === 'id' || idAttribute === 'Device ID' ? id : identity_data[idAttribute] ?? identity_data[nonIdKey];
+  const Component = isEditable ? attributeComponentMap[idAttribute] ?? attributeComponentMap.default : attributeComponentMap.default;
+  return <Component {...props} value={idValue} />;
+};
+
+export default DeviceIdentityDisplay;

--- a/src/js/components/common/deviceidentity.test.js
+++ b/src/js/components/common/deviceidentity.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DeviceIdentityDisplay from './deviceidentity';
+import { defaultState, undefineds } from '../../../../tests/mockData';
+
+describe('DeviceIdentityDisplay Component', () => {
+  it('renders correctly', async () => {
+    const { baseElement } = render(<DeviceIdentityDisplay device={defaultState.devices.byId.a1} isEditable={false} />);
+    const view = baseElement.firstChild.firstChild;
+    expect(view).toMatchSnapshot();
+    expect(view).toEqual(expect.not.stringMatching(undefineds));
+  });
+});

--- a/src/js/components/common/devicenameinput.js
+++ b/src/js/components/common/devicenameinput.js
@@ -15,7 +15,7 @@ export const DeviceNameInput = ({ device, isHovered, setSnackbar, setDeviceTags,
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState('');
   const { id = '', tags = {} } = device;
-  const name = tags.name ?? id.substring(0, 6);
+  const { name = '' } = tags;
 
   useEffect(() => {
     if (!isEditing && name !== value) {
@@ -65,12 +65,13 @@ export const DeviceNameInput = ({ device, isHovered, setSnackbar, setDeviceTags,
 
   const onInputClick = e => e.stopPropagation();
 
-  const textColorStyle = tags.name ? { color: menderTheme.palette.text.primary } : {};
+  const textColorStyle = name ? { color: menderTheme.palette.text.primary } : {};
   return (
     <Input
       id={`${device.id}-id-input`}
       disabled={!isEditing}
       value={value}
+      placeholder={id.substring(0, 6)}
       onClick={onInputClick}
       onChange={({ target: { value } }) => setValue(value)}
       style={{ ...style, ...textColorStyle, fontSize: '0.8125rem' }}

--- a/src/js/components/common/devicenameinput.js
+++ b/src/js/components/common/devicenameinput.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+
+// material ui
+import { IconButton, Input, InputAdornment } from '@material-ui/core';
+import { Clear as ClearIcon, Check as CheckIcon, Edit as EditIcon } from '@material-ui/icons';
+
+import { setSnackbar } from '../../actions/appActions';
+import { setDeviceTags } from '../../actions/deviceActions';
+import menderTheme from '../../themes/mender-theme';
+
+const iconStyle = { fontSize: '1.25rem' };
+
+export const DeviceNameInput = ({ device, isHovered, setSnackbar, setDeviceTags, style = {} }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState('');
+  const { id = '', tags = {} } = device;
+  const name = tags.name ?? id.substring(0, 6);
+
+  useEffect(() => {
+    if (!isEditing && name !== value) {
+      setValue(name);
+    }
+  }, [device, isEditing]);
+
+  const onSubmit = () => {
+    const changedTags = {
+      ...tags,
+      name: value
+    };
+    setDeviceTags(id, changedTags).then(() => {
+      setSnackbar('Device name changed');
+      setIsEditing(false);
+    });
+  };
+
+  const onCancel = () => {
+    setValue(name);
+    setIsEditing(false);
+  };
+
+  const onStartEdit = e => {
+    e.stopPropagation();
+    setIsEditing(true);
+  };
+
+  const editButton = (
+    <IconButton onClick={onStartEdit} size="small">
+      <EditIcon style={iconStyle} />
+    </IconButton>
+  );
+
+  const buttonArea = isEditing ? (
+    <>
+      <IconButton onClick={onSubmit} size="small">
+        <CheckIcon style={iconStyle} />
+      </IconButton>
+      <IconButton onClick={onCancel} size="small">
+        <ClearIcon style={iconStyle} />
+      </IconButton>
+    </>
+  ) : (
+    editButton
+  );
+
+  const onInputClick = e => e.stopPropagation();
+
+  const textColorStyle = tags.name ? { color: menderTheme.palette.text.primary } : {};
+  return (
+    <Input
+      id={`${device.id}-id-input`}
+      disabled={!isEditing}
+      value={value}
+      onClick={onInputClick}
+      onChange={({ target: { value } }) => setValue(value)}
+      style={{ ...style, ...textColorStyle, fontSize: '0.8125rem' }}
+      type="text"
+      endAdornment={(isHovered || isEditing) && <InputAdornment position="end">{buttonArea}</InputAdornment>}
+    />
+  );
+};
+
+const actionCreators = {
+  setDeviceTags,
+  setSnackbar
+};
+
+export default connect(undefined, actionCreators)(DeviceNameInput);

--- a/src/js/components/common/devicenameinput.test.js
+++ b/src/js/components/common/devicenameinput.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { defaultState, undefineds } from '../../../../tests/mockData';
+import { DeviceNameInput } from './devicenameinput';
+
+const mockStore = configureStore([thunk]);
+
+describe('DeviceNameInput Component', () => {
+  let store;
+  beforeEach(() => {
+    store = mockStore({ ...defaultState });
+  });
+  it('renders correctly', async () => {
+    const { baseElement } = render(<DeviceNameInput device={defaultState.devices.byId.a1} isHovered setSnackbar={jest.fn} setDeviceTags={jest.fn} />);
+    const view = baseElement.firstChild.firstChild;
+    expect(view).toMatchSnapshot();
+    expect(view).toEqual(expect.not.stringMatching(undefineds));
+  });
+
+  it('works as intended', async () => {
+    const submitCheck = jest.fn();
+    submitCheck.mockResolvedValue();
+    const snackCheck = jest.fn();
+    const ui = (
+      <Provider store={store}>
+        <DeviceNameInput
+          device={{ ...defaultState.devices.byId.a1, tags: { name: 'testname' } }}
+          isHovered
+          setSnackbar={snackCheck}
+          setDeviceTags={submitCheck}
+        />
+      </Provider>
+    );
+    const { rerender } = render(ui);
+    expect(screen.queryByDisplayValue(/testname/i)).toBeInTheDocument();
+    userEvent.click(screen.getByRole('button'));
+    await waitFor(() => rerender(ui));
+    userEvent.type(screen.getByDisplayValue(/testname/i), 'something');
+    await act(async () => await userEvent.click(screen.getAllByRole('button')[0]));
+    expect(submitCheck).toHaveBeenCalledWith(defaultState.devices.byId.a1.id, { name: 'testnamesomething' });
+    expect(snackCheck).toHaveBeenCalled();
+  });
+});

--- a/src/js/components/common/forms/keyvalueeditor.js
+++ b/src/js/components/common/forms/keyvalueeditor.js
@@ -21,6 +21,13 @@ export const KeyValueEditor = ({ disabled, errortext, input = {}, inputHelpTipsM
     setInputs(newInputs);
   }, [reset]);
 
+  const onClearClick = () => {
+    const changedInputs = [{ ...emptyInput }];
+    setInputs(changedInputs);
+    const inputObject = reducePairs(changedInputs);
+    onInputChange(inputObject);
+  };
+
   const updateInputs = (key, index, event) => {
     let changedInputs = [...inputs];
     const {
@@ -75,12 +82,12 @@ export const KeyValueEditor = ({ disabled, errortext, input = {}, inputHelpTipsM
         const Helptip = inputs[index].helptip?.component;
         const ref = inputRefs.current[index];
         return (
-          <div className="key-value-container flexbox" key={index}>
-            <FormControl disabled={disabled} error={hasError} style={{ marginRight: 15, marginTop: 10 }}>
+          <div className="key-value-container relative" key={index}>
+            <FormControl disabled={disabled} error={hasError}>
               <Input value={input.key} placeholder="Key" inputRef={ref} onChange={e => updateInputs('key', index, e)} type="text" />
               {hasError && <FormHelperText>{errortext || error}</FormHelperText>}
             </FormControl>
-            <FormControl disabled={disabled} error={hasError} style={{ marginTop: 10 }}>
+            <FormControl disabled={disabled} error={hasError}>
               <Input value={`${input.value}`} placeholder="Value" onChange={e => updateInputs('value', index, e)} type="text" />
             </FormControl>
             {inputs.length > 1 && !hasRemovalDisabled ? (
@@ -88,21 +95,33 @@ export const KeyValueEditor = ({ disabled, errortext, input = {}, inputHelpTipsM
                 <ClearIcon fontSize="small" />
               </IconButton>
             ) : (
-              <span style={{ minWidth: 44 }} />
+              <span />
             )}
             {showHelptips && Helptip && ref.current && <Helptip anchor={getHelptipPosition(ref)} {...inputs[index].helptip.props} />}
           </div>
         );
       })}
-      <Fab
-        disabled={disabled || !inputs[inputs.length - 1].key || !inputs[inputs.length - 1].value}
-        style={{ marginTop: 10, marginBottom: 10 }}
-        color="secondary"
-        size="small"
-        onClick={addKeyValue}
-      >
-        <ContentAddIcon />
-      </Fab>
+      <div className="key-value-container">
+        <div style={{ minWidth: theme.spacing(30) }}>
+          <Fab
+            disabled={disabled || !inputs[inputs.length - 1].key || !inputs[inputs.length - 1].value}
+            style={{ marginBottom: 10 }}
+            color="secondary"
+            size="small"
+            onClick={addKeyValue}
+          >
+            <ContentAddIcon />
+          </Fab>
+        </div>
+        <div style={{ minWidth: theme.spacing(30) }} />
+        {inputs.length > 1 ? (
+          <a className="margin-left-small" onClick={onClearClick}>
+            clear all
+          </a>
+        ) : (
+          <div />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/js/components/common/forms/keyvalueeditor.js
+++ b/src/js/components/common/forms/keyvalueeditor.js
@@ -15,7 +15,7 @@ export const KeyValueEditor = ({ disabled, errortext, input = {}, inputHelpTipsM
 
   useEffect(() => {
     const newInputs = Object.keys(input).length
-      ? Object.entries(input).map(([key, value]) => ({ helptip: inputHelpTipsMap[key], key, ref: createRef(), value }))
+      ? Object.entries(input).map(([key, value]) => ({ helptip: inputHelpTipsMap[key.toLowerCase()], key, ref: createRef(), value }))
       : [{ ...emptyInput, ref: createRef() }];
     inputRefs.current = newInputs.map((_, i) => inputRefs.current[i] ?? createRef());
     setInputs(newInputs);
@@ -35,8 +35,9 @@ export const KeyValueEditor = ({ disabled, errortext, input = {}, inputHelpTipsM
     } = event;
     changedInputs[index][key] = value;
     changedInputs[index].helptip = null;
-    if (inputHelpTipsMap[changedInputs[index].key]) {
-      changedInputs[index].helptip = inputHelpTipsMap[changedInputs[index].key];
+    const normalizedKey = changedInputs[index].key.toLowerCase();
+    if (inputHelpTipsMap[normalizedKey]) {
+      changedInputs[index].helptip = inputHelpTipsMap[normalizedKey];
     }
     setInputs(changedInputs);
     const inputObject = reducePairs(changedInputs);

--- a/src/js/components/deployments/__snapshots__/report.test.js.snap
+++ b/src/js/components/deployments/__snapshots__/report.test.js.snap
@@ -431,10 +431,7 @@ Devices that are in the middle of the deployment at the time of abort will finis
                 class=\\"MuiTableCell-root MuiTableCell-head\\"
                 scope=\\"col\\"
                 style=\\"position: sticky; top: 0px; background: white; z-index: 1;\\"
-                tooltip=\\"Device ID\\"
-              >
-                Device ID
-              </th>
+              />
               <th
                 class=\\"MuiTableCell-root MuiTableCell-head\\"
                 scope=\\"col\\"
@@ -496,7 +493,9 @@ Devices that are in the middle of the deployment at the time of abort will finis
                   href=\\"/devices/id=a1\\"
                   style=\\"font-weight: 500;\\"
                 >
-                  a1
+                  <div>
+                    a1
+                  </div>
                 </a>
               </td>
               <td

--- a/src/js/components/deployments/deployment-report/__snapshots__/deploymentdevicelistitem.test.js.snap
+++ b/src/js/components/deployments/deployment-report/__snapshots__/deploymentdevicelistitem.test.js.snap
@@ -11,7 +11,9 @@ exports[`DeploymentDeviceListItem Component renders correctly 1`] = `
       href="/devices/id=a1"
       style="font-weight: 500;"
     >
-      a1
+      <div>
+        a1
+      </div>
     </a>
   </td>
   <td

--- a/src/js/components/deployments/deployment-report/__snapshots__/devicelist.test.js.snap
+++ b/src/js/components/deployments/deployment-report/__snapshots__/devicelist.test.js.snap
@@ -78,7 +78,9 @@ exports[`ProgressDeviceList Component renders correctly 1`] = `
             href=\\"/devices/id=a1\\"
             style=\\"font-weight: 500;\\"
           >
-            a1
+            <div>
+              a1
+            </div>
           </a>
         </td>
         <td

--- a/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
+++ b/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
@@ -6,6 +6,7 @@ import Time from 'react-time';
 import { Button, LinearProgress, TableCell, TableRow } from '@material-ui/core';
 
 import { formatTime, statusToPercentage } from '../../../helpers';
+import DeviceIdentityDisplay from '../../common/deviceidentity';
 
 const stateTitleMap = {
   noartifact: 'No compatible artifact found',
@@ -16,14 +17,7 @@ const stateTitleMap = {
 };
 
 const DeploymentDeviceListItem = ({ created: deploymentCreationDate, device, idAttribute, viewLog, retries: maxRetries }) => {
-  const { attempts, attributes = {}, created, finished, id = 'id', identity_data, log, retries, substate, status } = device;
-
-  let id_attribute = id;
-  if (idAttribute !== 'Device ID' && identity_data) {
-    // if global setting is not "Device Id"
-    // if device identity data is available, set custom attribute
-    id_attribute = identity_data[idAttribute];
-  }
+  const { attempts, attributes = {}, created, finished, id = 'id', log, retries, substate, status } = device;
 
   const softwareName = attributes['rootfs-image.version'] || attributes.artifact_name;
   const encodedArtifactName = encodeURIComponent(softwareName);
@@ -45,7 +39,7 @@ const DeploymentDeviceListItem = ({ created: deploymentCreationDate, device, idA
     <TableRow>
       <TableCell>
         <Link style={{ fontWeight: '500' }} to={`/devices/id=${id}`}>
-          {id_attribute}
+          <DeviceIdentityDisplay device={device} idAttribute={idAttribute} isEditable={false} />
         </Link>
       </TableCell>
       <TableCell>{attributes.device_type || '-'}</TableCell>

--- a/src/js/components/deployments/report.js
+++ b/src/js/components/deployments/report.js
@@ -224,7 +224,7 @@ const mapStateToProps = state => {
     deviceCount: allDevices.length,
     devicesById: state.devices.byId,
     deployment,
-    idAttribute: getIdAttribute(state),
+    idAttribute: getIdAttribute(state).attribute,
     isEnterprise: getIsEnterprise(state),
     isHosted: state.app.features.isHosted,
     release:

--- a/src/js/components/devices/__snapshots__/device-groups.test.js.snap
+++ b/src/js/components/devices/__snapshots__/device-groups.test.js.snap
@@ -25,13 +25,13 @@ exports[`DeviceGroups Component renders correctly 1`] = `
             role=\\"button\\"
             tabindex=\\"0\\"
           >
-            Device ID
+            Name
           </div>
           <input
             aria-hidden=\\"true\\"
             class=\\"MuiSelect-nativeInput\\"
             tabindex=\\"-1\\"
-            value=\\"id\\"
+            value=\\"name\\"
           />
           <svg
             aria-hidden=\\"true\\"
@@ -454,10 +454,9 @@ exports[`DeviceGroups Component renders correctly 1`] = `
             <div
               class=\\"columnHeader\\"
             >
-              Device ID
               <svg
                 aria-hidden=\\"true\\"
-                class=\\"MuiSvgIcon-root sortIcon  true\\"
+                class=\\"MuiSvgIcon-root sortIcon selected true\\"
                 focusable=\\"false\\"
                 viewBox=\\"0 0 24 24\\"
               >

--- a/src/js/components/devices/__snapshots__/device-groups.test.js.snap
+++ b/src/js/components/devices/__snapshots__/device-groups.test.js.snap
@@ -47,6 +47,7 @@ exports[`DeviceGroups Component renders correctly 1`] = `
         <div
           class=\\"MuiFormControl-root MuiTextField-root search\\"
           style=\\"margin-left: 30px; margin-top: 0px;\\"
+          title=\\"This will only apply to devices that have a device name configured\\"
         >
           <div
             class=\\"MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl\\"
@@ -425,13 +426,13 @@ exports[`DeviceGroups Component renders correctly 1`] = `
           >
             <span
               aria-disabled=\\"false\\"
-              class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary\\"
+              class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-3 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary\\"
             >
               <span
                 class=\\"MuiIconButton-label\\"
               >
                 <input
-                  class=\\"PrivateSwitchBase-input-4\\"
+                  class=\\"PrivateSwitchBase-input-6\\"
                   data-indeterminate=\\"false\\"
                   type=\\"checkbox\\"
                   value=\\"\\"
@@ -554,13 +555,13 @@ exports[`DeviceGroups Component renders correctly 1`] = `
             >
               <span
                 aria-disabled=\\"false\\"
-                class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary\\"
+                class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-3 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary\\"
               >
                 <span
                   class=\\"MuiIconButton-label\\"
                 >
                   <input
-                    class=\\"PrivateSwitchBase-input-4\\"
+                    class=\\"PrivateSwitchBase-input-6\\"
                     data-indeterminate=\\"false\\"
                     type=\\"checkbox\\"
                     value=\\"\\"
@@ -628,13 +629,13 @@ exports[`DeviceGroups Component renders correctly 1`] = `
             >
               <span
                 aria-disabled=\\"false\\"
-                class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary\\"
+                class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-3 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary\\"
               >
                 <span
                   class=\\"MuiIconButton-label\\"
                 >
                   <input
-                    class=\\"PrivateSwitchBase-input-4\\"
+                    class=\\"PrivateSwitchBase-input-6\\"
                     data-indeterminate=\\"false\\"
                     type=\\"checkbox\\"
                     value=\\"\\"

--- a/src/js/components/devices/__snapshots__/filteritem.test.js.snap
+++ b/src/js/components/devices/__snapshots__/filteritem.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FilterItem Component renders correctly 1`] = `
 <div
-  class="flexbox center-aligned"
+  class="flexbox center-aligned relative"
 >
   <div
     aria-expanded="false"

--- a/src/js/components/devices/__snapshots__/filters.test.js.snap
+++ b/src/js/components/devices/__snapshots__/filters.test.js.snap
@@ -22,7 +22,7 @@ exports[`Filters Component renders correctly 1`] = `
         </div>
         <div>
           <div
-            class="flexbox center-aligned"
+            class="flexbox center-aligned relative"
           >
             <div
               aria-expanded="false"

--- a/src/js/components/devices/__snapshots__/preauth-dialog.test.js.snap
+++ b/src/js/components/devices/__snapshots__/preauth-dialog.test.js.snap
@@ -91,11 +91,10 @@ exports[`PreauthDialog Component renders correctly 1`] = `
         </h4>
         <div>
           <div
-            class="key-value-container flexbox"
+            class="key-value-container relative"
           >
             <div
               class="MuiFormControl-root"
-              style="margin-right: 15px; margin-top: 10px;"
             >
               <div
                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -111,7 +110,6 @@ exports[`PreauthDialog Component renders correctly 1`] = `
             </div>
             <div
               class="MuiFormControl-root"
-              style="margin-top: 10px;"
             >
               <div
                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -125,32 +123,42 @@ exports[`PreauthDialog Component renders correctly 1`] = `
                 />
               </div>
             </div>
-            <span
-              style="min-width: 44px;"
-            />
+            <span />
           </div>
-          <button
-            class="MuiButtonBase-root MuiFab-root MuiFab-sizeSmall Mui-disabled MuiFab-secondary Mui-disabled"
-            disabled=""
-            style="margin-top: 10px; margin-bottom: 10px;"
-            tabindex="-1"
-            type="button"
+          <div
+            class="key-value-container"
           >
-            <span
-              class="MuiFab-label"
+            <div
+              style="min-width: 240px;"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiFab-root MuiFab-sizeSmall Mui-disabled MuiFab-secondary Mui-disabled"
+                disabled=""
+                style="margin-bottom: 10px;"
+                tabindex="-1"
+                type="button"
               >
-                <path
-                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                />
-              </svg>
-            </span>
-          </button>
+                <span
+                  class="MuiFab-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              style="min-width: 240px;"
+            />
+            <div />
+          </div>
         </div>
       </div>
       <div

--- a/src/js/components/devices/__snapshots__/quickfilter.test.js.snap
+++ b/src/js/components/devices/__snapshots__/quickfilter.test.js.snap
@@ -19,7 +19,7 @@ exports[`QuickFilter Component renders correctly 1`] = `
       aria-hidden="true"
       class="MuiSelect-nativeInput"
       tabindex="-1"
-      value="id"
+      value="name"
     />
     <svg
       aria-hidden="true"

--- a/src/js/components/devices/__snapshots__/quickfilter.test.js.snap
+++ b/src/js/components/devices/__snapshots__/quickfilter.test.js.snap
@@ -35,6 +35,7 @@ exports[`QuickFilter Component renders correctly 1`] = `
   <div
     class="MuiFormControl-root MuiTextField-root search"
     style="margin-left: 30px; margin-top: 0px;"
+    title="This will only apply to devices that have a device name configured"
   >
     <div
       class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -235,9 +235,9 @@ export const Authorized = props => {
   const EmptyState = currentSelectedState.emptyState;
   const columnHeaders = [
     {
-      title: idAttributeTitleMap[idAttribute] ?? idAttribute,
+      title: idAttributeTitleMap[idAttribute.attribute] ?? idAttribute.attribute,
       customize: openSettingsDialog,
-      attribute: { name: idAttribute, scope: 'identity' },
+      attribute: { name: idAttribute.attribute, scope: idAttribute.scope },
       sortable: true
     },
     ...currentSelectedState.defaultHeaders

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -32,6 +32,10 @@ const idAttributeTitleMap = {
   name: 'Name'
 };
 
+const sortingNotes = {
+  name: 'Sorting by Name will only work properly with devices that already have a device name defined'
+};
+
 export const Authorized = props => {
   const {
     acceptedCount,
@@ -330,6 +334,7 @@ export const Authorized = props => {
               pageLoading={pageLoading}
               pageTotal={deviceCount}
               refreshDevices={getDevices}
+              sortingNotes={sortingNotes}
             />
             {showHelptips && <ExpandDevice />}
           </div>

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -27,6 +27,11 @@ const refreshDeviceLength = 10000;
 const { page: defaultPage, perPage: defaultPerPage } = DEVICE_LIST_DEFAULTS;
 let timer;
 
+const idAttributeTitleMap = {
+  id: 'Device ID',
+  name: 'Name'
+};
+
 export const Authorized = props => {
   const {
     acceptedCount,
@@ -212,9 +217,9 @@ export const Authorized = props => {
   };
 
   const onSortChange = attribute => {
-    let changedSortCol = attribute.name === 'Device ID' ? 'id' : attribute.name;
+    let changedSortCol = attribute.name;
     let changedSortDown = sortDown === DEVICE_SORTING_OPTIONS.desc ? DEVICE_SORTING_OPTIONS.asc : DEVICE_SORTING_OPTIONS.desc;
-    if (changedSortCol !== sortCol && attribute.name !== 'Device ID') {
+    if (changedSortCol !== sortCol) {
       changedSortDown = DEVICE_SORTING_OPTIONS.desc;
     }
     setDeviceListState({ sort: { direction: changedSortDown, columns: [{ column: changedSortCol, scope: attribute.scope }] } });
@@ -230,7 +235,7 @@ export const Authorized = props => {
   const EmptyState = currentSelectedState.emptyState;
   const columnHeaders = [
     {
-      title: idAttribute,
+      title: idAttributeTitleMap[idAttribute] ?? idAttribute,
       customize: openSettingsDialog,
       attribute: { name: idAttribute, scope: 'identity' },
       sortable: true

--- a/src/js/components/devices/device-details/__snapshots__/devicetags.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/devicetags.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeviceTags Component renders correctly 1`] = `
+<div
+  class="margin-bottom "
+>
+  <div
+    class="clickable flexbox space-between"
+    style="align-items: flex-start;"
+  >
+    <div
+      class="two-columns"
+    >
+      <div
+        class="flexbox center-aligned"
+      >
+        <h4
+          class="margin-right"
+        >
+          Tags
+        </h4>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSizeSmall MuiButton-sizeSmall"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            <span
+              class="MuiButton-startIcon MuiButton-iconSizeSmall"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </span>
+            Edit
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="flexbox centered"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+  <div />
+  <hr
+    class="MuiDivider-root"
+    style="margin-top: 24px;"
+  />
+</div>
+`;

--- a/src/js/components/devices/device-details/__snapshots__/identity.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/identity.test.js.snap
@@ -61,8 +61,9 @@ exports[`DeviceIdentity Component renders correctly 1`] = `
           class="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled MuiInputBase-inputAdornedEnd"
           disabled=""
           id="a1-id-input"
+          placeholder="a1"
           type="text"
-          value="a1"
+          value=""
         />
         <div
           class="MuiInputAdornment-root MuiInputAdornment-positionEnd"

--- a/src/js/components/devices/device-details/__snapshots__/identity.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/identity.test.js.snap
@@ -43,6 +43,58 @@ exports[`DeviceIdentity Component renders correctly 1`] = `
   </div>
   <div>
     <div
+      class="break-all two-columns column-data compact"
+      style="max-width: 80%; grid-template-columns: minmax(max-content, 150px) max-content; margin-bottom: 5px; align-items: center;"
+    >
+      <div
+        class="align-right key text-muted"
+      >
+        <b>
+          Name
+        </b>
+      </div>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-adornedEnd"
+        style="font-size: 0.8125rem;"
+      >
+        <input
+          class="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled MuiInputBase-inputAdornedEnd"
+          disabled=""
+          id="a1-id-input"
+          type="text"
+          value="a1"
+        />
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                style="font-size: 1.25rem;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
       class="break-all two-columns column-data compact "
       style="max-width: 80%; grid-template-columns: minmax(max-content, 150px) auto; margin-bottom: 5px;"
     >

--- a/src/js/components/devices/device-details/authsets/authsets.test.js
+++ b/src/js/components/devices/device-details/authsets/authsets.test.js
@@ -17,11 +17,7 @@ describe('Authsets Component', () => {
   it('renders correctly', async () => {
     const { baseElement } = render(
       <Provider store={store}>
-        <Authsets
-          device={{ id: 'a1', status: 'accepted', attributes: [], auth_sets: [] }}
-          id_attribute={defaultState.users.globalSettings.id_attribute}
-          open={true}
-        />
+        <Authsets device={{ id: 'a1', status: 'accepted', attributes: [], auth_sets: [] }} open={true} />
       </Provider>
     );
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];

--- a/src/js/components/devices/device-details/devicetags.js
+++ b/src/js/components/devices/device-details/devicetags.js
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+
+import { Button } from '@material-ui/core';
+import { Edit as EditIcon } from '@material-ui/icons';
+
+import Tracking from '../../../tracking';
+import ConfigurationObject from '../../common/configurationobject';
+import KeyValueEditor from '../../common/forms/keyvalueeditor';
+import { NameTagTip } from '../../helptips/helptooltips';
+import DeviceDataCollapse from './devicedatacollapse';
+import theme from '../../../themes/mender-theme';
+
+const configHelpTipsMap = {
+  name: {
+    position: 'right',
+    component: NameTagTip
+  }
+};
+
+export const DeviceTags = ({ device, setDeviceTags, setSnackbar, showHelptips }) => {
+  const [changedTags, setChangedTags] = useState({});
+  const [isEditDisabled, setIsEditDisabled] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [shouldUpdateEditor, setShouldUpdateEditor] = useState(false);
+
+  const { tags = {} } = device;
+  const visibleSectionKey = Object.keys(tags).length ? Object.keys(tags)[0] : '';
+  const { [visibleSectionKey]: visibleSection, ...remainderReported } = tags;
+  const extendedContentLength = Object.keys(remainderReported).length;
+  const hasTags = !!Object.keys(tags).length;
+
+  useEffect(() => {
+    setShouldUpdateEditor(!shouldUpdateEditor);
+  }, [isEditing]);
+
+  useEffect(() => {
+    if (open && !isEditing && !hasTags) {
+      setIsEditing(true);
+    }
+  }, [open, hasTags]);
+
+  const onCancel = () => {
+    setIsEditing(false);
+    setOpen(false);
+    setChangedTags(tags);
+  };
+
+  const onStartEdit = e => {
+    e.stopPropagation();
+    setChangedTags(tags);
+    setOpen(true);
+    setIsEditing(true);
+  };
+
+  const onSubmit = () => {
+    Tracking.event({ category: 'devices', action: 'modify_tags' });
+    setIsEditDisabled(true);
+    return setDeviceTags(device.id, changedTags)
+      .then(() => setIsEditing(false))
+      .finally(() => setIsEditDisabled(false));
+  };
+
+  const helpTipsMap = Object.entries(configHelpTipsMap).reduce((accu, [key, value]) => {
+    accu[key] = {
+      ...value,
+      props: { deviceId: device.id }
+    };
+    return accu;
+  }, {});
+  return (
+    <DeviceDataCollapse
+      header={
+        visibleSection &&
+        !isEditing && (
+          <>
+            <ConfigurationObject config={{ [visibleSectionKey]: visibleSection }} setSnackbar={setSnackbar} style={{ marginBottom: 10 }} />
+            {!open && !!extendedContentLength && <a onClick={setOpen}>show more</a>}
+          </>
+        )
+      }
+      isOpen={open}
+      onClick={setOpen}
+      title={
+        <div className="two-columns">
+          <div className="flexbox center-aligned">
+            <h4 className="margin-right">Tags</h4>
+            {!isEditing && (
+              <Button onClick={onStartEdit} startIcon={<EditIcon />} size="small">
+                Edit
+              </Button>
+            )}
+          </div>
+        </div>
+      }
+    >
+      <div className="relative" style={{ maxWidth: 700 }}>
+        {isEditing ? (
+          <>
+            <KeyValueEditor
+              disabled={isEditDisabled}
+              errortext=""
+              input={changedTags}
+              inputHelpTipsMap={helpTipsMap}
+              onInputChange={setChangedTags}
+              reset={shouldUpdateEditor}
+              showHelptips={showHelptips}
+            />
+            <div className="flexbox center-aligned margin-bottom-small" style={{ justifyContent: 'flex-end' }}>
+              <Button color="primary" onClick={onSubmit} variant="contained" style={{ marginRight: theme.spacing(2) }}>
+                Save
+              </Button>
+              <Button onClick={onCancel}>Cancel</Button>
+            </div>
+          </>
+        ) : (
+          hasTags && (
+            <>
+              <ConfigurationObject config={remainderReported} setSnackbar={setSnackbar} />
+              <a onClick={() => setOpen(false)}>show less</a>
+            </>
+          )
+        )}
+      </div>
+    </DeviceDataCollapse>
+  );
+};
+
+export default DeviceTags;

--- a/src/js/components/devices/device-details/devicetags.test.js
+++ b/src/js/components/devices/device-details/devicetags.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { render } from '@testing-library/react';
+
+import { defaultState, undefineds } from '../../../../../tests/mockData';
+import DeviceTags from './devicetags';
+
+const mockStore = configureStore([thunk]);
+
+describe('DeviceTags Component', () => {
+  let store;
+  beforeEach(() => {
+    store = mockStore({ ...defaultState });
+  });
+  it('renders correctly', async () => {
+    const { baseElement } = render(
+      <Provider store={store}>
+        <DeviceTags device={{ ...defaultState.devices.byId.a1 }} setDeviceTags={jest.fn} setSnackbar={jest.fn} showHelptips />
+      </Provider>
+    );
+    const view = baseElement.firstChild.firstChild;
+    expect(view).toMatchSnapshot();
+    expect(view).toEqual(expect.not.stringMatching(undefineds));
+  });
+});

--- a/src/js/components/devices/device-details/identity.js
+++ b/src/js/components/devices/device-details/identity.js
@@ -3,9 +3,25 @@ import Time from 'react-time';
 
 import { DEVICE_STATES } from '../../../constants/deviceConstants';
 import { TwoColumnData } from '../../common/configurationobject';
+import DeviceNameInput from '../../common/devicenameinput';
 import DeviceDataCollapse from './devicedatacollapse';
 
 const style = { maxWidth: '80%', gridTemplateColumns: 'minmax(max-content, 150px) auto' };
+const previewStyle = { ...style, marginBottom: 5 };
+
+const NameColumnData = ({ device, style }) => {
+  return (
+    <div
+      className="break-all two-columns column-data compact"
+      style={{ ...style, alignItems: 'center', gridTemplateColumns: 'minmax(max-content, 150px) max-content' }}
+    >
+      <div className="align-right key text-muted">
+        <b>Name</b>
+      </div>
+      <DeviceNameInput device={device} isHovered />
+    </div>
+  );
+};
 
 export const DeviceIdentity = ({ device, setSnackbar }) => {
   const [open, setOpen] = useState(false);
@@ -31,7 +47,8 @@ export const DeviceIdentity = ({ device, setSnackbar }) => {
     <DeviceDataCollapse
       header={
         <>
-          <TwoColumnData config={keyContent} compact setSnackbar={setSnackbar} style={{ ...style, marginBottom: 5 }} />
+          <NameColumnData device={device} style={previewStyle} />
+          <TwoColumnData config={keyContent} compact setSnackbar={setSnackbar} style={previewStyle} />
           {!open && !!extendedContentLength && <a onClick={setOpen}>show {extendedContentLength} more</a>}
         </>
       }

--- a/src/js/components/devices/device-details/identity.test.js
+++ b/src/js/components/devices/device-details/identity.test.js
@@ -1,11 +1,24 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import { render } from '@testing-library/react';
 import DeviceIdentity from './identity';
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 
+const mockStore = configureStore([thunk]);
+
 describe('DeviceIdentity Component', () => {
+  let store;
+  beforeEach(() => {
+    store = mockStore({ ...defaultState });
+  });
   it('renders correctly', async () => {
-    const { baseElement } = render(<DeviceIdentity device={defaultState.devices.byId.a1} setSnackbar={jest.fn} />);
+    const { baseElement } = render(
+      <Provider store={store}>
+        <DeviceIdentity device={defaultState.devices.byId.a1} setSnackbar={jest.fn} />
+      </Provider>
+    );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -380,10 +380,10 @@ export const DeviceGroups = ({
     setDeviceRefreshTrigger(!deviceRefreshTrigger);
   };
 
-  const onFilterDevices = (value, key) => {
+  const onFilterDevices = (value, key, scope = 'identity') => {
     setDeviceListState({ state: routes.allDevices.key });
     if (key) {
-      selectGroup(undefined, [{ scope: 'identity', key, operator: '$eq', value }]);
+      selectGroup(undefined, [{ scope, key, operator: '$eq', value }]);
     } else {
       setDeviceFilters([]);
     }
@@ -503,6 +503,7 @@ const mapStateToProps = state => {
   }
   const deviceIdAttribute = { key: 'id', value: 'Device ID', scope: 'identity', category: 'identity', priority: 1 };
   let identityAttributes = [
+    { key: 'name', value: 'Name', scope: 'tags', category: 'tags', priority: 1 },
     deviceIdAttribute,
     ...state.devices.filteringAttributes.identityAttributes.map(item => ({ key: item, value: item, scope: 'identity', category: 'identity', priority: 1 }))
   ];

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -227,6 +227,7 @@ export const DeviceGroups = ({
   removeDevicesFromGroup,
   removeDynamicGroup,
   removeStaticGroup,
+  selectedAttribute,
   selectedGroup,
   selectGroup,
   setDeviceFilters,
@@ -406,7 +407,7 @@ export const DeviceGroups = ({
       <div className="flexbox space-between margin-right">
         <div className="flexbox padding-top-small">
           <h3 style={{ minWidth: 300, marginTop: 0 }}>Devices</h3>
-          <QuickFilter attributes={identityAttributes} filters={filters} onChange={onFilterDevices} />
+          <QuickFilter attributes={identityAttributes} attributeSetting={selectedAttribute} filters={filters} onChange={onFilterDevices} />
         </div>
         <DeviceAdditionWidget docsVersion={docsVersion} onConnectClick={setShowConnectingDialog} onPreauthClick={setOpenPreauth} />
       </div>
@@ -501,10 +502,9 @@ const mapStateToProps = state => {
     groupCount = state.devices.groups.byId[selectedGroup].total;
     groupFilters = state.devices.groups.byId[selectedGroup].filters || [];
   }
-  const deviceIdAttribute = { key: 'id', value: 'Device ID', scope: 'identity', category: 'identity', priority: 1 };
   let identityAttributes = [
     { key: 'name', value: 'Name', scope: 'tags', category: 'tags', priority: 1 },
-    deviceIdAttribute,
+    { key: 'id', value: 'Device ID', scope: 'identity', category: 'identity', priority: 1 },
     ...state.devices.filteringAttributes.identityAttributes.map(item => ({ key: item, value: item, scope: 'identity', category: 'identity', priority: 1 }))
   ];
   return {
@@ -522,6 +522,7 @@ const mapStateToProps = state => {
     isEnterprise: getIsEnterprise(state),
     limitMaxed: getLimitMaxed(state),
     pendingCount: state.devices.byStatus.pending.total || 0,
+    selectedAttribute: state.users.globalSettings.id_attribute,
     selectedGroup,
     showHelptips: state.users.showHelptips
   };

--- a/src/js/components/devices/devicelist.js
+++ b/src/js/components/devices/devicelist.js
@@ -112,7 +112,7 @@ export const DeviceList = props => {
           <DeviceListItem
             columnHeaders={columnHeaders}
             device={device}
-            idAttribute={idAttribute}
+            idAttribute={idAttribute.attribute}
             itemClassName={itemClassName}
             key={device.id}
             onClick={event => (expandable ? expandRow(event, index) : onRowSelection(index))}

--- a/src/js/components/devices/devicelist.js
+++ b/src/js/components/devices/devicelist.js
@@ -12,6 +12,7 @@ import Pagination from '../common/pagination';
 import ExpandedDevice from './expanded-device';
 import DeviceListItem from './devicelistitem';
 import { deepCompare } from '../../helpers';
+import MenderTooltip from '../common/mendertooltip';
 
 const { page: defaultPage, perPage: defaultPerPage } = DEVICE_LIST_DEFAULTS;
 
@@ -22,6 +23,7 @@ export const DeviceList = props => {
     advanceOnboarding,
     className = '',
     columnHeaders,
+    sortingNotes,
     devices,
     deviceListState,
     expandable = true,
@@ -96,15 +98,26 @@ export const DeviceList = props => {
         {onSelect && (
           <Checkbox indeterminate={numSelected > 0 && numSelected < devices.length} checked={numSelected === devices.length} onChange={onSelectAllClick} />
         )}
-        {columnHeaders.map((item, index) => (
-          <div className="columnHeader" key={`columnHeader-${index}`} style={item.style} onClick={() => onSort(item.attribute ? item.attribute : {})}>
-            {item.title}
-            {item.sortable && (
-              <SortIcon className={`sortIcon ${sortCol === item.attribute.name ? 'selected' : ''} ${(sortDown === DEVICE_SORTING_OPTIONS.desc).toString()}`} />
-            )}
-            {item.customize && <SettingsIcon onClick={item.customize} style={{ fontSize: 16, marginLeft: 'auto' }} />}
-          </div>
-        ))}
+        {columnHeaders.map((item, index) => {
+          const header = (
+            <div className="columnHeader" key={`columnHeader-${index}`} style={item.style} onClick={() => onSort(item.attribute ? item.attribute : {})}>
+              {item.title}
+              {item.sortable && (
+                <SortIcon
+                  className={`sortIcon ${sortCol === item.attribute.name ? 'selected' : ''} ${(sortDown === DEVICE_SORTING_OPTIONS.desc).toString()}`}
+                />
+              )}
+              {item.customize && <SettingsIcon onClick={item.customize} style={{ fontSize: 16, marginLeft: 'auto' }} />}
+            </div>
+          );
+          return item.sortable && sortingNotes[item.attribute.name] ? (
+            <MenderTooltip key={`columnHeader-tip-${index}`} title={sortingNotes[item.attribute.name]} placement="top-start">
+              {header}
+            </MenderTooltip>
+          ) : (
+            header
+          );
+        })}
         {expandable && <div style={{ width: 48 }} />}
       </div>
       <div className="body">

--- a/src/js/components/devices/devicelistitem.js
+++ b/src/js/components/devices/devicelistitem.js
@@ -1,15 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 // material ui
 import { Checkbox } from '@material-ui/core';
+import DeviceIdentityDisplay from '../common/deviceidentity';
 
-const DeviceListItem = props => {
-  const { columnHeaders, device, idAttribute, itemClassName = '', onClick, onRowSelect, selectable, selected } = props;
-  const idValue = idAttribute !== 'Device ID' ? (device.identity_data || {})[idAttribute] : device.id;
+const DeviceListItem = ({ columnHeaders, device, itemClassName = '', onClick, onRowSelect, selectable, selected }) => {
+  const [isHovering, setIsHovering] = useState(false);
+
+  const onMouseOut = () => setIsHovering(false);
+  const onMouseOver = () => setIsHovering(true);
+
   return (
-    <div className={`${itemClassName} deviceListItem clickable`} style={{ alignItems: 'center' }} onClick={onClick}>
+    <div
+      className={`${itemClassName} deviceListItem clickable`}
+      style={{ alignItems: 'center' }}
+      onClick={onClick}
+      onMouseEnter={onMouseOver}
+      onMouseLeave={onMouseOut}
+    >
       {selectable ? <Checkbox checked={selected} onChange={onRowSelect} /> : null}
-      <div style={columnHeaders[0].style}>{idValue}</div>
+      <DeviceIdentityDisplay device={device} isHovered={isHovering} style={columnHeaders[0].style} />
       {/* we'll skip the first column, since this is the id and that gets resolved differently in the lines above */}
       {columnHeaders.slice(1).map((item, index) => (
         <div key={`column-${index}`} style={item.style}>

--- a/src/js/components/devices/devicelistitem.js
+++ b/src/js/components/devices/devicelistitem.js
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Checkbox } from '@material-ui/core';
 import DeviceIdentityDisplay from '../common/deviceidentity';
 
-const DeviceListItem = ({ columnHeaders, device, itemClassName = '', onClick, onRowSelect, selectable, selected }) => {
+const DeviceListItem = ({ columnHeaders, device, idAttribute, itemClassName = '', onClick, onRowSelect, selectable, selected }) => {
   const [isHovering, setIsHovering] = useState(false);
 
   const onMouseOut = () => setIsHovering(false);
@@ -19,7 +19,7 @@ const DeviceListItem = ({ columnHeaders, device, itemClassName = '', onClick, on
       onMouseLeave={onMouseOut}
     >
       {selectable ? <Checkbox checked={selected} onChange={onRowSelect} /> : null}
-      <DeviceIdentityDisplay device={device} isHovered={isHovering} style={columnHeaders[0].style} />
+      <DeviceIdentityDisplay device={device} idAttribute={idAttribute} isHovered={isHovering} style={columnHeaders[0].style} />
       {/* we'll skip the first column, since this is the id and that gets resolved differently in the lines above */}
       {columnHeaders.slice(1).map((item, index) => (
         <div key={`column-${index}`} style={item.style}>

--- a/src/js/components/devices/devicelistitem.test.js
+++ b/src/js/components/devices/devicelistitem.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import DeviceListItem from './devicelistitem';
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 
 describe('DeviceListItem Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <DeviceListItem device={{ id: 1 }} columnHeaders={[{ render: item => item }]} idAttribute={defaultState.users.globalSettings.id_attribute} />
-    );
+    const { baseElement } = render(<DeviceListItem device={{ id: 1 }} columnHeaders={[{ render: item => item }]} idAttribute={'id'} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -14,7 +14,8 @@ import {
   getDeviceById,
   getDeviceConfig,
   getDeviceConnect,
-  setDeviceConfig
+  setDeviceConfig,
+  setDeviceTags
 } from '../../actions/deviceActions';
 import { saveGlobalSettings } from '../../actions/userActions';
 import { DEVICE_STATES } from '../../constants/deviceConstants';
@@ -27,6 +28,7 @@ import TroubleshootDialog from './troubleshootdialog';
 import AuthStatus from './device-details/authstatus';
 import DeviceConfiguration from './device-details/configuration';
 import DeviceInventory from './device-details/deviceinventory';
+import DeviceTags from './device-details/devicetags';
 import DeviceIdentity from './device-details/identity';
 import DeviceConnection from './device-details/connection';
 import InstalledSoftware from './device-details/installedsoftware';
@@ -56,6 +58,7 @@ export const ExpandedDevice = ({
   refreshDevices,
   saveGlobalSettings,
   setDeviceConfig,
+  setDeviceTags,
   setSnackbar,
   showHelptips
 }) => {
@@ -135,6 +138,7 @@ export const ExpandedDevice = ({
         disableBottomBorder={!isAcceptedDevice}
         showHelptips={showHelptips}
       />
+      <DeviceTags device={device} setSnackbar={setSnackbar} setDeviceTags={setDeviceTags} showHelptips={showHelptips} />
       {isAcceptedDevice && (
         <>
           <InstalledSoftware device={device} docsVersion={docsVersion} setSnackbar={setSnackbar} />
@@ -199,6 +203,7 @@ const actionCreators = {
   getSingleDeployment,
   saveGlobalSettings,
   setDeviceConfig,
+  setDeviceTags,
   setSnackbar
 };
 

--- a/src/js/components/devices/filteritem.js
+++ b/src/js/components/devices/filteritem.js
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 
 // material ui
 import { IconButton, MenuItem, Select, TextField, FormHelperText } from '@material-ui/core';
-import { HighlightOff as HighlightOffIcon } from '@material-ui/icons';
+import { Help as HelpIcon, HighlightOff as HighlightOffIcon } from '@material-ui/icons';
 import { Autocomplete, createFilterOptions } from '@material-ui/lab';
 
 import { DEVICE_FILTERING_OPTIONS } from '../../constants/deviceConstants';
 
 import { emptyFilter, getFilterLabelByKey } from './filters';
+import MenderTooltip from '../common/mendertooltip';
+import theme from '../../themes/mender-theme';
 
 const optionsFilter = createFilterOptions();
 
@@ -21,6 +23,17 @@ const filterOptionsByPlan = {
 };
 
 const defaultScope = 'inventory';
+
+const filterNotificationLocation = { top: theme.spacing(2.5), left: theme.spacing(-1.5) };
+const filterNotifications = {
+  name: (
+    <MenderTooltip arrow placement="bottom" title="Filtering by name is limited to devices with a previously defined name.">
+      <div className="tooltip help" style={filterNotificationLocation}>
+        <HelpIcon />
+      </div>
+    </MenderTooltip>
+  )
+};
 
 export const FilterItem = ({ attributes, filter, onRemove, onSelect, plan }) => {
   const [key, setKey] = useState(filter.key || ''); // this refers to the selected filter with key as the id
@@ -100,7 +113,8 @@ export const FilterItem = ({ attributes, filter, onRemove, onSelect, plan }) => 
   const showValue = typeof (filterOptions[operator] || {}).value === 'undefined';
   return (
     <>
-      <div className="flexbox center-aligned">
+      <div className="flexbox center-aligned relative">
+        {filterNotifications[key]}
         <Autocomplete
           autoComplete
           autoHighlight

--- a/src/js/components/devices/filters.js
+++ b/src/js/components/devices/filters.js
@@ -211,7 +211,8 @@ const mapStateToProps = (state, ownProps) => {
     deviceNameAttribute,
     deviceIdAttribute,
     ...state.devices.filteringAttributes.identityAttributes.map(item => ({ key: item, value: item, scope: 'identity', category: 'identity', priority: 1 })),
-    ...state.devices.filteringAttributes.inventoryAttributes.map(item => ({ key: item, value: item, scope: 'inventory', category: 'inventory', priority: 2 }))
+    ...state.devices.filteringAttributes.inventoryAttributes.map(item => ({ key: item, value: item, scope: 'inventory', category: 'inventory', priority: 2 })),
+    ...state.devices.filteringAttributes.tagAttributes.map(item => ({ key: item, value: item, scope: 'tags', category: 'tags', priority: 3 }))
   ];
   const selectedGroup = state.devices.groups.selectedGroup;
   const groupFilters = state.devices.groups.byId[selectedGroup]?.filters ?? [];

--- a/src/js/components/devices/filters.js
+++ b/src/js/components/devices/filters.js
@@ -199,23 +199,20 @@ const actionCreators = {
 
 const mapStateToProps = (state, ownProps) => {
   const { plan = 'os' } = state.organization.organization;
+  const deviceNameAttribute = { key: 'name', value: 'Name', scope: 'tags', category: 'tags', priority: 1 };
   const deviceIdAttribute = { key: 'id', value: 'Device ID', scope: 'identity', category: 'identity', priority: 1 };
-  let attributes = [
+  const attributes = [
+    ...state.users.globalSettings.previousFilters.map(item => ({
+      ...item,
+      value: deviceIdAttribute.key === item.key ? deviceIdAttribute.value : item.key,
+      category: 'recently used',
+      priority: 0
+    })),
+    deviceNameAttribute,
     deviceIdAttribute,
-    ...state.devices.filteringAttributes.identityAttributes.map(item => ({ key: item, value: item, scope: 'identity', category: 'identity', priority: 1 }))
+    ...state.devices.filteringAttributes.identityAttributes.map(item => ({ key: item, value: item, scope: 'identity', category: 'identity', priority: 1 })),
+    ...state.devices.filteringAttributes.inventoryAttributes.map(item => ({ key: item, value: item, scope: 'inventory', category: 'inventory', priority: 2 }))
   ];
-  if (!ownProps.identityOnly) {
-    attributes = [
-      ...state.users.globalSettings.previousFilters.map(item => ({
-        ...item,
-        value: deviceIdAttribute.key === item.key ? deviceIdAttribute.value : item.key,
-        category: 'recently used',
-        priority: 0
-      })),
-      ...attributes,
-      ...state.devices.filteringAttributes.inventoryAttributes.map(item => ({ key: item, value: item, scope: 'inventory', category: 'inventory', priority: 2 }))
-    ];
-  }
   const selectedGroup = state.devices.groups.selectedGroup;
   const groupFilters = state.devices.groups.byId[selectedGroup]?.filters ?? [];
   return {

--- a/src/js/components/devices/quickfilter.js
+++ b/src/js/components/devices/quickfilter.js
@@ -6,14 +6,15 @@ let timer;
 
 export const QuickFilter = ({ attributes, filters, onChange }) => {
   const [filterValue, setFilterValue] = useState('');
-  const [selectedAttribute, setSelectedAttribute] = useState('id');
+  const [selectedAttribute, setSelectedAttribute] = useState('name');
 
   useEffect(() => {
     if (!(filterValue && selectedAttribute)) {
       return;
     }
     clearTimeout(timer);
-    timer = setTimeout(() => onChange(filterValue, selectedAttribute), 700);
+    const selectedScope = attributes.find(attribute => attribute.key === selectedAttribute)?.scope;
+    timer = setTimeout(() => onChange(filterValue, selectedAttribute, selectedScope), 700);
     return () => {
       clearTimeout(timer);
     };

--- a/src/js/components/devices/quickfilter.js
+++ b/src/js/components/devices/quickfilter.js
@@ -4,13 +4,13 @@ import { MenuItem, Select, TextField } from '@material-ui/core';
 
 let timer;
 
-export const QuickFilter = ({ attributes, attributeSetting = 'name', filters, onChange }) => {
+export const QuickFilter = ({ attributes, attributeSetting = { attribute: 'name', scope: 'tags' }, filters, onChange }) => {
   const [filterValue, setFilterValue] = useState('');
-  const [selectedAttribute, setSelectedAttribute] = useState(attributeSetting);
+  const [selectedAttribute, setSelectedAttribute] = useState(attributeSetting.attribute);
 
   useEffect(() => {
-    setSelectedAttribute(attributeSetting);
-  }, [attributeSetting]);
+    setSelectedAttribute(attributeSetting.attribute);
+  }, [attributeSetting.attribute]);
 
   useEffect(() => {
     if (!(filterValue && selectedAttribute)) {

--- a/src/js/components/devices/quickfilter.js
+++ b/src/js/components/devices/quickfilter.js
@@ -2,7 +2,13 @@ import React, { useEffect, useState } from 'react';
 
 import { MenuItem, Select, TextField } from '@material-ui/core';
 
+import MenderTooltip from '../common/mendertooltip';
+
 let timer;
+
+const filterNotifications = {
+  name: 'This will only apply to devices that have a device name configured'
+};
 
 export const QuickFilter = ({ attributes, attributeSetting = { attribute: 'name', scope: 'tags' }, filters, onChange }) => {
   const [filterValue, setFilterValue] = useState('');
@@ -39,6 +45,16 @@ export const QuickFilter = ({ attributes, attributeSetting = { attribute: 'name'
 
   const onSelectionChange = ({ target: { value } }) => setSelectedAttribute(value);
 
+  const input = <TextField placeholder="Filter" className="search" value={filterValue} onChange={onSearchChange} style={{ marginLeft: 30, marginTop: 0 }} />;
+
+  const filterInput = filterNotifications[selectedAttribute] ? (
+    <MenderTooltip arrow title={filterNotifications[selectedAttribute]}>
+      {input}
+    </MenderTooltip>
+  ) : (
+    input
+  );
+
   return (
     <div>
       Quick find Device
@@ -49,7 +65,7 @@ export const QuickFilter = ({ attributes, attributeSetting = { attribute: 'name'
           </MenuItem>
         ))}
       </Select>
-      <TextField placeholder="Filter" className="search" value={filterValue} onChange={onSearchChange} style={{ marginLeft: 30, marginTop: 0 }} />
+      {filterInput}
     </div>
   );
 };

--- a/src/js/components/devices/quickfilter.js
+++ b/src/js/components/devices/quickfilter.js
@@ -4,9 +4,13 @@ import { MenuItem, Select, TextField } from '@material-ui/core';
 
 let timer;
 
-export const QuickFilter = ({ attributes, filters, onChange }) => {
+export const QuickFilter = ({ attributes, attributeSetting = 'name', filters, onChange }) => {
   const [filterValue, setFilterValue] = useState('');
-  const [selectedAttribute, setSelectedAttribute] = useState('name');
+  const [selectedAttribute, setSelectedAttribute] = useState(attributeSetting);
+
+  useEffect(() => {
+    setSelectedAttribute(attributeSetting);
+  }, [attributeSetting]);
 
   useEffect(() => {
     if (!(filterValue && selectedAttribute)) {

--- a/src/js/components/devices/quickfilter.test.js
+++ b/src/js/components/devices/quickfilter.test.js
@@ -7,7 +7,7 @@ import { undefineds } from '../../../../tests/mockData';
 
 describe('QuickFilter Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(<QuickFilter attributes={[{ key: 'id', value: 'thing' }]} filters={[]} onChange={jest.fn} />);
+    const { baseElement } = render(<QuickFilter attributes={[{ key: 'name', value: 'thing' }]} filters={[]} onChange={jest.fn} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -15,7 +15,7 @@ describe('QuickFilter Component', () => {
 
   it('works as intended', async () => {
     const changeMock = jest.fn();
-    const ui = <QuickFilter attributes={[{ key: 'id', value: 'thing' }]} filters={[]} onChange={changeMock} />;
+    const ui = <QuickFilter attributes={[{ key: 'name', value: 'thing', scope: 'test' }]} filters={[]} onChange={changeMock} />;
     const { rerender } = render(ui);
     await waitFor(() => rerender(ui));
     const element = screen.getByText('thing');
@@ -23,6 +23,6 @@ describe('QuickFilter Component', () => {
     act(() => userEvent.paste(screen.queryByPlaceholderText(/Filter/i), 'something'));
     jest.runAllTimers();
     await waitFor(() => rerender(ui));
-    expect(changeMock).toHaveBeenCalledWith('something', 'id');
+    expect(changeMock).toHaveBeenCalledWith('something', 'name', 'test');
   });
 });

--- a/src/js/components/helptips/helptooltips.js
+++ b/src/js/components/helptips/helptooltips.js
@@ -278,3 +278,16 @@ const ConfigureAddOnTipComponent = ({ docsVersion }) => (
 );
 
 export const ConfigureAddOnTip = connect(mapStateToProps, actionCreators)(ConfigureAddOnTipComponent);
+
+export const NameTagTip = () => (
+  <div>
+    <div id="name-tag-help" className="tooltip help" data-tip data-for="name-tag-tip" data-event="click focus" style={{ top: '15%', left: '85%' }}>
+      <HelpIcon />
+    </div>
+    <ReactTooltip id="name-tag-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+      <p>
+        The <i>name</i> tag will be available as a device indentifier too.
+      </p>
+    </ReactTooltip>
+  </div>
+);

--- a/src/js/components/helptips/helptooltips.js
+++ b/src/js/components/helptips/helptooltips.js
@@ -9,6 +9,7 @@ import { setSnackbar } from '../../actions/appActions';
 import { toggleHelptips } from '../../actions/userActions';
 import { getDocsVersion } from '../../selectors';
 import ConfigurationObject from '../common/configurationobject';
+import MenderTooltip from '../common/mendertooltip';
 
 const actionCreators = { setSnackbar, toggleHelptips };
 const mapStateToProps = (state, ownProps) => {
@@ -280,14 +281,16 @@ const ConfigureAddOnTipComponent = ({ docsVersion }) => (
 export const ConfigureAddOnTip = connect(mapStateToProps, actionCreators)(ConfigureAddOnTipComponent);
 
 export const NameTagTip = () => (
-  <div>
-    <div id="name-tag-help" className="tooltip help" data-tip data-for="name-tag-tip" data-event="click focus" style={{ top: '15%', left: '85%' }}>
+  <MenderTooltip
+    arrow
+    title={
+      <>
+        The <i>Name</i> tag will be available as a device indentifier too.
+      </>
+    }
+  >
+    <div className="tooltip help" style={{ top: '15%', left: '85%' }}>
       <HelpIcon />
     </div>
-    <ReactTooltip id="name-tag-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
-      <p>
-        The <i>name</i> tag will be available as a device indentifier too.
-      </p>
-    </ReactTooltip>
-  </div>
+  </MenderTooltip>
 );

--- a/src/js/components/settings/__snapshots__/global.test.js.snap
+++ b/src/js/components/settings/__snapshots__/global.test.js.snap
@@ -35,7 +35,7 @@ exports[`GlobalSettings Component renders correctly 1`] = `
       class="MuiFormControl-root"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
         data-shrink="true"
         id="device-id"
       >
@@ -50,13 +50,15 @@ exports[`GlobalSettings Component renders correctly 1`] = `
           role="button"
           tabindex="0"
         >
-          Device ID
+          <span>
+            ​
+          </span>
         </div>
         <input
           aria-hidden="true"
           class="MuiSelect-nativeInput"
           tabindex="-1"
-          value="Device ID"
+          value=""
         />
         <svg
           aria-hidden="true"
@@ -70,7 +72,7 @@ exports[`GlobalSettings Component renders correctly 1`] = `
         </svg>
       </div>
       <div
-        class="MuiFormHelperText-root info MuiFormHelperText-filled"
+        class="MuiFormHelperText-root info"
       >
         <div
           class="margin-top-small margin-bottom-small"

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -352,7 +352,7 @@ export const mapDeviceAttributes = (attributes = []) =>
       };
       return accu;
     },
-    { inventory: { device_type: '', artifact_name: '' }, identity: {}, system: {} }
+    { inventory: { device_type: '', artifact_name: '' }, identity: {}, system: {}, tags: {} }
   );
 
 export const getFormattedSize = bytes => {

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -291,7 +291,8 @@ describe('mapDeviceAttributes function', () => {
   const defaultAttributes = {
     inventory: { device_type: '', artifact_name: '' },
     identity: {},
-    system: {}
+    system: {},
+    tags: {}
   };
   it('works with empty attributes', async () => {
     expect(mapDeviceAttributes()).toEqual(defaultAttributes);

--- a/src/js/reducers/deviceReducer.js
+++ b/src/js/reducers/deviceReducer.js
@@ -29,7 +29,7 @@ export const initialState = {
   filters: [
     // { key: 'device_type', value: 'raspberry', operator: '$eq', scope: 'inventory' }
   ],
-  filteringAttributes: { identityAttributes: [], inventoryAttributes: [] },
+  filteringAttributes: { identityAttributes: [], inventoryAttributes: [], tagAttributes: [] },
   filteringAttributesLimit: 10,
   total: 0,
   limit: 0,

--- a/src/js/reducers/userReducer.js
+++ b/src/js/reducers/userReducer.js
@@ -6,7 +6,7 @@ export const initialState = {
   jwtToken: null,
   qrCode: null,
   globalSettings: {
-    id_attribute: 'Device ID',
+    id_attribute: undefined,
     previousFilters: [],
     previousPhases: [],
     retries: 0

--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -25,7 +25,7 @@ export const getDemoDeviceAddress = createSelector([getDevicesList, getOnboardin
   return getDemoDeviceAddressHelper(devices, approach, demoArtifactPort);
 });
 
-export const getIdAttribute = createSelector([getGlobalSettings], ({ id_attribute }) => id_attribute);
+export const getIdAttribute = createSelector([getGlobalSettings], ({ id_attribute = {} }) => id_attribute);
 
 export const getLimitMaxed = createSelector([getAcceptedDevices, getDeviceLimit], ({ total: acceptedDevices = 0 }, deviceLimit) =>
   Boolean(deviceLimit && deviceLimit <= acceptedDevices)

--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -25,7 +25,7 @@ export const getDemoDeviceAddress = createSelector([getDevicesList, getOnboardin
   return getDemoDeviceAddressHelper(devices, approach, demoArtifactPort);
 });
 
-export const getIdAttribute = createSelector([getGlobalSettings], ({ id_attribute = 'Device ID' }) => id_attribute);
+export const getIdAttribute = createSelector([getGlobalSettings], ({ id_attribute }) => id_attribute);
 
 export const getLimitMaxed = createSelector([getAcceptedDevices, getDeviceLimit], ({ total: acceptedDevices = 0 }, deviceLimit) =>
   Boolean(deviceLimit && deviceLimit <= acceptedDevices)

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1278,10 +1278,15 @@ div:focus {
   outline: none !important;
 }
 
-.key-value-container button {
-  margin-left: 8px;
-  height: 100%;
-  align-self: center;
+.key-value-container {
+  display: grid;
+  grid-template-columns: max-content max-content 65px;
+  column-gap: @defaultGutterWidth;
+  align-items: center;
+  justify-items: baseline;
+  > div {
+    margin-top: 10px;
+  }
 }
 
 /* Log in */

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -560,10 +560,9 @@ ul.link-list {
   column-gap: 2 * @defaultGutterWidth;
   &.column-data {
     max-width: 25 * @defaultGutterWidth;
-    row-gap: @defaultGutterWidth;
+    row-gap: 5px;
     &.compact {
       grid-template-columns: max-content 1fr;
-      row-gap: 5px;
     }
     &.multiple {
       grid-template-columns: 1fr 1fr;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1509,7 +1509,7 @@ div:focus {
       }
     }
     &.columns-6 {
-      @columns-6: 1.5fr 1fr minmax(350px, 1.5fr) 1fr 1fr 1.5fr;
+      @columns-6: minmax(300px, 1fr) 1fr minmax(300px, 1fr) 0.75fr 0.75fr 1fr;
       grid-template-columns: @columns-6;
       &.selectable {
         grid-template-columns: @row-selector-width @columns-6;

--- a/tests/mockData.js
+++ b/tests/mockData.js
@@ -318,7 +318,7 @@ export const defaultState = {
       [userId]: { email: 'a2@b.com', id: userId, created_ts: '2019-01-01T12:30:00.000Z' }
     },
     currentUser: 'a1',
-    globalSettings: { '2fa': 'enabled', id_attribute: 'Device ID', previousFilters: [] },
+    globalSettings: { '2fa': 'enabled', id_attribute: undefined, previousFilters: [] },
     jwtToken: null,
     qrCode: null,
     rolesById: {

--- a/tests/mockData.js
+++ b/tests/mockData.js
@@ -171,7 +171,8 @@ export const defaultState = {
     },
     filteringAttributes: {
       identityAttributes: ['mac'],
-      inventoryAttributes: ['artifact_name']
+      inventoryAttributes: ['artifact_name'],
+      tagAttributes: []
     },
     filteringAttributesLimit: 10,
     filters: [],


### PR DESCRIPTION
the device naming comes with some caveats: 
since the alternative means to set a device name in the backend I think it is tolerable to handle this with notifications... mostly because setting the device name based on a substring of the deviceId might lead to collisions, especially for larger device fleets...
<img width="513" alt="Screenshot 2021-07-22 at 13 55 13" src="https://user-images.githubusercontent.com/482243/126635273-8dcd43ee-785d-48ad-82e2-9788cfc20ed8.png">
Besides the notification when sorting, here is also how devices without a set device name are displayed:
<img width="376" alt="Screenshot 2021-07-22 at 13 54 58" src="https://user-images.githubusercontent.com/482243/126635268-f75fe44a-5de0-4722-843e-dcac13ab5c04.png">
Similar for filtering: 
<img width="778" alt="Screenshot 2021-07-22 at 17 02 20" src="https://user-images.githubusercontent.com/482243/126661846-aafff4a9-4411-4531-a6d6-5202a7477f2d.png">
And a note for the tag editor:
<img width="842" alt="Screenshot 2021-07-22 at 16 28 20" src="https://user-images.githubusercontent.com/482243/126658255-eee76ec1-ea44-42fe-a273-ad2ed2fb07b1.png">
