### PR TITLE
MEN-4928: improvements to the monitoring UI

### DIFF
--- a/src/js/actions/monitorActions.js
+++ b/src/js/actions/monitorActions.js
@@ -12,7 +12,9 @@ export const getDeviceAlerts = (id, config = {}) => dispatch => {
   const { page = defaultPage, perPage = defaultPerPage, issuedBefore, issuedAfter, sortAscending = false } = config;
   const issued_after = issuedAfter ? `&issued_after=${issuedAfter}` : '';
   const issued_before = issuedBefore ? `&issued_before=${issuedBefore}` : '';
-  return Api.get(`${monitorApiUrlv1}/devices/${id}/alerts?page=${page}&per_page=${perPage}${issued_after}${issued_before}&sort_ascending=${sortAscending}`)
+  return Api.get(
+    `${monitorApiUrlv1}/devices/${id}/alerts/latest?page=${page}&per_page=${perPage}${issued_after}${issued_before}&sort_ascending=${sortAscending}`
+  )
     .catch(err => commonErrorHandler(err, `Retrieving device alerts for device ${id} failed:`, dispatch))
     .then(res =>
       Promise.resolve(

--- a/src/js/components/devices/device-details/__snapshots__/monitoring.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/monitoring.test.js.snap
@@ -128,29 +128,17 @@ exports[`DeviceMonitoring Component renders correctly 1`] = `
           >
             2021-07-23 12:22
           </time>
-          <div>
-            Jul 22 10:40:56 raspberrypi sshd[32031]: pam_unix(sshd:session): session closed for user root
-          </div>
-          <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiButton-label"
-            >
-              view log
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
+          <a>
+            view log
+          </a>
         </div>
-        <a
+        <div
           class="margin-top-small"
         >
-          show less
-        </a>
+          <a>
+            show less
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/js/components/devices/device-details/monitoring.js
+++ b/src/js/components/devices/device-details/monitoring.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import Time from 'react-time';
 
-import { Button } from '@material-ui/core';
-
 import DeviceDataCollapse from './devicedatacollapse';
 import { DeviceOfflineHeaderNotification, NoAlertsHeaderNotification, severityMap } from './notifications';
 
@@ -14,10 +12,7 @@ const MonitoringAlert = ({ alert: { id, level, name, subject, timestamp }, onLog
     </div>
     <div>{level}</div>
     <Time value={timestamp} format="YYYY-MM-DD HH:mm" />
-    <div>{subject.details}</div>
-    <Button variant="text" onClick={() => onLogClick(id, subject.details)}>
-      view log
-    </Button>
+    {subject.details ? <a onClick={() => onLogClick(id, subject.details)}>view log</a> : null}
   </div>
 );
 
@@ -50,9 +45,9 @@ export const DeviceMonitoring = ({ alerts, device, innerRef, isOffline, onLogCli
       {alerts.map(alert => (
         <MonitoringAlert alert={alert} key={alert.id} onLogClick={onLogClick} />
       ))}
-      <a className="margin-top-small" onClick={toggleOpen}>
-        show less
-      </a>
+      <div className="margin-top-small">
+        <a onClick={toggleOpen}>show less</a>
+      </div>
     </DeviceDataCollapse>
   );
 };

--- a/tests/__mocks__/monitorHandlers.js
+++ b/tests/__mocks__/monitorHandlers.js
@@ -4,7 +4,7 @@ import { monitorApiUrlv1 } from '../../src/js/actions/monitorActions';
 import { alertChannels } from '../../src/js/constants/monitorConstants';
 
 export const monitorHandlers = [
-  rest.get(`${monitorApiUrlv1}/devices/:id/alerts`, (req, res, ctx) => {
+  rest.get(`${monitorApiUrlv1}/devices/:id/alerts/latest`, (req, res, ctx) => {
     return res(ctx.json([]));
   }),
   rest.put(`${monitorApiUrlv1}/settings/global/channel/alerts/:channel/status`, ({ params: { channel }, body }, res, ctx) => {


### PR DESCRIPTION
- Improve margins and layout
- Use link instead of button to view logs
- Show the "view logs" link only if there are logs
- Use the right end-point (/alerts/latest)

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>