### PR TITLE
Update feature toggles to respect env variables

### DIFF
--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -85,9 +85,9 @@ export const getTenantCapabilities = createSelector(
     { hasAuditlogs, hasDeviceConfig: isDeviceConfigEnabled, hasDeviceConnect: isDeviceConnectEnabled, hasMonitor: isMonitorEnabled, isHosted },
     { addons = [] }
   ) => {
-    const hasDeviceConfig = (!isHosted && isDeviceConfigEnabled) || addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled));
-    const hasDeviceConnect = (!isHosted && isDeviceConnectEnabled) || addons.some(addon => addon.name === 'troubleshoot' && Boolean(addon.enabled));
-    const hasMonitor = (!isHosted && isMonitorEnabled) || addons.some(addon => addon.name === 'monitor' && Boolean(addon.enabled));
+    const hasDeviceConfig = isDeviceConfigEnabled && (!isHosted || addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled)));
+    const hasDeviceConnect = isDeviceConnectEnabled && (!isHosted || addons.some(addon => addon.name === 'troubleshoot' && Boolean(addon.enabled)));
+    const hasMonitor = isMonitorEnabled && (!isHosted || addons.some(addon => addon.name === 'monitor' && Boolean(addon.enabled)));
     return { hasAuditlogs, hasDeviceConfig, hasDeviceConnect, hasMonitor };
   }
 );


### PR DESCRIPTION
If `MENDER_HOSTED` is set, fature toggles do not respect the environment
variables and rely on the tenants' capabilities (enabled add-ons) only.
This makes impossible to disable a feature in Hosted Mender when the
backend already supports a new add-on.

Make the feature toggles always respect the environment variables.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>