### PR TITLE
MEN-4934: Fix remote terminal in Safari

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -40,7 +40,7 @@ http {
     }
     location @index {
       add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.stripe.com https://www.google-analytics.com https://stats.g.doubleclick.net; script-src 'self' https://www.google-analytics.com https://js.stripe.com https://cdn.jsdelivr.net/npm/cookieconsent@3 https://www.google.com www.gstatic.com 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com; font-src 'self'; frame-src https://js.stripe.com https://hooks.stripe.com https://www.google.com; style-src 'self' https://cdn.jsdelivr.net/npm/cookieconsent@3 'unsafe-inline'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';";
+      add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss://$host https://api.stripe.com https://www.google-analytics.com https://stats.g.doubleclick.net; script-src 'self' https://www.google-analytics.com https://js.stripe.com https://cdn.jsdelivr.net/npm/cookieconsent@3 https://www.google.com www.gstatic.com 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com; font-src 'self'; frame-src https://js.stripe.com https://hooks.stripe.com https://www.google.com; style-src 'self' https://cdn.jsdelivr.net/npm/cookieconsent@3 'unsafe-inline'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';";
       add_header Last-Modified $date_gmt;
       add_header X-Frame-Options "SAMEORIGIN";
       add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
Some browsers (namely, Safari) do not support websocket connections to
wss://$host if connect-src only specifies `self` in the
Content-Security-Policy HTTP header. We need to be more explicit, adding
wss://$host to connect-src to allow the browser to connect back to the
hostname used in the request.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>