### PR TITLE
e2e tests: fixed remote terminal button visibility during staging tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,7 +159,7 @@ test:prep:
     expire_in: 30 days
 
 test:staging-deployment:
-  image: mcr.microsoft.com/playwright:v1.11.0
+  image: mcr.microsoft.com/playwright:v1.13.1
   stage: .post
   services:
     - docker:19.03.5-dind

--- a/tests/e2e_tests/integration/05-deviceDetails.spec.ts
+++ b/tests/e2e_tests/integration/05-deviceDetails.spec.ts
@@ -21,7 +21,8 @@ test.describe('Device details', () => {
     await page.click(`.leftNav :text('Devices')`);
     await page.click(`.deviceListItem`);
     // the deviceconnect connection might not be established right away
-    await page.waitForSelector('text=/Remote Terminal session/i', { timeout: 10000 });
+    const terminalLaunchButton = await page.waitForSelector('text=/Remote Terminal session/i', { timeout: 10000 });
+    await terminalLaunchButton.scrollIntoViewIfNeeded();
     await page.click(`css=.expandedDevice >> text=Remote Terminal session`);
     await page.waitForSelector(`text=Connection with the device established`, { timeout: 10000 });
     expect(await page.isVisible('.terminal.xterm canvas')).toBeTruthy();

--- a/tests/e2e_tests/integration/06-auditlogs.spec.ts
+++ b/tests/e2e_tests/integration/06-auditlogs.spec.ts
@@ -15,7 +15,8 @@ test.describe('Auditlogs', () => {
     await page.click(`.leftNav :text('Devices')`);
     await page.click(`.deviceListItem`);
     // the deviceconnect connection might not be established right away
-    await page.waitForSelector('text=/Remote Terminal session/i', { timeout: 10000 });
+    const terminalLaunchButton = await page.waitForSelector('text=/Remote Terminal session/i', { timeout: 10000 });
+    await terminalLaunchButton.scrollIntoViewIfNeeded();
     await page.click(`css=.expandedDevice >> text=Remote Terminal session`);
     await page.waitForSelector(`text=Connection with the device established`, { timeout: 10000 });
     expect(await page.isVisible('.terminal.xterm canvas')).toBeTruthy();


### PR DESCRIPTION
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>