### PR TITLE
follow up fix after device_type array support

### DIFF
--- a/src/js/actions/onboardingActions.js
+++ b/src/js/actions/onboardingActions.js
@@ -27,10 +27,11 @@ export const getOnboardingState = () => (dispatch, getState) => {
     const pendingDevices = store.devices.byStatus[DEVICE_STATES.pending].deviceIds;
     const releases = Object.values(store.releases.byId);
     const pastDeployments = store.deployments.byStatus.finished.deploymentIds;
-    const deviceType =
-      onboardingState.deviceType || (acceptedDevices.length && store.devices.byId[acceptedDevices[0]].hasOwnProperty('attributes'))
+    let { deviceType = [] } = onboardingState;
+    deviceType =
+      !deviceType.length && acceptedDevices.length && store.devices.byId[acceptedDevices[0]].hasOwnProperty('attributes')
         ? store.devices.byId[acceptedDevices[0]].attributes.device_type
-        : [];
+        : deviceType;
     const progress = applyOnboardingFallbacks(onboardingState.progress || determineProgress(acceptedDevices, pendingDevices, releases, pastDeployments));
     const state = {
       complete: !!(


### PR DESCRIPTION
mainly to allow reapplying the device type selected earlier during onboarding

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>