### PR TITLE
MEN-4788, MEN-4958, MEN-4959 + cleanup tooltips + classes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,7 @@ test:lint:
     reports:
       junit:
         - junit/results.xml
+    when: on_failure
 
 test:acceptance:
   extends: .template:test:acceptance

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "react-redux": "^7.2.6",
         "react-router-dom": "^5.3.0",
         "react-time": "^4.3.0",
-        "react-tooltip": "^3.11.6",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "react-window-infinite-loader": "^1.0.7",
@@ -13361,22 +13360,6 @@
         "react": ">=0.13.0 <16.0.0"
       }
     },
-    "node_modules/react-tooltip": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.11.6.tgz",
-      "integrity": "sha512-nTc1yHHaPCHHURvMpf/VNF17pIZiU4zwUGFJBUVr1fZkezFC7E0VPMMVrCfDjt+IpwTHICyzlyx+1FiQ7lw5LQ==",
-      "dependencies": {
-        "prop-types": "^15.6.0"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "react": ">=^16.0.0",
-        "react-dom": ">=^16.0.0"
-      }
-    },
     "node_modules/react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -25633,14 +25616,6 @@
       "resolved": "https://registry.npmjs.org/react-time/-/react-time-4.3.0.tgz",
       "integrity": "sha1-s3UHuLUnjwOo5/K/5wkRgkqJkd0=",
       "requires": {}
-    },
-    "react-tooltip": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.11.6.tgz",
-      "integrity": "sha512-nTc1yHHaPCHHURvMpf/VNF17pIZiU4zwUGFJBUVr1fZkezFC7E0VPMMVrCfDjt+IpwTHICyzlyx+1FiQ7lw5LQ==",
-      "requires": {
-        "prop-types": "^15.6.0"
-      }
     },
     "react-transition-group": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react-redux": "^7.2.6",
     "react-router-dom": "^5.3.0",
     "react-time": "^4.3.0",
-    "react-tooltip": "^3.11.6",
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",

--- a/src/js/components/__snapshots__/app.test.js.snap
+++ b/src/js/components/__snapshots__/app.test.js.snap
@@ -24,85 +24,42 @@ exports[`App Component renders correctly 1`] = `
         <div
           style="flex-grow: 1;"
         />
-        <div>
+        <div
+          class=""
+        >
           <div
-            currentitem="false"
-            data-for="limit-tip"
-            data-offset="{'bottom': 0, 'right': 0}"
-            data-tip="true"
-            data-tip-disable="false"
-            id="limit"
+            class="header-section"
           >
-            <div
-              class="__react_component_tooltip place-bottom type-dark"
-              data-id="tooltip"
-              id="limit-tip"
+            <a
+              class=""
+              href="/devices"
             >
-              <h3>
-                Device limit
-              </h3>
-              <p>
-                You can still connect another 
-                498
-                 
-                devices
-                .
-              </p>
-              <p>
-                If you need a higher device limit, you can contact us by email at 
-                <a
-                  href="mailto:support@mender.io"
-                >
-                  support@mender.io
-                </a>
-                 to change your plan.
-              </p>
-              <p>
-                Learn about the different plans available by visiting
-                 
-                <a
-                  href="https://mender.io/pricing"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  mender.io/pricing
-                </a>
-              </p>
-            </div>
-            <div
-              class="header-section"
+              <span>
+                2
+              </span>
+              <span>
+                /
+                500
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                style="margin: 0px 7px 0px 10px; font-size: 20px;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z"
+                />
+              </svg>
+            </a>
+            <a
+              href="/devices/pending"
+              style="margin-left: 7px;"
             >
-              <a
-                class="inline"
-                href="/devices"
-              >
-                <span>
-                  2
-                </span>
-                <span>
-                  /
-                  500
-                </span>
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  style="margin: 0px 7px 0px 10px; font-size: 20px;"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z"
-                  />
-                </svg>
-              </a>
-              <a
-                href="/devices/pending"
-                style="margin-left: 7px;"
-              >
-                1
-                 pending
-              </a>
-            </div>
+              1
+               pending
+            </a>
           </div>
         </div>
         <a

--- a/src/js/components/artifacts/releaserepository.js
+++ b/src/js/components/artifacts/releaserepository.js
@@ -220,7 +220,7 @@ export const ReleaseRepository = ({
               variant="contained"
               buttonRef={creationRef}
               component={ForwardingLink}
-              to={`/deployments?open=true&release=${release.Name}`}
+              to={`/deployments/active?open=true&release=${release.Name}`}
               style={{ marginLeft: 20 }}
               onClick={() => onCreateDeploymentFrom(release)}
             >

--- a/src/js/components/common/dialogs/__snapshots__/deviceconnectiondialog.test.js.snap
+++ b/src/js/components/common/dialogs/__snapshots__/deviceconnectiondialog.test.js.snap
@@ -49,45 +49,20 @@ exports[`DeviceConnectionDialog Component renders correctly 1`] = `
             <p>
               We'll walk you through the steps to connect a Raspberry Pi and deploy your first update.
             </p>
-            <div>
-              <div
-                class="tooltip help"
-                currentitem="false"
-                data-event="click focus"
-                data-for="deb-package-tip"
-                data-tip="true"
-                id="deb-package-help"
-                style="top: 22%; left: 88%;"
+            <div
+              class="tooltip help"
+              style="top: 22%; left: 88%;"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="__react_component_tooltip place-bottom type-dark"
-                data-id="tooltip"
-                id="deb-package-tip"
-              >
-                <p>
-                  The steps in the guide should work on most operating systems in the Debian family (e.g. Debian, Ubuntu, Raspberry Pi OS) and devices based on ARMv6 or newer (e.g. Raspberry Pi 2/3/4, Beaglebone). Visit
-                   
-                  <a
-                    href="https://docs.mender.io/development/overview/device-support"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    our documentation
-                  </a>
-                  for more information about device support.
-                </p>
-              </div>
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                />
+              </svg>
             </div>
             <div
               class="flexbox centered column os-list"

--- a/src/js/components/common/dialogs/__snapshots__/physicaldeviceonboarding.test.js.snap
+++ b/src/js/components/common/dialogs/__snapshots__/physicaldeviceonboarding.test.js.snap
@@ -6,346 +6,6 @@ exports[`PhysicalDeviceOnboarding Component tiny onboarding tips renders DeviceT
 <html>
   <head>
     <style
-      type="text/css"
-    >
-      .__react_component_tooltip {
-  border-radius: 3px;
-  display: inline-block;
-  font-size: 13px;
-  left: -999em;
-  opacity: 0;
-  padding: 8px 21px;
-  position: fixed;
-  pointer-events: none;
-  transition: opacity 0.3s ease-out;
-  top: -999em;
-  visibility: hidden;
-  z-index: 999;
-}
-.__react_component_tooltip.allow_hover, .__react_component_tooltip.allow_click {
-  pointer-events: auto;
-}
-.__react_component_tooltip:before, .__react_component_tooltip:after {
-  content: "";
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-.__react_component_tooltip.show {
-  opacity: 0.9;
-  margin-top: 0px;
-  margin-left: 0px;
-  visibility: visible;
-}
-.__react_component_tooltip.type-dark {
-  color: #fff;
-  background-color: #222;
-}
-.__react_component_tooltip.type-dark.place-top:after {
-  border-top-color: #222;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-dark.place-bottom:after {
-  border-bottom-color: #222;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-dark.place-left:after {
-  border-left-color: #222;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-dark.place-right:after {
-  border-right-color: #222;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-dark.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-success {
-  color: #fff;
-  background-color: #8DC572;
-}
-.__react_component_tooltip.type-success.place-top:after {
-  border-top-color: #8DC572;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-success.place-bottom:after {
-  border-bottom-color: #8DC572;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-success.place-left:after {
-  border-left-color: #8DC572;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-success.place-right:after {
-  border-right-color: #8DC572;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-success.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning {
-  color: #fff;
-  background-color: #F0AD4E;
-}
-.__react_component_tooltip.type-warning.place-top:after {
-  border-top-color: #F0AD4E;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-warning.place-bottom:after {
-  border-bottom-color: #F0AD4E;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-warning.place-left:after {
-  border-left-color: #F0AD4E;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-warning.place-right:after {
-  border-right-color: #F0AD4E;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-warning.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-error {
-  color: #fff;
-  background-color: #BE6464;
-}
-.__react_component_tooltip.type-error.place-top:after {
-  border-top-color: #BE6464;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-error.place-bottom:after {
-  border-bottom-color: #BE6464;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-error.place-left:after {
-  border-left-color: #BE6464;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-error.place-right:after {
-  border-right-color: #BE6464;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-error.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-info {
-  color: #fff;
-  background-color: #337AB7;
-}
-.__react_component_tooltip.type-info.place-top:after {
-  border-top-color: #337AB7;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-info.place-bottom:after {
-  border-bottom-color: #337AB7;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-info.place-left:after {
-  border-left-color: #337AB7;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-info.place-right:after {
-  border-right-color: #337AB7;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-info.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-light {
-  color: #222;
-  background-color: #fff;
-}
-.__react_component_tooltip.type-light.place-top:after {
-  border-top-color: #fff;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-light.place-bottom:after {
-  border-bottom-color: #fff;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-light.place-left:after {
-  border-left-color: #fff;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-light.place-right:after {
-  border-right-color: #fff;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-light.border {
-  border: 1px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-top:before {
-  border-top: 8px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-bottom:before {
-  border-bottom: 8px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-left:before {
-  border-left: 8px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-right:before {
-  border-right: 8px solid #222;
-}
-.__react_component_tooltip.place-top {
-  margin-top: -10px;
-}
-.__react_component_tooltip.place-top:before {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  bottom: -8px;
-  left: 50%;
-  margin-left: -10px;
-}
-.__react_component_tooltip.place-top:after {
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  bottom: -6px;
-  left: 50%;
-  margin-left: -8px;
-}
-.__react_component_tooltip.place-bottom {
-  margin-top: 10px;
-}
-.__react_component_tooltip.place-bottom:before {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  top: -8px;
-  left: 50%;
-  margin-left: -10px;
-}
-.__react_component_tooltip.place-bottom:after {
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  top: -6px;
-  left: 50%;
-  margin-left: -8px;
-}
-.__react_component_tooltip.place-left {
-  margin-left: -10px;
-}
-.__react_component_tooltip.place-left:before {
-  border-top: 6px solid transparent;
-  border-bottom: 6px solid transparent;
-  right: -8px;
-  top: 50%;
-  margin-top: -5px;
-}
-.__react_component_tooltip.place-left:after {
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  right: -6px;
-  top: 50%;
-  margin-top: -4px;
-}
-.__react_component_tooltip.place-right {
-  margin-left: 10px;
-}
-.__react_component_tooltip.place-right:before {
-  border-top: 6px solid transparent;
-  border-bottom: 6px solid transparent;
-  left: -8px;
-  top: 50%;
-  margin-top: -5px;
-}
-.__react_component_tooltip.place-right:after {
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  left: -6px;
-  top: 50%;
-  margin-top: -4px;
-}
-.__react_component_tooltip .multi-line {
-  display: block;
-  padding: 2px 0px;
-  text-align: center;
-}
-    </style>
-    <style
       data-jss=""
       data-meta="MuiSvgIcon"
     >
@@ -878,6 +538,155 @@ label + .MuiInput-formControl {
     </style>
     <style
       data-jss=""
+      data-meta="MuiTooltip"
+    >
+      
+.MuiTooltip-popper {
+  z-index: 1500;
+  pointer-events: none;
+}
+.MuiTooltip-popperInteractive {
+  pointer-events: auto;
+}
+.MuiTooltip-popperArrow[x-placement*="bottom"] .MuiTooltip-arrow {
+  top: 0;
+  left: 0;
+  margin-top: -0.71em;
+  margin-left: 4px;
+  margin-right: 4px;
+}
+.MuiTooltip-popperArrow[x-placement*="top"] .MuiTooltip-arrow {
+  left: 0;
+  bottom: 0;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-bottom: -0.71em;
+}
+.MuiTooltip-popperArrow[x-placement*="right"] .MuiTooltip-arrow {
+  left: 0;
+  width: 0.71em;
+  height: 1em;
+  margin-top: 4px;
+  margin-left: -0.71em;
+  margin-bottom: 4px;
+}
+.MuiTooltip-popperArrow[x-placement*="left"] .MuiTooltip-arrow {
+  right: 0;
+  width: 0.71em;
+  height: 1em;
+  margin-top: 4px;
+  margin-right: -0.71em;
+  margin-bottom: 4px;
+}
+.MuiTooltip-popperArrow[x-placement*="left"] .MuiTooltip-arrow::before {
+  transform-origin: 0 0;
+}
+.MuiTooltip-popperArrow[x-placement*="right"] .MuiTooltip-arrow::before {
+  transform-origin: 100% 100%;
+}
+.MuiTooltip-popperArrow[x-placement*="top"] .MuiTooltip-arrow::before {
+  transform-origin: 100% 0;
+}
+.MuiTooltip-popperArrow[x-placement*="bottom"] .MuiTooltip-arrow::before {
+  transform-origin: 0 100%;
+}
+.MuiTooltip-tooltip {
+  color: #fff;
+  padding: 4px 8px;
+  font-size: 0.625rem;
+  max-width: 300px;
+  word-wrap: break-word;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 500;
+  line-height: 1.4em;
+  border-radius: 4px;
+  background-color: rgba(97, 97, 97, 0.9);
+}
+.MuiTooltip-tooltipArrow {
+  margin: 0;
+  position: relative;
+}
+.MuiTooltip-arrow {
+  color: rgba(97, 97, 97, 0.9);
+  width: 1em;
+  height: 0.71em;
+  overflow: hidden;
+  position: absolute;
+  box-sizing: border-box;
+}
+.MuiTooltip-arrow::before {
+  width: 100%;
+  height: 100%;
+  margin: auto;
+  content: "";
+  display: block;
+  transform: rotate(45deg);
+  background-color: currentColor;
+}
+.MuiTooltip-touch {
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.14286em;
+}
+.MuiTooltip-tooltipPlacementLeft {
+  margin: 0 24px ;
+  transform-origin: right center;
+}
+@media (min-width:600px) {
+  .MuiTooltip-tooltipPlacementLeft {
+    margin: 0 14px;
+  }
+}
+.MuiTooltip-tooltipPlacementRight {
+  margin: 0 24px;
+  transform-origin: left center;
+}
+@media (min-width:600px) {
+  .MuiTooltip-tooltipPlacementRight {
+    margin: 0 14px;
+  }
+}
+.MuiTooltip-tooltipPlacementTop {
+  margin: 24px 0;
+  transform-origin: center bottom;
+}
+@media (min-width:600px) {
+  .MuiTooltip-tooltipPlacementTop {
+    margin: 14px 0;
+  }
+}
+.MuiTooltip-tooltipPlacementBottom {
+  margin: 24px 0;
+  transform-origin: center top;
+}
+@media (min-width:600px) {
+  .MuiTooltip-tooltipPlacementBottom {
+    margin: 14px 0;
+  }
+}
+
+    </style>
+    <style
+      data-jss=""
+      data-meta="WithStyles(ForwardRef(Tooltip))"
+    >
+      
+.WithStyles\\(ForwardRef\\(Tooltip\\)\\)-arrow-1 {
+  color: #5d0f43;
+}
+.WithStyles\\(ForwardRef\\(Tooltip\\)\\)-tooltip-2 {
+  info: [object Object];
+  color: #DECFD9;
+  font-size: small;
+  max-width: 600px;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);
+  background-color: #5d0f43;
+}
+
+    </style>
+    <style
+      data-jss=""
       data-meta="MuiAutocomplete"
     >
       
@@ -1086,7 +895,26 @@ label + .MuiInput-formControl {
           Setting this attribute on the device ensures that the device will only receive updates for compatible software releases.
         </p>
         <div
-          class="flexbox centered"
+          class=""
+          style="margin-top: -24px;"
+        >
+          <div
+            class="tooltip help"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="flexbox centered margin-top"
         >
           <div
             aria-expanded="false"
@@ -1154,47 +982,6 @@ label + .MuiInput-formControl {
           </div>
         </div>
         <div
-          class="tooltip help"
-          currentitem="false"
-          data-event="click focus"
-          data-for="physical-device-type-tip"
-          data-tip="true"
-          id="onboard-connect-1"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-            />
-          </svg>
-        </div>
-        <div
-          class="__react_component_tooltip place-bottom type-dark"
-          data-id="tooltip"
-          id="physical-device-type-tip"
-        >
-          <div>
-            <p>
-              If you don't see your exact device on the list, choose 
-              <i>
-                Generic ARMv6 or newer
-              </i>
-               to continue the tutorial for now.
-            </p>
-            <p>
-              (Note: if your device is 
-              <i>
-                not
-              </i>
-               based on ARMv6 or newer, the tutorial won't work - instead, go back and use the virtual device)
-            </p>
-          </div>
-        </div>
-        <div
           class="margin-top"
         >
           <p>
@@ -1220,346 +1007,6 @@ label + .MuiInput-formControl {
 exports[`PhysicalDeviceOnboarding Component tiny onboarding tips renders InstallationStep correctly 1`] = `
 <html>
   <head>
-    <style
-      type="text/css"
-    >
-      .__react_component_tooltip {
-  border-radius: 3px;
-  display: inline-block;
-  font-size: 13px;
-  left: -999em;
-  opacity: 0;
-  padding: 8px 21px;
-  position: fixed;
-  pointer-events: none;
-  transition: opacity 0.3s ease-out;
-  top: -999em;
-  visibility: hidden;
-  z-index: 999;
-}
-.__react_component_tooltip.allow_hover, .__react_component_tooltip.allow_click {
-  pointer-events: auto;
-}
-.__react_component_tooltip:before, .__react_component_tooltip:after {
-  content: "";
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-.__react_component_tooltip.show {
-  opacity: 0.9;
-  margin-top: 0px;
-  margin-left: 0px;
-  visibility: visible;
-}
-.__react_component_tooltip.type-dark {
-  color: #fff;
-  background-color: #222;
-}
-.__react_component_tooltip.type-dark.place-top:after {
-  border-top-color: #222;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-dark.place-bottom:after {
-  border-bottom-color: #222;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-dark.place-left:after {
-  border-left-color: #222;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-dark.place-right:after {
-  border-right-color: #222;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-dark.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-dark.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-success {
-  color: #fff;
-  background-color: #8DC572;
-}
-.__react_component_tooltip.type-success.place-top:after {
-  border-top-color: #8DC572;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-success.place-bottom:after {
-  border-bottom-color: #8DC572;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-success.place-left:after {
-  border-left-color: #8DC572;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-success.place-right:after {
-  border-right-color: #8DC572;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-success.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-success.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning {
-  color: #fff;
-  background-color: #F0AD4E;
-}
-.__react_component_tooltip.type-warning.place-top:after {
-  border-top-color: #F0AD4E;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-warning.place-bottom:after {
-  border-bottom-color: #F0AD4E;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-warning.place-left:after {
-  border-left-color: #F0AD4E;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-warning.place-right:after {
-  border-right-color: #F0AD4E;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-warning.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-warning.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-error {
-  color: #fff;
-  background-color: #BE6464;
-}
-.__react_component_tooltip.type-error.place-top:after {
-  border-top-color: #BE6464;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-error.place-bottom:after {
-  border-bottom-color: #BE6464;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-error.place-left:after {
-  border-left-color: #BE6464;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-error.place-right:after {
-  border-right-color: #BE6464;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-error.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-error.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-info {
-  color: #fff;
-  background-color: #337AB7;
-}
-.__react_component_tooltip.type-info.place-top:after {
-  border-top-color: #337AB7;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-info.place-bottom:after {
-  border-bottom-color: #337AB7;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-info.place-left:after {
-  border-left-color: #337AB7;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-info.place-right:after {
-  border-right-color: #337AB7;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-info.border {
-  border: 1px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-top:before {
-  border-top: 8px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-bottom:before {
-  border-bottom: 8px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-left:before {
-  border-left: 8px solid #fff;
-}
-.__react_component_tooltip.type-info.border.place-right:before {
-  border-right: 8px solid #fff;
-}
-.__react_component_tooltip.type-light {
-  color: #222;
-  background-color: #fff;
-}
-.__react_component_tooltip.type-light.place-top:after {
-  border-top-color: #fff;
-  border-top-style: solid;
-  border-top-width: 6px;
-}
-.__react_component_tooltip.type-light.place-bottom:after {
-  border-bottom-color: #fff;
-  border-bottom-style: solid;
-  border-bottom-width: 6px;
-}
-.__react_component_tooltip.type-light.place-left:after {
-  border-left-color: #fff;
-  border-left-style: solid;
-  border-left-width: 6px;
-}
-.__react_component_tooltip.type-light.place-right:after {
-  border-right-color: #fff;
-  border-right-style: solid;
-  border-right-width: 6px;
-}
-.__react_component_tooltip.type-light.border {
-  border: 1px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-top:before {
-  border-top: 8px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-bottom:before {
-  border-bottom: 8px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-left:before {
-  border-left: 8px solid #222;
-}
-.__react_component_tooltip.type-light.border.place-right:before {
-  border-right: 8px solid #222;
-}
-.__react_component_tooltip.place-top {
-  margin-top: -10px;
-}
-.__react_component_tooltip.place-top:before {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  bottom: -8px;
-  left: 50%;
-  margin-left: -10px;
-}
-.__react_component_tooltip.place-top:after {
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  bottom: -6px;
-  left: 50%;
-  margin-left: -8px;
-}
-.__react_component_tooltip.place-bottom {
-  margin-top: 10px;
-}
-.__react_component_tooltip.place-bottom:before {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  top: -8px;
-  left: 50%;
-  margin-left: -10px;
-}
-.__react_component_tooltip.place-bottom:after {
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  top: -6px;
-  left: 50%;
-  margin-left: -8px;
-}
-.__react_component_tooltip.place-left {
-  margin-left: -10px;
-}
-.__react_component_tooltip.place-left:before {
-  border-top: 6px solid transparent;
-  border-bottom: 6px solid transparent;
-  right: -8px;
-  top: 50%;
-  margin-top: -5px;
-}
-.__react_component_tooltip.place-left:after {
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  right: -6px;
-  top: 50%;
-  margin-top: -4px;
-}
-.__react_component_tooltip.place-right {
-  margin-left: 10px;
-}
-.__react_component_tooltip.place-right:before {
-  border-top: 6px solid transparent;
-  border-bottom: 6px solid transparent;
-  left: -8px;
-  top: 50%;
-  margin-top: -5px;
-}
-.__react_component_tooltip.place-right:after {
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  left: -6px;
-  top: 50%;
-  margin-top: -4px;
-}
-.__react_component_tooltip .multi-line {
-  display: block;
-  padding: 2px 0px;
-  text-align: center;
-}
-    </style>
     <style
       data-jss=""
       data-meta="MuiSvgIcon"

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import ReactTooltip from 'react-tooltip';
 
 import { TextField } from '@material-ui/core';
 import { Autocomplete, createFilterOptions } from '@material-ui/lab';
@@ -11,6 +10,8 @@ import { advanceOnboarding, setOnboardingApproach, setOnboardingDeviceType } fro
 import { onboardingSteps } from '../../../constants/onboardingConstants';
 import { getDebConfigurationCode, versionCompare } from '../../../helpers';
 import { getDocsVersion, getIsEnterprise, getOnboardingState } from '../../../selectors';
+import { MenderTooltipClickable } from '../mendertooltip';
+import menderTheme from '../../../themes/mender-theme';
 
 const filter = createFilterOptions();
 
@@ -31,7 +32,27 @@ export const DeviceTypeSelectionStep = ({ docsVersion, hasConvertedImage, onboar
     <div className="flexbox column">
       <b>1. Enter your device type</b>
       <p>Setting this attribute on the device ensures that the device will only receive updates for compatible software releases.</p>
-      <div className="flexbox centered">
+      {shouldShowOnboardingTip && (
+        <MenderTooltipClickable
+          placement="bottom"
+          style={{ marginTop: menderTheme.spacing(-3) }}
+          title={
+            <div>
+              <p>
+                If you don&apos;t see your exact device on the list, choose <i>Generic ARMv6 or newer</i> to continue the tutorial for now.
+              </p>
+              <p>
+                (Note: if your device is <i>not</i> based on ARMv6 or newer, the tutorial won&apos;t work - instead, go back and use the virtual device)
+              </p>
+            </div>
+          }
+        >
+          <div className="tooltip help">
+            <HelpIcon />
+          </div>
+        </MenderTooltipClickable>
+      )}
+      <div className="flexbox centered margin-top">
         <Autocomplete
           id="device-type-selection"
           autoSelect
@@ -69,31 +90,7 @@ export const DeviceTypeSelectionStep = ({ docsVersion, hasConvertedImage, onboar
           value={selection}
         />
       </div>
-      {shouldShowOnboardingTip && (
-        <>
-          <div id="onboard-connect-1" className="tooltip help" data-tip data-for="physical-device-type-tip" data-event="click focus">
-            <HelpIcon />
-          </div>
-          <ReactTooltip
-            id="physical-device-type-tip"
-            globalEventOff="click"
-            place="bottom"
-            type="light"
-            effect="solid"
-            className="react-tooltip"
-            style={{ maxWidth: 300 }}
-          >
-            <div>
-              <p>
-                If you don&apos;t see your exact device on the list, choose <i>Generic ARMv6 or newer</i> to continue the tutorial for now.
-              </p>
-              <p>
-                (Note: if your device is <i>not</i> based on ARMv6 or newer, the tutorial won&apos;t work - instead, go back and use the virtual device)
-              </p>
-            </div>
-          </ReactTooltip>
-        </>
-      )}
+
       {hasConvertedImage && (
         <div className="margin-top">
           <p>

--- a/src/js/components/common/mendertooltip.js
+++ b/src/js/components/common/mendertooltip.js
@@ -1,4 +1,6 @@
-import { Tooltip, withStyles } from '@material-ui/core';
+import React, { useState } from 'react';
+
+import { ClickAwayListener, Tooltip, withStyles } from '@material-ui/core';
 
 import theme, { colors } from '../../themes/mender-theme';
 
@@ -10,8 +12,78 @@ export const MenderTooltip = withStyles({
     backgroundColor: theme.palette.secondary.main,
     boxShadow: theme.shadows[1],
     color: colors.tooltipText,
-    fontSize: 'small'
+    fontSize: 'small',
+    maxWidth: 600,
+    info: {
+      maxWidth: 300,
+      color: colors.mutedText,
+      backgroundColor: colors.placeholder
+    }
   }
 })(Tooltip);
 
+export const MenderTooltipClickable = ({ children, onboarding, startOpen = false, ...remainingProps }) => {
+  const [open, setOpen] = useState(startOpen || false);
+
+  const toggle = () => setOpen(!open);
+
+  const hide = () => setOpen(false);
+
+  const Component = onboarding ? OnboardingTooltip : MenderTooltip;
+  const extraProps = onboarding
+    ? {
+        PopperProps: {
+          disablePortal: true,
+          popperOptions: {
+            positionFixed: true,
+            modifiers: { preventOverflow: { boundariesElement: 'window' } }
+          }
+        }
+      }
+    : {};
+  return (
+    <ClickAwayListener onClickAway={hide}>
+      <Component
+        arrow={!onboarding}
+        interactive
+        open={open}
+        disableFocusListener
+        disableHoverListener
+        disableTouchListener
+        onOpen={() => setOpen(true)}
+        {...extraProps}
+        {...remainingProps}
+      >
+        <div onClick={toggle}>{children}</div>
+      </Component>
+    </ClickAwayListener>
+  );
+};
+
+const iconWidth = 30;
+
+export const OnboardingTooltip = withStyles({
+  arrow: {
+    color: theme.palette.primary.main
+  },
+  tooltip: {
+    backgroundColor: theme.palette.primary.main,
+    boxShadow: theme.shadows[1],
+    color: colors.placeholder,
+    fontSize: 14,
+    maxWidth: 350,
+    padding: '12px 18px',
+    width: 350,
+    '& a': {
+      color: colors.placeholder
+    },
+    '&.MuiTooltip-tooltipPlacementTop': { marginLeft: iconWidth, marginBottom: 0, marginTop: iconWidth + theme.spacing(1.5) },
+    '&.MuiTooltip-tooltipPlacementRight': { marginTop: iconWidth / 2 },
+    '&.MuiTooltip-tooltipPlacementBottom': { marginLeft: iconWidth },
+    '&.MuiTooltip-tooltipPlacementLeft': { marginTop: iconWidth / 2 }
+  },
+  popper: {
+    opacity: 0.9
+  }
+})(Tooltip);
 export default MenderTooltip;

--- a/src/js/components/common/relative-time.js
+++ b/src/js/components/common/relative-time.js
@@ -1,44 +1,37 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import moment from 'moment';
 import Time from 'react-time';
 import { Tooltip } from '@material-ui/core';
 
 const cutoff = -5 * 60;
 
-export default class RelativeTime extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {
-      updateTime: props.updateTime ? moment(props.updateTime) : null
-    };
-  }
+export const RelativeTime = ({ className, shouldCount = 'both', updateTime }) => {
+  const [updatedTime, setUpdatedTime] = useState();
 
-  componentDidUpdate(prevProps) {
-    if ((!this.state.updateTime && this.props.updateTime) || prevProps.updateTime !== this.props.updateTime) {
-      this.setState({ updateTime: this.props.updateTime ? moment(this.props.updateTime) : null });
+  useEffect(() => {
+    if (updateTime !== updatedTime) {
+      setUpdatedTime(moment(updateTime));
     }
-  }
+  }, [updateTime]);
 
-  render() {
-    const { updateTime } = this.state;
-    const { className, shouldCount = 'both' } = this.props;
-    let timeDisplay = updateTime ? <Time className={className} value={updateTime} format="YYYY-MM-DD HH:mm" /> : <div className={className}>-</div>;
-    const diffSeconds = updateTime ? updateTime.diff(moment(), 'seconds') : 0;
-    if (
-      updateTime &&
-      diffSeconds > cutoff &&
-      (shouldCount === 'both' || (shouldCount === 'up' && diffSeconds > 0) || (shouldCount === 'down' && diffSeconds < 0))
-    ) {
-      timeDisplay = (
-        <time className={className} dateTime={updateTime}>
-          {updateTime.fromNow()}
-        </time>
-      );
-    }
-    return (
-      <Tooltip title={updateTime ? updateTime.toLocaleString() : ''} arrow={true} enterDelay={500}>
-        {timeDisplay}
-      </Tooltip>
+  let timeDisplay = updatedTime ? <Time className={className} value={updatedTime} format="YYYY-MM-DD HH:mm" /> : <div className={className}>-</div>;
+  const diffSeconds = updatedTime ? updatedTime.diff(moment(), 'seconds') : 0;
+  if (
+    updatedTime &&
+    diffSeconds > cutoff &&
+    (shouldCount === 'both' || (shouldCount === 'up' && diffSeconds > 0) || (shouldCount === 'down' && diffSeconds < 0))
+  ) {
+    timeDisplay = (
+      <time className={className} dateTime={updatedTime}>
+        {updatedTime.fromNow()}
+      </time>
     );
   }
-}
+  return (
+    <Tooltip title={updatedTime ? updatedTime.toLocaleString() : ''} arrow={true} enterDelay={500}>
+      {timeDisplay}
+    </Tooltip>
+  );
+};
+
+export default RelativeTime;

--- a/src/js/components/deployments/__snapshots__/createdeployment.test.js.snap
+++ b/src/js/components/deployments/__snapshots__/createdeployment.test.js.snap
@@ -316,7 +316,7 @@ exports[`CreateDeployment Component renders correctly 1`] = `
                   artifacts available.
                   <br />
                   <a
-                    href="/artifacts"
+                    href="/releases"
                   >
                     Upload one to the repository
                   </a>

--- a/src/js/components/deployments/__snapshots__/createdeployment.test.js.snap
+++ b/src/js/components/deployments/__snapshots__/createdeployment.test.js.snap
@@ -348,7 +348,7 @@ exports[`CreateDeployment Component renders correctly 1`] = `
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text"
-          style="margin-right: 10px; display: inline-block;"
+          style="margin-right: 10px;"
           tabindex="0"
           type="button"
         >

--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -64,9 +64,8 @@ export const CreateDialog = props => {
   } = props;
 
   const [activeStep, setActiveStep] = useState(0);
-  const [steps, setSteps] = useState(deploymentSteps);
   const [releaseSelectionLocked] = useState(Boolean(deploymentObject.release));
-
+  const [steps, setSteps] = useState(deploymentSteps);
   const [hasNewRetryDefault, setHasNewRetryDefault] = useState(false);
   const deploymentRef = useRef();
 
@@ -191,7 +190,7 @@ export const CreateDialog = props => {
         />
       </DialogContent>
       <DialogActions className="margin-left margin-right">
-        <Button key="schedule-action-button-1" onClick={closeWizard} style={{ marginRight: '10px', display: 'inline-block' }}>
+        <Button onClick={closeWizard} style={{ marginRight: 10 }}>
           Cancel
         </Button>
         <Button disabled={activeStep === 0} onClick={() => setActiveStep(activeStep - 1)}>

--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -219,7 +219,8 @@ export const mapStateToProps = state => {
   const { [UNGROUPED_GROUP.id]: ungrouped, ...groups } = state.devices.groups.byId;
   return {
     acceptedDeviceCount: state.devices.byStatus.accepted.total,
-    createdGroup: Object.keys(state.devices.groups.byId)[0],
+    // we need to use group 1 here, as group 0 will be the ungrouped group placeholder
+    createdGroup: Object.keys(state.devices.groups.byId)[1],
     docsVersion: getDocsVersion(state),
     globalSettings: state.users.globalSettings,
     groups,

--- a/src/js/components/deployments/deployment-wizard/softwaredevices.js
+++ b/src/js/components/deployments/deployment-wizard/softwaredevices.js
@@ -33,7 +33,7 @@ const ReleasesWarning = ({ lacksReleases }) => (
     <ErrorOutlineIcon fontSize="small" style={{ marginRight: 4, top: 4, color: 'rgb(171, 16, 0)' }} />
     <p className="info">
       There are no {lacksReleases ? 'compatible ' : ''}artifacts available.{lacksReleases ? <br /> : ' '}
-      <Link to="/artifacts">Upload one to the repository</Link> to get started.
+      <Link to="/releases">Upload one to the repository</Link> to get started.
     </p>
   </div>
 );

--- a/src/js/components/deployments/deployments.js
+++ b/src/js/components/deployments/deployments.js
@@ -201,7 +201,7 @@ export const Deployments = ({
             Create a deployment
           </Button>
         </div>
-        <ComponentToShow abort={onAbortDeployment} createClick={onCreationShow} openReport={showReport} />
+        <ComponentToShow abort={onAbortDeployment} createClick={onCreationShow} openReport={showReport} isShowingDetails={reportDialog} />
       </div>
       <Report abort={onAbortDeployment} onClose={closeReport} open={reportDialog} retry={retryDeployment} type={reportType} />
       {createDialog && (
@@ -212,7 +212,7 @@ export const Deployments = ({
           setDeploymentObject={setDeploymentObject}
         />
       )}
-      {onboardingComponent}
+      {!reportDialog && onboardingComponent}
     </>
   );
 };

--- a/src/js/components/deployments/pastdeployments.js
+++ b/src/js/components/deployments/pastdeployments.js
@@ -30,7 +30,18 @@ const headers = [...defaultHeaders.slice(0, defaultHeaders.length - 1), { title:
 const type = DEPLOYMENT_STATES.finished;
 
 export const Past = props => {
-  const { advanceOnboarding, createClick, getDeploymentsByStatus, groups, onboardingState, past, pastSelectionState, setDeploymentsState, setSnackbar } = props;
+  const {
+    advanceOnboarding,
+    createClick,
+    getDeploymentsByStatus,
+    groups,
+    isShowingDetails,
+    onboardingState,
+    past,
+    pastSelectionState,
+    setDeploymentsState,
+    setSnackbar
+  } = props;
   // eslint-disable-next-line no-unused-vars
   const size = useWindowSize();
   const [timeRangeToggle, setTimeRangeToggle] = useState(false);
@@ -138,7 +149,7 @@ export const Past = props => {
     onboardingComponent = getOnboardingComponentFor(
       onboardingSteps.DEPLOYMENTS_PAST_COMPLETED_FAILURE,
       onboardingState,
-      { anchor: { left, top: anchor.top } },
+      { anchor: { left, top: detailsButtons[0].parentElement.offsetTop + detailsButtons[0].parentElement.offsetHeight } },
       onboardingComponent
     );
     onboardingComponent = getOnboardingComponentFor(onboardingSteps.ONBOARDING_FINISHED, onboardingState, { anchor }, onboardingComponent);
@@ -210,7 +221,7 @@ export const Past = props => {
       <div className="deploy-table-contain">
         <Loader show={loading} />
         {/* TODO: fix status retrieval for past deployments to decide what to show here - */}
-        {!loading && !!past.length && !!onboardingComponent && onboardingComponent}
+        {!loading && !!past.length && !!onboardingComponent && !isShowingDetails && onboardingComponent}
         {!!past.length && (
           <RootRef rootRef={deploymentsRef}>
             <DeploymentsList

--- a/src/js/components/devices/__snapshots__/device-groups.test.js.snap
+++ b/src/js/components/devices/__snapshots__/device-groups.test.js.snap
@@ -887,59 +887,20 @@ exports[`DeviceGroups Component renders correctly 1`] = `
             </div>
           </div>
         </div>
-        <div>
-          <div
-            class=\\"tooltip help\\"
-            currentitem=\\"false\\"
-            data-event=\\"click focus\\"
-            data-for=\\"expand-device-tip\\"
-            data-tip=\\"true\\"
-            id=\\"onboard-6\\"
-            style=\\"right: 45px;\\"
+        <div
+          class=\\"tooltip help\\"
+          style=\\"right: 45px;\\"
+        >
+          <svg
+            aria-hidden=\\"true\\"
+            class=\\"MuiSvgIcon-root\\"
+            focusable=\\"false\\"
+            viewBox=\\"0 0 24 24\\"
           >
-            <svg
-              aria-hidden=\\"true\\"
-              class=\\"MuiSvgIcon-root\\"
-              focusable=\\"false\\"
-              viewBox=\\"0 0 24 24\\"
-            >
-              <path
-                d=\\"M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z\\"
-              />
-            </svg>
-          </div>
-          <div
-            class=\\"__react_component_tooltip place-left type-dark\\"
-            data-id=\\"tooltip\\"
-            id=\\"expand-device-tip\\"
-          >
-            <h3>
-              Device inventory
-            </h3>
-            <hr />
-            <p>
-              Mender automatically collects identity and inventory information from connected devices. You can view this information by clicking on a device to expand the row.
-            </p>
-            <p>
-              Which information is collected about devices is fully configurable;
-               
-              <a
-                href=\\"https://docs.mender.io/development/client-installation/identity\\"
-                rel=\\"noopener noreferrer\\"
-                target=\\"_blank\\"
-              >
-                see the documentation for how to configure this
-              </a>
-              .
-            </p>
-            <p>
-              <a
-                class=\\"hidehelp\\"
-              >
-                Hide all help tips
-              </a>
-            </p>
-          </div>
+            <path
+              d=\\"M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z\\"
+            />
+          </svg>
         </div>
       </div>
     </div>

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -75,6 +75,7 @@ export const Authorized = props => {
     states = {},
     updateDevicesAuth
   } = props;
+  const [expandedDeviceId, setExpandedDeviceId] = useState();
   const [isInitialized, setIsInitialized] = useState(!!props.devices.length);
   const [pageLoading, setPageLoading] = useState(true);
   const [showFilters, setShowFilters] = useState(false);
@@ -379,12 +380,14 @@ export const Authorized = props => {
             <DeviceList
               {...props}
               columnHeaders={columnHeaders}
+              expandedDeviceId={expandedDeviceId}
               onChangeRowsPerPage={onPageLengthChange}
               onPageChange={handlePageChange}
               onSelect={onSelectionChange}
               onSort={onSortChange}
               pageLoading={pageLoading}
               pageTotal={deviceCount}
+              setExpandedDeviceId={setExpandedDeviceId}
               sortingNotes={sortingNotes}
             />
             {showHelptips && <ExpandDevice />}
@@ -401,7 +404,7 @@ export const Authorized = props => {
       ) : (
         <div />
       )}
-      {onboardingComponent ? onboardingComponent : null}
+      {!expandedDeviceId && onboardingComponent ? onboardingComponent : null}
       {!!selectedRows.length && (
         <DeviceQuickActions
           actionCallbacks={{ onAddDevicesToGroup, onAuthorizationChange, onDeviceDismiss, onRemoveDevicesFromGroup }}

--- a/src/js/components/devices/device-details/__snapshots__/connection.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/connection.test.js.snap
@@ -185,11 +185,7 @@ exports[`DeviceConnection Component renders correctly when connected 1`] = `
         </button>
         <a
           class="flexbox centered margin-left"
-          currentitem="false"
-          data-for="port-forward-tip"
-          data-tip="true"
           href="https://docs.mender.io/add-ons/port-forward"
-          id="port-forward-link"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -205,25 +201,6 @@ exports[`DeviceConnection Component renders correctly when connected 1`] = `
             />
           </svg>
         </a>
-        <div
-          class="__react_component_tooltip place-bottom type-dark"
-          data-id="tooltip"
-          id="port-forward-tip"
-        >
-          <div
-            style="white-space: normal;"
-          >
-            <h3>
-              Port forwarding
-            </h3>
-            <p>
-              Port forwarding allows you to troubleshoot or use services on or via the device, without opening any ports on the device itself.
-            </p>
-            <p>
-              To enable port forwarding you will need to install and configure the necessary software on the device and your workstation. Follow the link to learn more.
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -397,11 +374,7 @@ exports[`tiny DeviceConnection components renders PortForwardLink correctly 1`] 
 <div>
   <a
     class="flexbox centered margin-left"
-    currentitem="false"
-    data-for="port-forward-tip"
-    data-tip="true"
     href="https://docs.mender.io/add-ons/port-forward"
-    id="port-forward-link"
     rel="noopener noreferrer"
     target="_blank"
   >
@@ -417,24 +390,5 @@ exports[`tiny DeviceConnection components renders PortForwardLink correctly 1`] 
       />
     </svg>
   </a>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="port-forward-tip"
-  >
-    <div
-      style="white-space: normal;"
-    >
-      <h3>
-        Port forwarding
-      </h3>
-      <p>
-        Port forwarding allows you to troubleshoot or use services on or via the device, without opening any ports on the device itself.
-      </p>
-      <p>
-        To enable port forwarding you will need to install and configure the necessary software on the device and your workstation. Follow the link to learn more.
-      </p>
-    </div>
-  </div>
 </div>
 `;

--- a/src/js/components/devices/device-details/__snapshots__/deviceinventoryloader.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/deviceinventoryloader.test.js.snap
@@ -8,13 +8,7 @@ exports[`CreateGroup Component renders correctly 1`] = `
     class="waiting-inventory"
   >
     <div
-      class="tooltip info"
-      currentitem="false"
-      data-event="click focus"
-      data-for="inventory-wait"
-      data-tip="true"
-      id="inventory-info"
-      style="top: 8px; right: 8px;"
+      class=""
     >
       <svg
         aria-hidden="true"
@@ -26,30 +20,6 @@ exports[`CreateGroup Component renders correctly 1`] = `
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
         />
       </svg>
-    </div>
-    <div
-      class="__react_component_tooltip place-left type-dark"
-      data-id="tooltip"
-      id="inventory-wait"
-    >
-      <h3>
-        Waiting for inventory data
-      </h3>
-      <p>
-        Inventory data not yet received from the device - this can take up to 30 minutes with default installation.
-      </p>
-      <p>
-        Also see the documentation for
-         
-        <a
-          href="https://docs.mender.io/client-installation/configuration-file/polling-intervals"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Polling intervals
-        </a>
-        .
-      </p>
     </div>
     <p>
       Waiting for inventory data from the device

--- a/src/js/components/devices/device-details/connection.js
+++ b/src/js/components/devices/device-details/connection.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Time from 'react-time';
-import ReactTooltip from 'react-tooltip';
 
 import { Button, Typography, SvgIcon } from '@material-ui/core';
 import { ImportExport as ImportExportIcon, InfoOutlined as InfoIcon, Launch as LaunchIcon } from '@material-ui/icons';
@@ -11,23 +10,13 @@ import { BEGINNING_OF_TIME } from '../../../constants/appConstants';
 import { DEVICE_CONNECT_STATES } from '../../../constants/deviceConstants';
 import theme from '../../../themes/mender-theme';
 import DeviceDataCollapse from './devicedatacollapse';
+import MenderTooltip from '../../common/mendertooltip';
 
 const buttonStyle = { textTransform: 'none', textAlign: 'left' };
 export const PortForwardLink = ({ docsVersion }) => (
-  <>
-    <a
-      id="port-forward-link"
-      data-tip
-      data-for="port-forward-tip"
-      href={`https://docs.mender.io/${docsVersion}add-ons/port-forward`}
-      className="flexbox centered margin-left"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Enable port forwarding
-      <LaunchIcon className="margin-left-small" fontSize="small" />
-    </a>
-    <ReactTooltip id="port-forward-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+  <MenderTooltip
+    arrow
+    title={
       <div style={{ whiteSpace: 'normal' }}>
         <h3>Port forwarding</h3>
         <p>Port forwarding allows you to troubleshoot or use services on or via the device, without opening any ports on the device itself.</p>
@@ -36,8 +25,13 @@ export const PortForwardLink = ({ docsVersion }) => (
           more.
         </p>
       </div>
-    </ReactTooltip>
-  </>
+    }
+  >
+    <a href={`https://docs.mender.io/${docsVersion}add-ons/port-forward`} className="flexbox centered margin-left" target="_blank" rel="noopener noreferrer">
+      Enable port forwarding
+      <LaunchIcon className="margin-left-small" fontSize="small" />
+    </a>
+  </MenderTooltip>
 );
 
 const DeviceConnectionNote = ({ children, style }) => (

--- a/src/js/components/devices/device-details/deviceinventoryloader.js
+++ b/src/js/components/devices/device-details/deviceinventoryloader.js
@@ -1,37 +1,37 @@
 import React from 'react';
-import ReactTooltip from 'react-tooltip';
 
 import { List } from '@material-ui/core';
 import { Info as InfoIcon } from '@material-ui/icons';
 
 import Loader from '../../common/loader';
+import { MenderTooltipClickable } from '../../common/mendertooltip';
 
 export const DeviceInventoryLoader = ({ docsVersion = '' }) => (
   <List>
     <div className="waiting-inventory" key="waiting-inventory">
-      <div
-        onClick={e => e.stopPropagation()}
-        id="inventory-info"
-        className="tooltip info"
-        style={{ top: '8px', right: '8px' }}
-        data-tip
-        data-for="inventory-wait"
-        data-event="click focus"
+      <MenderTooltipClickable
+        placement="left"
+        disableFocusListener={false}
+        title={
+          <>
+            <h3>Waiting for inventory data</h3>
+            <p>Inventory data not yet received from the device - this can take up to 30 minutes with default installation.</p>
+            <p>
+              Also see the documentation for{' '}
+              <a
+                href={`https://docs.mender.io/${docsVersion}client-installation/configuration-file/polling-intervals`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Polling intervals
+              </a>
+              .
+            </p>
+          </>
+        }
       >
         <InfoIcon />
-      </div>
-      <ReactTooltip id="inventory-wait" globalEventOff="click" place="left" type="light" effect="solid" className="react-tooltip">
-        <h3>Waiting for inventory data</h3>
-        <p>Inventory data not yet received from the device - this can take up to 30 minutes with default installation.</p>
-        <p>
-          Also see the documentation for{' '}
-          <a href={`https://docs.mender.io/${docsVersion}client-installation/configuration-file/polling-intervals`} target="_blank" rel="noopener noreferrer">
-            Polling intervals
-          </a>
-          .
-        </p>
-      </ReactTooltip>
-
+      </MenderTooltipClickable>
       <p>Waiting for inventory data from the device</p>
       <Loader show={true} waiting={true} />
     </div>

--- a/src/js/components/devices/devicelist.js
+++ b/src/js/components/devices/devicelist.js
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo } from 'react';
 
 // material ui
 import { Checkbox } from '@material-ui/core';
@@ -18,12 +18,11 @@ import MenderTooltip from '../common/mendertooltip';
 const { page: defaultPage, perPage: defaultPerPage } = DEVICE_LIST_DEFAULTS;
 
 export const DeviceList = props => {
-  const [expandedDeviceId, setExpandedDeviceId] = useState();
-
   const {
     advanceOnboarding,
     className = '',
     columnHeaders,
+    expandedDeviceId,
     sortingNotes,
     devices,
     deviceListState,
@@ -36,6 +35,7 @@ export const DeviceList = props => {
     onSort,
     pageLoading,
     pageTotal,
+    setExpandedDeviceId,
     setSnackbar,
     showPagination = true
   } = props;
@@ -157,6 +157,7 @@ const areEqual = (prevProps, nextProps) => {
   if (
     prevProps.pageTotal != nextProps.pageTotal ||
     prevProps.pageLoading != nextProps.pageLoading ||
+    prevProps.expandedDeviceId != nextProps.expandedDeviceId ||
     prevProps.idAttribute != nextProps.idAttribute ||
     !deepCompare(prevProps.onboardingState, nextProps.onboardingState) ||
     !deepCompare(prevProps.devices, nextProps.devices)

--- a/src/js/components/header/__snapshots__/demonotification.test.js.snap
+++ b/src/js/components/header/__snapshots__/demonotification.test.js.snap
@@ -2,16 +2,11 @@
 
 exports[`DemoNotification Component renders correctly 1`] = `
 <div
-  class="flexbox centered"
-  id="demoBox"
+  class=""
 >
-  <a
-    currentitem="false"
-    data-event="click focus"
-    data-for="demo-mode"
-    data-offset="{'bottom': 15}"
-    data-tip="true"
-    id="demo-info"
+  <div
+    class="flexbox centered"
+    id="demoBox"
   >
     <svg
       aria-hidden="true"
@@ -24,33 +19,9 @@ exports[`DemoNotification Component renders correctly 1`] = `
         d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
       />
     </svg>
-    Demo mode
-  </a>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="demo-mode"
-  >
-    <h3>
+    <a>
       Demo mode
-    </h3>
-    <p>
-      Mender is currently running in 
-      <b>
-        demo mode
-      </b>
-      .
-    </p>
-    <p>
-      <a
-        href="https://docs.mender.io/development/server-installation/production-installation-with-kubernetes"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        See the documentation for help switching to production mode
-      </a>
-      .
-    </p>
+    </a>
   </div>
 </div>
 `;

--- a/src/js/components/header/__snapshots__/devicenotifications.test.js.snap
+++ b/src/js/components/header/__snapshots__/devicenotifications.test.js.snap
@@ -1,85 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DeviceNotifications Component renders correctly 1`] = `
-<div>
+<div
+  class=""
+>
   <div
-    currentitem="false"
-    data-for="limit-tip"
-    data-offset="{'bottom': 0, 'right': 0}"
-    data-tip="true"
-    data-tip-disable="false"
-    id="limit"
+    class="header-section"
   >
-    <div
-      class="__react_component_tooltip place-bottom type-dark"
-      data-id="tooltip"
-      id="limit-tip"
+    <a
+      class=""
+      href="/devices"
     >
-      <h3>
-        Device limit
-      </h3>
-      <p>
-        You can still connect another 
-        900
-         
-        devices
-        .
-      </p>
-      <p>
-        If you need a higher device limit, you can contact us by email at 
-        <a
-          href="mailto:support@mender.io"
-        >
-          support@mender.io
-        </a>
-         to change your plan.
-      </p>
-      <p>
-        Learn about the different plans available by visiting
-         
-        <a
-          href="https://mender.io/pricing"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          mender.io/pricing
-        </a>
-      </p>
-    </div>
-    <div
-      class="header-section"
+      <span>
+        100
+      </span>
+      <span>
+        /
+        1,000
+      </span>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        style="margin: 0px 7px 0px 10px; font-size: 20px;"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z"
+        />
+      </svg>
+    </a>
+    <a
+      href="/devices/pending"
+      style="margin-left: 7px;"
     >
-      <a
-        class="inline"
-        href="/devices"
-      >
-        <span>
-          100
-        </span>
-        <span>
-          /
-          1,000
-        </span>
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root"
-          focusable="false"
-          style="margin: 0px 7px 0px 10px; font-size: 20px;"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z"
-          />
-        </svg>
-      </a>
-      <a
-        href="/devices/pending"
-        style="margin-left: 7px;"
-      >
-        10
-         pending
-      </a>
-    </div>
+      10
+       pending
+    </a>
   </div>
 </div>
 `;

--- a/src/js/components/header/__snapshots__/trialnotification.test.js.snap
+++ b/src/js/components/header/__snapshots__/trialnotification.test.js.snap
@@ -6,57 +6,24 @@ exports[`DeviceNotifications Component renders correctly 1`] = `
   id="trialVersion"
 >
   <div
-    class="muted margin-right-small"
-    currentitem="false"
-    data-event="click focus"
-    data-for="trial-version"
-    data-offset="{'bottom': 15, 'right': 60}"
-    data-tip="true"
+    class=""
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      style="margin-right: 2px; height: 16px; vertical-align: bottom;"
-      viewBox="0 0 24 24"
+    <div
+      class="muted margin-right-small"
     >
-      <path
-        d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-      />
-    </svg>
-    Trial plan
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="trial-version"
-  >
-    <h3>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        style="margin-right: 2px; height: 16px; vertical-align: bottom;"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
       Trial plan
-    </h3>
-    <p>
-      You're using the trial version of Mender – it's free for up to 10 devices for 12 months.
-    </p>
-    <p>
-      <a
-        href="/settings/upgrade"
-      >
-        Upgrade to a plan
-      </a>
-       to add more devices and continue using Mender after the trial expires.
-    </p>
-    <p>
-      Or compare the plans at
-       
-      <a
-        href="https://mender.io/plans/pricing"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        mender.io/plans/pricing
-      </a>
-      .
-    </p>
+    </div>
   </div>
   <a
     aria-disabled="false"
@@ -98,57 +65,24 @@ exports[`DeviceNotifications Component renders correctly with an expiration date
   id="trialVersion"
 >
   <div
-    class="muted margin-right-small"
-    currentitem="false"
-    data-event="click focus"
-    data-for="trial-version"
-    data-offset="{'bottom': 15, 'right': 60}"
-    data-tip="true"
+    class=""
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      style="margin-right: 2px; height: 16px; vertical-align: bottom;"
-      viewBox="0 0 24 24"
+    <div
+      class="muted margin-right-small"
     >
-      <path
-        d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-      />
-    </svg>
-    Trial plan
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="trial-version"
-  >
-    <h3>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        style="margin-right: 2px; height: 16px; vertical-align: bottom;"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
       Trial plan
-    </h3>
-    <p>
-      You're using the trial version of Mender – it's free for up to 10 devices for 12 months.
-    </p>
-    <p>
-      <a
-        href="/settings/upgrade"
-      >
-        Upgrade to a plan
-      </a>
-       to add more devices and continue using Mender after the trial expires.
-    </p>
-    <p>
-      Or compare the plans at
-       
-      <a
-        href="https://mender.io/plans/pricing"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        mender.io/plans/pricing
-      </a>
-      .
-    </p>
+    </div>
   </div>
   <a
     aria-disabled="false"

--- a/src/js/components/header/demonotification.js
+++ b/src/js/components/header/demonotification.js
@@ -1,27 +1,35 @@
 import React from 'react';
-import ReactTooltip from 'react-tooltip';
+
 import { InfoOutlined as InfoIcon } from '@material-ui/icons';
 
-const DemoNotification = ({ docsVersion = 'development/' }) => (
-  <div id="demoBox" className="flexbox centered">
-    <a id="demo-info" data-tip data-for="demo-mode" data-event="click focus" data-offset="{'bottom': 15}">
-      <InfoIcon style={{ marginRight: '2px', height: '16px', verticalAlign: 'bottom' }} />
-      Demo mode
-    </a>
+import { MenderTooltipClickable } from '../common/mendertooltip';
 
-    <ReactTooltip id="demo-mode" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
-      <h3>Demo mode</h3>
-      <p>
-        Mender is currently running in <b>demo mode</b>.
-      </p>
-      <p>
-        <a href={`https://docs.mender.io/${docsVersion}server-installation/production-installation-with-kubernetes`} target="_blank" rel="noopener noreferrer">
-          See the documentation for help switching to production mode
-        </a>
-        .
-      </p>
-    </ReactTooltip>
-  </div>
+const DemoNotification = ({ docsVersion = 'development/' }) => (
+  <MenderTooltipClickable
+    title={
+      <>
+        <h3>Demo mode</h3>
+        <p>
+          Mender is currently running in <b>demo mode</b>.
+        </p>
+        <p>
+          <a
+            href={`https://docs.mender.io/${docsVersion}server-installation/production-installation-with-kubernetes`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            See the documentation for help switching to production mode
+          </a>
+          .
+        </p>
+      </>
+    }
+  >
+    <div id="demoBox" className="flexbox centered">
+      <InfoIcon style={{ marginRight: '2px', height: '16px', verticalAlign: 'bottom' }} />
+      <a>Demo mode</a>
+    </div>
+  </MenderTooltipClickable>
 );
 
 export default DemoNotification;

--- a/src/js/components/header/devicenotifications.js
+++ b/src/js/components/header/devicenotifications.js
@@ -1,27 +1,22 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import ReactTooltip from 'react-tooltip';
 import pluralize from 'pluralize';
 
 // material ui
 import DeveloperBoardIcon from '@material-ui/icons/DeveloperBoard';
 
+import { MenderTooltipClickable } from '../common/mendertooltip';
+
 const DeviceNotifications = ({ total, limit, pending }) => {
   const approaching = limit && total / limit > 0.8;
   const warning = limit && limit <= total;
   return (
-    <div>
-      <div id="limit" data-tip data-for="limit-tip" data-offset="{'bottom': 0, 'right': 0}" data-tip-disable={!limit}>
-        <ReactTooltip
-          id="limit-tip"
-          globalEventOff="click"
-          place="bottom"
-          type="light"
-          effect="solid"
-          delayHide={500}
-          className="react-tooltip"
-          disabled={!limit}
-        >
+    <MenderTooltipClickable
+      disabled={!limit}
+      disableHoverListener={false}
+      enterDelay={500}
+      title={
+        <>
           <h3>Device limit</h3>
           {approaching || warning ? (
             <p>You {approaching ? <span>are nearing</span> : <span>have reached</span>} your device limit.</p>
@@ -39,24 +34,24 @@ const DeviceNotifications = ({ total, limit, pending }) => {
               mender.io/pricing
             </a>
           </p>
-        </ReactTooltip>
+        </>
+      }
+    >
+      <div className="header-section">
+        <Link to="/devices" className={warning ? 'warning' : approaching ? 'approaching' : ''}>
+          <span>{total.toLocaleString()}</span>
+          {limit ? <span>/{limit.toLocaleString()}</span> : null}
 
-        <div className="header-section">
-          <Link to="/devices" className={warning ? 'warning inline' : approaching ? 'approaching inline' : 'inline'}>
-            <span>{total.toLocaleString()}</span>
-            {limit ? <span>/{limit.toLocaleString()}</span> : null}
+          <DeveloperBoardIcon style={{ margin: '0 7px 0 10px', fontSize: '20px' }} />
+        </Link>
 
-            <DeveloperBoardIcon style={{ margin: '0 7px 0 10px', fontSize: '20px' }} />
+        {pending ? (
+          <Link to="/devices/pending" style={{ marginLeft: '7px' }} className={limit && limit < pending + total ? 'warning' : null}>
+            {pending.toLocaleString()} pending
           </Link>
-
-          {pending ? (
-            <Link to="/devices/pending" style={{ marginLeft: '7px' }} className={limit && limit < pending + total ? 'warning' : null}>
-              {pending.toLocaleString()} pending
-            </Link>
-          ) : null}
-        </div>
+        ) : null}
       </div>
-    </div>
+    </MenderTooltipClickable>
   );
 };
 export default DeviceNotifications;

--- a/src/js/components/header/trialnotification.js
+++ b/src/js/components/header/trialnotification.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactTooltip from 'react-tooltip';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
@@ -7,10 +6,28 @@ import momentDurationFormatSetup from 'moment-duration-format';
 import { Button } from '@material-ui/core';
 import { InfoOutlined as InfoIcon, Payment } from '@material-ui/icons';
 import pluralize from 'pluralize';
+import { MenderTooltipClickable } from '../common/mendertooltip';
 
 momentDurationFormatSetup(moment);
 
 const today = new Date();
+
+const TrialInformation = () => (
+  <>
+    <h3>Trial plan</h3>
+    <p>You&apos;re using the trial version of Mender – it&apos;s free for up to 10 devices for 12 months.</p>
+    <p>
+      <Link to="/settings/upgrade">Upgrade to a plan</Link> to add more devices and continue using Mender after the trial expires.
+    </p>
+    <p>
+      Or compare the plans at{' '}
+      <a href={`https://mender.io/plans/pricing`} target="_blank" rel="noopener noreferrer">
+        mender.io/plans/pricing
+      </a>
+      .
+    </p>
+  </>
+);
 
 const TrialNotification = ({ expiration }) => {
   const expirationDate = moment(expiration);
@@ -18,26 +35,12 @@ const TrialNotification = ({ expiration }) => {
   const daysLeft = Math.floor(duration.asDays());
   return (
     <div id="trialVersion" className="flexbox centered">
-      <div className="muted margin-right-small" data-tip data-for="trial-version" data-event="click focus" data-offset="{'bottom': 15, 'right': 60}">
-        <InfoIcon style={{ marginRight: '2px', height: '16px', verticalAlign: 'bottom' }} />
-        Trial plan
-      </div>
-
-      <ReactTooltip id="trial-version" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
-        <h3>Trial plan</h3>
-        <p>You&apos;re using the trial version of Mender – it&apos;s free for up to 10 devices for 12 months.</p>
-        <p>
-          <Link to="/settings/upgrade">Upgrade to a plan</Link> to add more devices and continue using Mender after the trial expires.
-        </p>
-        <p>
-          Or compare the plans at{' '}
-          <a href={`https://mender.io/plans/pricing`} target="_blank" rel="noopener noreferrer">
-            mender.io/plans/pricing
-          </a>
-          .
-        </p>
-      </ReactTooltip>
-
+      <MenderTooltipClickable disableHoverListener={false} title={<TrialInformation />}>
+        <div className="muted margin-right-small">
+          <InfoIcon style={{ marginRight: '2px', height: '16px', verticalAlign: 'bottom' }} />
+          Trial plan
+        </div>
+      </MenderTooltipClickable>
       <Button id="trial-upgrade-now" color="primary" component={Link} startIcon={<Payment />} to="/settings/upgrade">
         Upgrade now
       </Button>

--- a/src/js/components/help/left-nav.js
+++ b/src/js/components/help/left-nav.js
@@ -1,59 +1,49 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
 // material ui
 import { List, ListItem, ListSubheader, ListItemText } from '@material-ui/core';
+import theme from '../../themes/mender-theme';
 
-export default class LeftNav extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {
-      links: []
-    };
-  }
+export const LeftNav = ({ isHosted, pages }) => {
+  const [links, setLinks] = useState([]);
 
-  componentDidMount() {
+  useEffect(() => {
     // generate sidebar links
-    this._setNavLinks();
-  }
+    setLinks(eachRecursive(pages, '/help', 1, []));
+  }, [pages]);
 
-  componentDidUpdate(prevProps) {
-    if (this.props.pages !== prevProps.pages) {
-      this._setNavLinks();
-    }
-  }
-
-  _setNavLinks() {
-    var self = this;
-    var links = [];
-
-    // build array of link list components
-    function eachRecursive(obj, path, level) {
-      for (var k in obj) {
-        if (typeof obj[k] == 'object' && obj[k] !== null && k !== 'component') {
-          var this_path = `${path}/${k}`;
-          links.push({ title: obj[k].title, level: level, path: this_path, hosted: obj[k].hosted });
-          self.setState({ links: links });
-          eachRecursive(obj[k], this_path, level + 1);
-        }
+  // build array of link list components
+  const eachRecursive = (obj, path, level, accu) => {
+    for (var k in obj) {
+      if (typeof obj[k] == 'object' && obj[k] !== null && k !== 'component') {
+        var this_path = `${path}/${k}`;
+        accu.push({ title: obj[k].title, level: level, path: this_path, hosted: obj[k].hosted });
+        accu = eachRecursive(obj[k], this_path, level + 1, accu);
       }
     }
-    eachRecursive(self.props.pages, '/help', 1);
-  }
+    return accu;
+  };
 
-  render() {
-    var self = this;
-    return (
-      <List className="leftFixed">
-        <ListSubheader disableSticky={true}>Help topics</ListSubheader>
-        {self.state.links.map(link => {
-          return !self.props.isHosted && link.hosted ? null : (
-            <ListItem className="navLink helpNav" component={NavLink} exact={true} key={link.path} style={{ paddingLeft: link.level * 16 }} to={link.path}>
-              <ListItemText primary={link.title} />
-            </ListItem>
-          );
-        })}
-      </List>
-    );
-  }
-}
+  return (
+    <List className="leftFixed">
+      <ListSubheader disableSticky={true}>Help topics</ListSubheader>
+      {links.map(link =>
+        !isHosted && link.hosted ? null : (
+          <ListItem
+            className="navLink helpNav"
+            component={NavLink}
+            exact={true}
+            key={link.path}
+            style={{ paddingLeft: link.level * theme.spacing(2) }}
+            to={link.path}
+          >
+            <ListItemText primary={link.title} />
+          </ListItem>
+        )
+      )}
+    </List>
+  );
+};
+
+export default LeftNav;

--- a/src/js/components/helptips/__snapshots__/baseonboardingtip.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/baseonboardingtip.test.js.snap
@@ -1,46 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BaseOnboardingTip Component renders correctly 1`] = `
-<div
-  class="onboard-tip"
-  style="left: -14px; top: 1px; overflow: initial;"
->
-  <a
-    class="tooltip onboard-icon bottom"
-    currentitem="false"
-    data-event="click focus"
-    data-event-off="dblclick"
-    data-for="onboard-tip-test"
-    data-tip="true"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-      />
-    </svg>
-  </a>
-  <div
-    class="__react_component_tooltip show place-bottom type-light allow_click content bottom"
-    data-id="tooltip"
-    id="onboard-tip-test"
-    style="left: 0px; top: 0px;"
-  >
-    <div />
+<body>
+  <div>
     <div
-      class="flexbox"
+      class="onboard-tip"
+      style="left: -14px; top: 1px; overflow: initial;"
     >
       <div
-        style="flex-grow: 1;"
-      />
-      <a>
-        Dismiss
-      </a>
+        class="tooltip onboard-icon bottom"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="MuiTooltip-popper WithStyles(ForwardRef(Tooltip))-popper-3 MuiTooltip-popperInteractive"
+      id="test"
+      role="tooltip"
+      style="position: fixed; top: 0px; left: 0px;"
+      x-placement="bottom"
+    >
+      <div
+        class="MuiTooltip-tooltip WithStyles(ForwardRef(Tooltip))-tooltip-2 MuiTooltip-tooltipPlacementBottom"
+        style="opacity: 1; transform: scale(1, 1); transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 133ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      >
+        <div
+          class="content"
+        >
+          <div>
+            Testcontent
+          </div>
+          <div
+            class="flexbox"
+          >
+            <div
+              style="flex-grow: 1;"
+            />
+            <a>
+              Dismiss
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
-</div>
+</body>
 `;

--- a/src/js/components/helptips/__snapshots__/deploymentcompletetip.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/deploymentcompletetip.test.js.snap
@@ -1,67 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DeploymentCompleteTip Component renders correctly 1`] = `
-<div
-  class="onboard-tip"
->
-  <a
-    class="tooltip onboard-icon"
-    currentitem="false"
-    data-event="click focus"
-    data-event-off="dblclick"
-    data-for="deployment-complete-tip"
-    data-tip="true"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-      />
-    </svg>
-  </a>
-  <div
-    class="__react_component_tooltip show place-bottom type-light allow_click content"
-    data-id="tooltip"
-    id="deployment-complete-tip"
-    style="left: 0px; top: 0px;"
-  >
-    <p>
-      Fantastic! You completed your first deployment!
-    </p>
-    <p>
-      Your deployment is finished and your device is now running the updated software!
-    </p>
+<body>
+  <div>
     <div
-      class="flexbox centered"
+      aria-describedby="deployments-past-completed"
+      class="tooltip onboard-icon onboard-tip"
     >
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained"
-        tabindex="0"
-        type="button"
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <span
-          class="MuiButton-label"
-        >
-          Go to http://192.168.10.141:85
-        </span>
-        <span
-          class="MuiTouchRipple-root"
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
         />
-      </button>
+      </svg>
     </div>
-    <p>
-      and you should see the demo web application actually being run on the device.
-    </p>
-    <p>
-      NOTE: if you have local network restrictions, you may need to check them if you have difficulty loading the page.
-    </p>
-    <a>
-      Visit the web app running your device
-    </a>
   </div>
-</div>
+  <div
+    class="MuiTooltip-popper WithStyles(ForwardRef(Tooltip))-popper-3 MuiTooltip-popperInteractive"
+    id="deployments-past-completed"
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin-left: -30px; margin-top: -20px;"
+    x-placement="bottom"
+  >
+    <div
+      class="MuiTooltip-tooltip WithStyles(ForwardRef(Tooltip))-tooltip-2 MuiTooltip-tooltipPlacementBottom"
+      style="opacity: 1; transform: scale(1, 1); transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 133ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <div
+        class="content"
+      >
+        <p>
+          Fantastic! You completed your first deployment!
+        </p>
+        <p>
+          Your deployment is finished and your device is now running the updated software!
+        </p>
+        <div
+          class="flexbox centered"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Go to http://192.168.10.141:85
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <p>
+          and you should see the demo web application actually being run on the device.
+        </p>
+        <p>
+          NOTE: if you have local network restrictions, you may need to check them if you have difficulty loading the page.
+        </p>
+        <a>
+          Visit the web app running your device
+        </a>
+      </div>
+    </div>
+  </div>
+</body>
 `;

--- a/src/js/components/helptips/__snapshots__/helptooltips.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/helptooltips.test.js.snap
@@ -1,545 +1,142 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Helptooltips Components renders Connect(AddGroupComponent) correctly 1`] = `
-<div>
-  <div
-    class="tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="groups-tip"
-    data-tip="true"
-    id="onboard-5"
-    style="bottom: -10px;"
+<div
+  class="tooltip help"
+  style="bottom: -10px;"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="groups-tip"
-  >
-    <h3>
-      Device groups
-    </h3>
-    <hr />
-    <p>
-      It is possible to create groups of devices. Once you have created a group and added one or more devices to it, you can deploy an update to that specific group only.
-    </p>
-    <p>
-      To avoid accidents, Mender only allows a device to be in one group at the time.
-    </p>
-    <p>
-      You can find out additional information about device groups in 
-      <a
-        href="/help/devices"
-      >
-        the help section
-      </a>
-      .
-    </p>
-    <p>
-      <a
-        class="hidehelp"
-      >
-        Hide all help tips
-      </a>
-    </p>
-  </div>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
 </div>
 `;
 
 exports[`Helptooltips Components renders Connect(AuthButtonComponent) correctly 1`] = `
-<div>
-  <div
-    class="tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="auth-button-tip"
-    data-tip="true"
-    id="onboard-4"
-    style="left: 75%; top: 0px;"
+<div
+  class="tooltip help"
+  style="left: 75%; top: 0px;"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="auth-button-tip"
-  >
-    <div
-      style="white-space: normal;"
-    >
-      <h3>
-        Authorize devices
-      </h3>
-      <hr />
-      <p>
-        Expand this section to view the authentication options for this device. You can decide whether to accept it, reject it, or just dismiss this device for now.
-      </p>
-      <p>
-        See the documentation for more on
-         
-        <a
-          href="https://docs.mender.io/overview/device-authentication"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Device authentication
-        </a>
-        .
-      </p>
-      <p>
-        <a
-          class="hidehelp"
-        >
-          Hide all help tips
-        </a>
-      </p>
-    </div>
-  </div>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
 </div>
 `;
 
 exports[`Helptooltips Components renders Connect(ConfigureAddOnTipComponent) correctly 1`] = `
-<div>
-  <div
-    class="tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="configure-add-on-help-tip"
-    data-tip="true"
-    id="configure-add-on-help"
-    style="top: 10%; left: 75%;"
+<div
+  class="tooltip help"
+  style="top: 10%; left: 75%;"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="configure-add-on-help-tip"
-  >
-    <p>
-      Mender deploys the configuration attributes using the same mechanisms as software updates. The configuration is stored as a JSON file at
-      <code>
-        /var/lib/mender-configure/device-config.json
-      </code>
-       on the device and then all the scripts in
-       
-      <code>
-        /usr/lib/mender-configure/apply-device-config.d/
-      </code>
-       are executed to apply the configuration attributes. To add a new configuration attribute, you simply need to input it in the UI and add a script to that directory that applies it accordingly. Read more about how it works in the
-       
-      <a
-        href="https://docs.mender.io/add-ons/configure"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Configure documentation
-      </a>
-      .
-    </p>
-  </div>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
 </div>
 `;
 
 exports[`Helptooltips Components renders Connect(ConfigureRaspberryLedComponent) correctly 1`] = `
-NodeList [
-  <div
-    class="fadeIn tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="config-led-tip"
-    data-tip="true"
-    id="config-led-help"
+<div
+  class="fadeIn tooltip help"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>,
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="config-led-tip"
-  >
-    To see the effects of applying a configuration to your device you can set one of the below values to modify the behaviour of your Raspberry Pi green status LED
-    <div
-      class="break-all two-columns column-data compact react-tooltip margin-top-small margin-bottom-small"
-    >
-      <div
-        class="align-right key text-muted"
-      >
-        <b>
-          mmc0
-        </b>
-      </div>
-      <div
-        class="flexbox clickable"
-      >
-        The default, which blinks the led on storage activity
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root margin-left-small fadeOut MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall"
-          focusable="false"
-          title="Copy to clipboard"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"
-          />
-        </svg>
-      </div>
-      <div
-        class="align-right key text-muted"
-      >
-        <b>
-          on
-        </b>
-      </div>
-      <div
-        class="flexbox clickable"
-      >
-        Turn on the light permanently
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root margin-left-small fadeOut MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall"
-          focusable="false"
-          title="Copy to clipboard"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"
-          />
-        </svg>
-      </div>
-      <div
-        class="align-right key text-muted"
-      >
-        <b>
-          off
-        </b>
-      </div>
-      <div
-        class="flexbox clickable"
-      >
-        Turn off the light permanently
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root margin-left-small fadeOut MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall"
-          focusable="false"
-          title="Copy to clipboard"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"
-          />
-        </svg>
-      </div>
-      <div
-        class="align-right key text-muted"
-      >
-        <b>
-          heartbeat
-        </b>
-      </div>
-      <div
-        class="flexbox clickable"
-      >
-        Enable heartbeat blinking
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root margin-left-small fadeOut MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall"
-          focusable="false"
-          title="Copy to clipboard"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"
-          />
-        </svg>
-      </div>
-    </div>
-    There are other possible values, but we won't advertise them here. See
-    <a
-      href="http://www.d3noob.org/2020/07/controlling-activity-led-on-raspberry-pi.html"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      this blog post
-    </a>
-     
-    or
-     
-    <a
-      href="https://www.raspberrypi.org/forums/viewtopic.php?t=273194#p1658930"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      in the Raspberry Pi forums
-    </a>
-    for more information.
-    <p>
-      <a
-        class="hidehelp"
-      >
-        Hide all help tips
-      </a>
-    </p>
-  </div>,
-]
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
+</div>
 `;
 
 exports[`Helptooltips Components renders Connect(ConfigureTimezoneTipComponent) correctly 1`] = `
-NodeList [
-  <div
-    class="fadeIn tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="config-timezone-tip"
-    data-tip="true"
-    id="config-timezone-help"
+<div
+  class="fadeIn tooltip help"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>,
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="config-timezone-tip"
-  >
-    To see the effects of applying a configuration to your device you can set one of the below values to modify the timezone of your device. While all values from 
-    <i>
-      timedatectl list-timezones
-    </i>
-     will work, to easily see the impact of the changed value you can use one of the following values:
-    <ul>
-      <li>
-        Europe/Oslo
-      </li>
-      <li>
-        America/Los_Angeles
-      </li>
-      <li>
-        Asia/Tokyo
-      </li>
-    </ul>
-    Once the configuration has been applied you can see the effect by opening the Remote Terminal to the device and executing the 
-    <i>
-      date
-    </i>
-     command.
-    <p>
-      <a
-        class="hidehelp"
-      >
-        Hide all help tips
-      </a>
-    </p>
-  </div>,
-]
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
+</div>
 `;
 
 exports[`Helptooltips Components renders Connect(DeviceSupportTipComponent) correctly 1`] = `
-<div>
-  <div
-    class="tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="deb-package-tip"
-    data-tip="true"
-    id="deb-package-help"
-    style="top: 22%; left: 88%;"
+<div
+  class="tooltip help"
+  style="top: 22%; left: 88%;"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="deb-package-tip"
-  >
-    <p>
-      The steps in the guide should work on most operating systems in the Debian family (e.g. Debian, Ubuntu, Raspberry Pi OS) and devices based on ARMv6 or newer (e.g. Raspberry Pi 2/3/4, Beaglebone). Visit
-       
-      <a
-        href="https://docs.mender.io/overview/device-support"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        our documentation
-      </a>
-      for more information about device support.
-    </p>
-  </div>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
 </div>
 `;
 
 exports[`Helptooltips Components renders Connect(ExpandArtifactComponent) correctly 1`] = `
-<div>
-  <div
-    class="tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="artifact-expand-tip"
-    data-tip="true"
-    id="onboard-10"
+<div
+  class="tooltip help"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-bottom type-dark"
-    data-id="tooltip"
-    id="artifact-expand-tip"
-  >
-    <h3>
-      Device type compatibility
-    </h3>
-    <hr />
-    <p>
-      Mender Artifacts have 
-      <b>
-        Device types compatible
-      </b>
-       as part of their metadata. All devices report which device type they are, as part of their inventory information. During a deployment, Mender makes sure that a device will only download and install an Artifact it is compatible with.
-    </p>
-    <p>
-      You can click on each Artifact in the Release to expand the row and view more information about it.
-    </p>
-    <p>
-      For more information on how to specify the device type compatibility and other artifact metadata,
-       
-      <a
-        href="https://docs.mender.io/artifact-creation/create-an-artifact"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        see the documentation
-      </a>
-      .
-    </p>
-    <p>
-      <a
-        class="hidehelp"
-      >
-        Hide all help tips
-      </a>
-    </p>
-  </div>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
 </div>
 `;
 
 exports[`Helptooltips Components renders Connect(ExpandDeviceComponent) correctly 1`] = `
-<div>
-  <div
-    class="tooltip help"
-    currentitem="false"
-    data-event="click focus"
-    data-for="expand-device-tip"
-    data-tip="true"
-    id="onboard-6"
-    style="right: 45px;"
+<div
+  class="tooltip help"
+  style="right: 45px;"
+>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root"
+    focusable="false"
+    viewBox="0 0 24 24"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-      />
-    </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-left type-dark"
-    data-id="tooltip"
-    id="expand-device-tip"
-  >
-    <h3>
-      Device inventory
-    </h3>
-    <hr />
-    <p>
-      Mender automatically collects identity and inventory information from connected devices. You can view this information by clicking on a device to expand the row.
-    </p>
-    <p>
-      Which information is collected about devices is fully configurable;
-       
-      <a
-        href="https://docs.mender.io/client-installation/identity"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        see the documentation for how to configure this
-      </a>
-      .
-    </p>
-    <p>
-      <a
-        class="hidehelp"
-      >
-        Hide all help tips
-      </a>
-    </p>
-  </div>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+    />
+  </svg>
 </div>
 `;

--- a/src/js/components/helptips/__snapshots__/onboardingcompletetip.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/onboardingcompletetip.test.js.snap
@@ -1,110 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OnboardingCompleteTip Component renders correctly 1`] = `
-<div
-  class="onboard-tip"
->
-  <a
-    class="tooltip onboard-icon"
-    currentitem="false"
-    data-event="click focus"
-    data-event-off="dblclick"
-    data-for="onboarding-complete-tip"
-    data-tip="true"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-      />
-    </svg>
-  </a>
-  <div
-    class="__react_component_tooltip show place-bottom type-light allow_click content"
-    data-id="tooltip"
-    id="onboarding-complete-tip"
-    style="left: 0px; top: 0px;"
-  >
-    <p>
-      Great work! You updated your device with the new Release!
-    </p>
-    <p>
-      Your device is now running the updated version of the software. At
-      <div
-        class="flexbox centered"
-        style="margin: 5px 0px;"
-      >
-        <a
-          aria-disabled="false"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained button"
-          href="http://192.168.10.141:85/index.html?source=http%3A%2F%2Ftest.com"
-          tabindex="0"
-          target="_blank"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Go to http://192.168.10.141:85
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </a>
-      </div>
-      you should now see "Hello world" in place of the webpage you saw previously. If you continue to see the webpage you saw previously you might have to refresh the page.
-    </p>
-    <p>
-      You've now got a good foundation in how to use Mender. Look for more help hints in the UI as you go along.
-    </p>
-    What next?
-    <div>
-      Proceed to one of the following tutorials (listed in recommended order):
-      <ol>
-        <li>
-          <a
-            href="https://docs.mender.io/get-started/deploy-a-system-update"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Deploy a system update
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://docs.mender.io/get-started/deploy-a-container-update"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Deploy a container update
-          </a>
-        </li>
-      </ol>
-    </div>
+<body>
+  <div>
     <div
-      class="flexbox"
+      aria-describedby="onboarding-finished"
+      class="tooltip onboard-icon onboard-tip"
     >
-      <div
-        style="flex-grow: 1;"
-      />
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary"
-        tabindex="0"
-        type="button"
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <span
-          class="MuiButton-label"
-        >
-          Close
-        </span>
-        <span
-          class="MuiTouchRipple-root"
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
         />
-      </button>
+      </svg>
     </div>
   </div>
-</div>
+  <div
+    class="MuiTooltip-popper WithStyles(ForwardRef(Tooltip))-popper-3 MuiTooltip-popperInteractive"
+    id="onboarding-finished"
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin-left: -30px; margin-top: -20px;"
+    x-placement="bottom"
+  >
+    <div
+      class="MuiTooltip-tooltip WithStyles(ForwardRef(Tooltip))-tooltip-2 MuiTooltip-tooltipPlacementBottom"
+      style="opacity: 1; transform: scale(1, 1); transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 133ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <div
+        class="content"
+      >
+        <p>
+          Great work! You updated your device with the new Release!
+        </p>
+        <p>
+          Your device is now running the updated version of the software. At
+          <div
+            class="flexbox centered"
+            style="margin: 5px 0px;"
+          >
+            <a
+              aria-disabled="false"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained button"
+              href="http://192.168.10.141:85/index.html?source=http%3A%2F%2Ftest.com"
+              tabindex="0"
+              target="_blank"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Go to http://192.168.10.141:85
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </a>
+          </div>
+          you should now see "Hello world" in place of the webpage you saw previously. If you continue to see the webpage you saw previously you might have to refresh the page.
+        </p>
+        <p>
+          You've now got a good foundation in how to use Mender. Look for more help hints in the UI as you go along.
+        </p>
+        What next?
+        <div>
+          Proceed to one of the following tutorials (listed in recommended order):
+          <ol>
+            <li>
+              <a
+                href="https://docs.mender.io/get-started/deploy-a-system-update"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Deploy a system update
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://docs.mender.io/get-started/deploy-a-container-update"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Deploy a container update
+              </a>
+            </li>
+          </ol>
+        </div>
+        <div
+          class="flexbox"
+        >
+          <div
+            style="flex-grow: 1;"
+          />
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Close
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
 `;

--- a/src/js/components/helptips/__snapshots__/onboardingtips.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/onboardingtips.test.js.snap
@@ -2,59 +2,27 @@
 
 exports[`OnboardingTips Components DevicePendingTip renders correctly 1`] = `
 <div
-  class="onboard-tip"
-  style="left: 50%; top: 50%;"
+  style="display: grid; place-items: center;"
 >
-  <a
-    class="tooltip onboard-icon"
-    currentitem="false"
-    data-event="click focus"
-    data-event-off="dblclick"
-    data-for="pending-device-onboarding-tip"
-    data-tip="true"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-      />
-      <path
-        d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"
-      />
-    </svg>
-  </a>
   <div
-    class="__react_component_tooltip show place-bottom type-light allow_click content"
-    data-id="tooltip"
-    id="pending-device-onboarding-tip"
-    style="left: 0px; top: 0px;"
+    class=""
   >
-    <p>
-      It may take a few moments before your device appears.
-    </p>
-    <a>
-      Open the tutorial
-    </a>
-     again or 
-    <a
-      href="/help/get-started"
-    >
-      go to the help pages
-    </a>
-     if you have problems.
     <div
-      class="flexbox"
+      class="onboard-icon"
     >
-      <div
-        style="flex-grow: 1;"
-      />
-      <a>
-        Dismiss
-      </a>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+        />
+        <path
+          d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+        />
+      </svg>
     </div>
   </div>
 </div>

--- a/src/js/components/helptips/baseonboardingtip.test.js
+++ b/src/js/components/helptips/baseonboardingtip.test.js
@@ -17,10 +17,10 @@ describe('BaseOnboardingTip Component', () => {
   it('renders correctly', async () => {
     const { baseElement } = render(
       <Provider store={store}>
-        <BaseOnboardingTip anchor={{ left: 1, top: 1, right: 1, bottom: 1 }} component={<div />} id="test" />
+        <BaseOnboardingTip anchor={{ left: 1, top: 1, right: 1, bottom: 1 }} component={<div>Testcontent</div>} id="test" />
       </Provider>
     );
-    const view = baseElement.firstChild.firstChild;
+    const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
   });

--- a/src/js/components/helptips/deploymentcompletetip.js
+++ b/src/js/components/helptips/deploymentcompletetip.js
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import ReactTooltip from 'react-tooltip';
 
 import Button from '@material-ui/core/Button';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
@@ -13,6 +12,7 @@ import { onboardingSteps } from '../../constants/onboardingConstants';
 import { getDemoDeviceAddress } from '../../selectors';
 import Tracking from '../../tracking';
 import Loader from '../common/loader';
+import { MenderTooltipClickable } from '../common/mendertooltip';
 
 export const DeploymentCompleteTip = ({
   advanceOnboarding,
@@ -23,10 +23,7 @@ export const DeploymentCompleteTip = ({
   setOnboardingComplete,
   url
 }) => {
-  const tipRef = useRef(null);
-
   useEffect(() => {
-    ReactTooltip.show(tipRef.current);
     getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted).then(tasks => tasks[tasks.length - 1].deviceAccu.ids.map(getDeviceById));
     Tracking.event({ category: 'onboarding', action: onboardingSteps.DEPLOYMENTS_PAST_COMPLETED });
   }, []);
@@ -41,19 +38,26 @@ export const DeploymentCompleteTip = ({
   };
 
   return (
-    <div className="onboard-tip" style={anchor}>
-      <a className="tooltip onboard-icon" data-tip data-for="deployment-complete-tip" data-event="click focus" data-event-off="dblclick" ref={tipRef}>
-        <CheckCircleIcon />
-      </a>
-      <ReactTooltip id="deployment-complete-tip" place="bottom" type="light" effect="solid" className="content" clickable={true}>
-        <p>Fantastic! You completed your first deployment!</p>
-        <p>Your deployment is finished and your device is now running the updated software!</p>
-        <div className="flexbox centered">{!url ? <Loader show={true} /> : <Button variant="contained" onClick={onClick}>{`Go to ${url}`}</Button>}</div>
-        <p>and you should see the demo web application actually being run on the device.</p>
-        <p>NOTE: if you have local network restrictions, you may need to check them if you have difficulty loading the page.</p>
-        <a onClick={onClick}>Visit the web app running your device</a>
-      </ReactTooltip>
-    </div>
+    <MenderTooltipClickable
+      className="tooltip onboard-icon onboard-tip"
+      id={onboardingSteps.DEPLOYMENTS_PAST_COMPLETED}
+      onboarding
+      startOpen
+      style={anchor}
+      PopperProps={{ style: { marginLeft: -30, marginTop: -20 } }}
+      title={
+        <div className="content">
+          <p>Fantastic! You completed your first deployment!</p>
+          <p>Your deployment is finished and your device is now running the updated software!</p>
+          <div className="flexbox centered">{!url ? <Loader show={true} /> : <Button variant="contained" onClick={onClick}>{`Go to ${url}`}</Button>}</div>
+          <p>and you should see the demo web application actually being run on the device.</p>
+          <p>NOTE: if you have local network restrictions, you may need to check them if you have difficulty loading the page.</p>
+          <a onClick={onClick}>Visit the web app running your device</a>
+        </div>
+      }
+    >
+      <CheckCircleIcon />
+    </MenderTooltipClickable>
   );
 };
 

--- a/src/js/components/helptips/deploymentcompletetip.test.js
+++ b/src/js/components/helptips/deploymentcompletetip.test.js
@@ -20,7 +20,7 @@ describe('DeploymentCompleteTip Component', () => {
         <DeploymentCompleteTip targetUrl="https://test.com" />
       </Provider>
     );
-    const view = baseElement.firstChild.firstChild;
+    const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
   });

--- a/src/js/components/helptips/helptooltips.js
+++ b/src/js/components/helptips/helptooltips.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import ReactTooltip from 'react-tooltip';
 
 import { Help as HelpIcon, InfoOutlined as InfoIcon } from '@material-ui/icons';
 
@@ -9,7 +8,7 @@ import { setSnackbar } from '../../actions/appActions';
 import { toggleHelptips } from '../../actions/userActions';
 import { getDocsVersion } from '../../selectors';
 import ConfigurationObject from '../common/configurationobject';
-import MenderTooltip from '../common/mendertooltip';
+import MenderTooltip, { MenderTooltipClickable } from '../common/mendertooltip';
 
 const actionCreators = { setSnackbar, toggleHelptips };
 const mapStateToProps = (state, ownProps) => {
@@ -32,41 +31,37 @@ const HideHelptipsButton = ({ toggleHelptips }) => (
 );
 
 const AuthExplainComponent = ({ docsVersion }) => (
-  <div>
-    <div id="auth-info" className="tooltip" style={{ right: 0, top: -70 }} data-tip data-for="auth-info-tip" data-event="click focus">
-      <InfoIcon />
-    </div>
-    <ReactTooltip id="auth-info-tip" globalEventOff="click" place="left" type="light" effect="solid" className="react-tooltip">
-      <h3>Device authorization status</h3>
-      <p>
-        Each device sends an authentication request containing its identity attributes and its current public key. You can accept, reject or dismiss these
-        requests to determine the authorization status of the device.
-      </p>
-      <p>
-        In cases such as key rotation, each device may have more than one identity/key combination listed. See the documentation for more on{' '}
-        <a href={`https://docs.mender.io/${docsVersion}overview/device-authentication`} target="_blank" rel="noopener noreferrer">
-          Device authentication
-        </a>
-        .
-      </p>
-    </ReactTooltip>
-  </div>
+  <MenderTooltipClickable
+    placement="left"
+    className="absolute clickable"
+    style={{ right: 0, top: -70 }}
+    title={
+      <>
+        <h3>Device authorization status</h3>
+        <p>
+          Each device sends an authentication request containing its identity attributes and its current public key. You can accept, reject or dismiss these
+          requests to determine the authorization status of the device.
+        </p>
+        <p>
+          In cases such as key rotation, each device may have more than one identity/key combination listed. See the documentation for more on{' '}
+          <a href={`https://docs.mender.io/${docsVersion}overview/device-authentication`} target="_blank" rel="noopener noreferrer">
+            Device authentication
+          </a>
+          .
+        </p>
+      </>
+    }
+  >
+    <InfoIcon />
+  </MenderTooltipClickable>
 );
 export const AuthExplainButton = connect(mapStateToProps, actionCreators)(AuthExplainComponent);
 
 const AuthButtonComponent = ({ docsVersion, highlightHelp, toggleHelptips }) => (
-  <div>
-    <div
-      id="onboard-4"
-      className={highlightHelp ? 'tooltip help highlight' : 'tooltip help'}
-      data-tip
-      data-for="auth-button-tip"
-      data-event="click focus"
-      style={{ left: '75%', top: 0 }}
-    >
-      <HelpIcon />
-    </div>
-    <ReactTooltip id="auth-button-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+  <MenderTooltipClickable
+    className={highlightHelp ? 'tooltip help highlight' : 'tooltip help'}
+    style={{ left: '75%', top: 0 }}
+    title={
       <div style={{ whiteSpace: 'normal' }}>
         <h3>Authorize devices</h3>
         <hr />
@@ -83,100 +78,111 @@ const AuthButtonComponent = ({ docsVersion, highlightHelp, toggleHelptips }) => 
         </p>
         <HideHelptipsButton toggleHelptips={toggleHelptips} />
       </div>
-    </ReactTooltip>
-  </div>
+    }
+  >
+    <HelpIcon />
+  </MenderTooltipClickable>
 );
 export const AuthButton = connect(mapStateToProps, actionCreators)(AuthButtonComponent);
 
 const AddGroupComponent = ({ toggleHelptips }) => (
-  <div>
-    <div id="onboard-5" className="tooltip help" data-tip data-for="groups-tip" data-event="click focus" style={{ bottom: '-10px' }}>
-      <HelpIcon />
-    </div>
-    <ReactTooltip id="groups-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
-      <h3>Device groups</h3>
-      <hr />
-      <p>
-        It is possible to create groups of devices. Once you have created a group and added one or more devices to it, you can deploy an update to that specific
-        group only.
-      </p>
-      <p>To avoid accidents, Mender only allows a device to be in one group at the time.</p>
-      <p>
-        You can find out additional information about device groups in <Link to="/help/devices">the help section</Link>.
-      </p>
-      <HideHelptipsButton toggleHelptips={toggleHelptips} />
-    </ReactTooltip>
-  </div>
+  <MenderTooltipClickable
+    className="tooltip help"
+    style={{ bottom: -10 }}
+    title={
+      <>
+        <h3>Device groups</h3>
+        <hr />
+        <p>
+          It is possible to create groups of devices. Once you have created a group and added one or more devices to it, you can deploy an update to that
+          specific group only.
+        </p>
+        <p>To avoid accidents, Mender only allows a device to be in one group at the time.</p>
+        <p>
+          You can find out additional information about device groups in <Link to="/help/devices">the help section</Link>.
+        </p>
+        <HideHelptipsButton toggleHelptips={toggleHelptips} />
+      </>
+    }
+  >
+    <HelpIcon />
+  </MenderTooltipClickable>
 );
 export const AddGroup = connect(mapStateToProps, actionCreators)(AddGroupComponent);
 
 const ExpandDeviceComponent = ({ docsVersion, toggleHelptips }) => (
-  <div>
-    <div id="onboard-6" className="tooltip help" data-tip data-for="expand-device-tip" data-event="click focus" style={{ left: 'inherit', right: '45px' }}>
-      <HelpIcon />
-    </div>
-    <ReactTooltip id="expand-device-tip" globalEventOff="click" place="left" type="light" effect="solid" className="react-tooltip">
-      <h3>Device inventory</h3>
-      <hr />
-      <p>
-        Mender automatically collects identity and inventory information from connected devices. You can view this information by clicking on a device to expand
-        the row.
-      </p>
-      <p>
-        Which information is collected about devices is fully configurable;{' '}
-        <a href={`https://docs.mender.io/${docsVersion}client-installation/identity`} target="_blank" rel="noopener noreferrer">
-          see the documentation for how to configure this
-        </a>
-        .
-      </p>
-      <HideHelptipsButton toggleHelptips={toggleHelptips} />
-    </ReactTooltip>
-  </div>
+  <MenderTooltipClickable
+    className="tooltip help"
+    style={{ left: 'inherit', right: '45px' }}
+    title={
+      <>
+        <h3>Device inventory</h3>
+        <hr />
+        <p>
+          Mender automatically collects identity and inventory information from connected devices. You can view this information by clicking on a device to
+          expand the row.
+        </p>
+        <p>
+          Which information is collected about devices is fully configurable;{' '}
+          <a href={`https://docs.mender.io/${docsVersion}client-installation/identity`} target="_blank" rel="noopener noreferrer">
+            see the documentation for how to configure this
+          </a>
+          .
+        </p>
+        <HideHelptipsButton toggleHelptips={toggleHelptips} />
+      </>
+    }
+  >
+    <HelpIcon />
+  </MenderTooltipClickable>
 );
 export const ExpandDevice = connect(mapStateToProps, actionCreators)(ExpandDeviceComponent);
 
 const ExpandArtifactComponent = ({ docsVersion, toggleHelptips }) => (
-  <div>
-    <div id="onboard-10" className="tooltip help" data-tip data-for="artifact-expand-tip" data-event="click focus">
-      <HelpIcon />
-    </div>
-    <ReactTooltip id="artifact-expand-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
-      <h3>Device type compatibility</h3>
-      <hr />
-      <p>
-        Mender Artifacts have <b>Device types compatible</b> as part of their metadata. All devices report which device type they are, as part of their
-        inventory information. During a deployment, Mender makes sure that a device will only download and install an Artifact it is compatible with.
-      </p>
-      <p>You can click on each Artifact in the Release to expand the row and view more information about it.</p>
-      <p>
-        For more information on how to specify the device type compatibility and other artifact metadata,{' '}
-        <a href={`https://docs.mender.io/${docsVersion}artifact-creation/create-an-artifact`} target="_blank" rel="noopener noreferrer">
-          see the documentation
-        </a>
-        .
-      </p>
-      <HideHelptipsButton toggleHelptips={toggleHelptips} />
-    </ReactTooltip>
-  </div>
+  <MenderTooltipClickable
+    className="tooltip help"
+    title={
+      <>
+        <h3>Device type compatibility</h3>
+        <hr />
+        <p>
+          Mender Artifacts have <b>Device types compatible</b> as part of their metadata. All devices report which device type they are, as part of their
+          inventory information. During a deployment, Mender makes sure that a device will only download and install an Artifact it is compatible with.
+        </p>
+        <p>You can click on each Artifact in the Release to expand the row and view more information about it.</p>
+        <p>
+          For more information on how to specify the device type compatibility and other artifact metadata,{' '}
+          <a href={`https://docs.mender.io/${docsVersion}artifact-creation/create-an-artifact`} target="_blank" rel="noopener noreferrer">
+            see the documentation
+          </a>
+          .
+        </p>
+        <HideHelptipsButton toggleHelptips={toggleHelptips} />
+      </>
+    }
+  >
+    <HelpIcon />
+  </MenderTooltipClickable>
 );
 export const ExpandArtifact = connect(mapStateToProps, actionCreators)(ExpandArtifactComponent);
 
 const DeviceSupportTipComponent = ({ docsVersion }) => (
-  <div>
-    <div id="deb-package-help" className="tooltip help" data-tip data-for="deb-package-tip" data-event="click focus" style={{ top: '22%', left: '88%' }}>
-      <HelpIcon />
-    </div>
-    <ReactTooltip id="deb-package-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+  <MenderTooltipClickable
+    className="tooltip help"
+    style={{ top: '22%', left: '88%' }}
+    title={
       <p>
         The steps in the guide should work on most operating systems in the Debian family (e.g. Debian, Ubuntu, Raspberry Pi OS) and devices based on ARMv6 or
         newer (e.g. Raspberry Pi 2/3/4, Beaglebone). Visit{' '}
         <a href={`https://docs.mender.io/${docsVersion}overview/device-support`} target="_blank" rel="noopener noreferrer">
           our documentation
-        </a>
+        </a>{' '}
         for more information about device support.
       </p>
-    </ReactTooltip>
-  </div>
+    }
+  >
+    <HelpIcon />
+  </MenderTooltipClickable>
 );
 
 export const DeviceSupportTip = connect(mapStateToProps, actionCreators)(DeviceSupportTipComponent);
@@ -187,11 +193,10 @@ const ConfigureTimezoneTipComponent = ({ anchor, device, toggleHelptips }) => {
     return null;
   }
   return (
-    <>
-      <div id="config-timezone-help" className="fadeIn tooltip help" data-tip data-for="config-timezone-tip" data-event="click focus" style={anchor}>
-        <HelpIcon />
-      </div>
-      <ReactTooltip id="config-timezone-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+    <MenderTooltipClickable
+      className="fadeIn tooltip help"
+      style={anchor}
+      title={
         <>
           To see the effects of applying a configuration to your device you can set one of the below values to modify the timezone of your device. While all
           values from <i>timedatectl list-timezones</i> will work, to easily see the impact of the changed value you can use one of the following values:
@@ -203,8 +208,10 @@ const ConfigureTimezoneTipComponent = ({ anchor, device, toggleHelptips }) => {
           Once the configuration has been applied you can see the effect by opening the Remote Terminal to the device and executing the <i>date</i> command.
           <HideHelptipsButton toggleHelptips={toggleHelptips} />
         </>
-      </ReactTooltip>
-    </>
+      }
+    >
+      <HelpIcon />
+    </MenderTooltipClickable>
   );
 };
 
@@ -216,16 +223,15 @@ const ConfigureRaspberryLedComponent = ({ anchor, device, setSnackbar, toggleHel
     return null;
   }
   return (
-    <>
-      <div id="config-led-help" className="fadeIn tooltip help" data-tip data-for="config-led-tip" data-event="click focus" style={anchor}>
-        <HelpIcon />
-      </div>
-      <ReactTooltip id="config-led-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+    <MenderTooltipClickable
+      className="fadeIn tooltip help"
+      style={anchor}
+      title={
         <>
           To see the effects of applying a configuration to your device you can set one of the below values to modify the behaviour of your Raspberry Pi green
           status LED
           <ConfigurationObject
-            className="react-tooltip margin-top-small margin-bottom-small"
+            className="margin-top-small margin-bottom-small"
             config={{
               mmc0: 'The default, which blinks the led on storage activity',
               on: 'Turn on the light permanently',
@@ -242,30 +248,24 @@ const ConfigureRaspberryLedComponent = ({ anchor, device, setSnackbar, toggleHel
           or{' '}
           <a href="https://www.raspberrypi.org/forums/viewtopic.php?t=273194#p1658930" target="_blank" rel="noopener noreferrer">
             in the Raspberry Pi forums
-          </a>
+          </a>{' '}
           for more information.
           <HideHelptipsButton toggleHelptips={toggleHelptips} />
         </>
-      </ReactTooltip>
-    </>
+      }
+    >
+      <HelpIcon />
+    </MenderTooltipClickable>
   );
 };
 
 export const ConfigureRaspberryLedTip = connect(mapStateToProps, actionCreators)(ConfigureRaspberryLedComponent);
 
 const ConfigureAddOnTipComponent = ({ docsVersion }) => (
-  <div>
-    <div
-      id="configure-add-on-help"
-      className="tooltip help"
-      data-tip
-      data-for="configure-add-on-help-tip"
-      data-event="click focus"
-      style={{ top: '10%', left: '75%' }}
-    >
-      <HelpIcon />
-    </div>
-    <ReactTooltip id="configure-add-on-help-tip" globalEventOff="click" place="bottom" type="light" effect="solid" className="react-tooltip">
+  <MenderTooltipClickable
+    className="tooltip help"
+    style={{ top: '10%', left: '75%' }}
+    title={
       <p>
         Mender deploys the configuration attributes using the same mechanisms as software updates. The configuration is stored as a JSON file at
         <code>/var/lib/mender-configure/device-config.json</code> on the device and then all the scripts in{' '}
@@ -276,8 +276,10 @@ const ConfigureAddOnTipComponent = ({ docsVersion }) => (
         </a>
         .
       </p>
-    </ReactTooltip>
-  </div>
+    }
+  >
+    <HelpIcon />
+  </MenderTooltipClickable>
 );
 
 export const ConfigureAddOnTip = connect(mapStateToProps, actionCreators)(ConfigureAddOnTipComponent);

--- a/src/js/components/helptips/onboardingcompletetip.js
+++ b/src/js/components/helptips/onboardingcompletetip.js
@@ -1,22 +1,20 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import ReactTooltip from 'react-tooltip';
 
 import { Button } from '@material-ui/core';
 import { CheckCircle as CheckCircleIcon } from '@material-ui/icons';
 
 import { getDeviceById, getDevicesByStatus } from '../../actions/deviceActions';
 import { setOnboardingComplete } from '../../actions/onboardingActions';
-import DeviceConstants from '../../constants/deviceConstants';
-import { getDemoDeviceAddress, getDocsVersion } from '../../selectors';
 import Loader from '../common/loader';
+import { MenderTooltipClickable } from '../common/mendertooltip';
+import DeviceConstants from '../../constants/deviceConstants';
+import { onboardingSteps } from '../../constants/onboardingConstants';
+import { getDemoDeviceAddress, getDocsVersion } from '../../selectors';
 
 export const OnboardingCompleteTip = ({ anchor, docsVersion, getDeviceById, getDevicesByStatus, setOnboardingComplete, url }) => {
-  const tipRef = useRef(null);
-
   useEffect(() => {
-    ReactTooltip.show(tipRef.current);
     getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted)
       .then(tasks => tasks[tasks.length - 1].deviceAccu.ids.map(getDeviceById))
       .finally(() => setTimeout(() => setOnboardingComplete(true), 120000));
@@ -26,54 +24,61 @@ export const OnboardingCompleteTip = ({ anchor, docsVersion, getDeviceById, getD
   }, []);
 
   return (
-    <div className="onboard-tip" style={anchor}>
-      <a className="tooltip onboard-icon" data-tip data-for="onboarding-complete-tip" data-event="click focus" data-event-off="dblclick" ref={tipRef}>
-        <CheckCircleIcon />
-      </a>
-      <ReactTooltip id="onboarding-complete-tip" place="bottom" type="light" effect="solid" className="content" clickable={true}>
-        <p>Great work! You updated your device with the new Release!</p>
-        <p>
-          Your device is now running the updated version of the software. At
-          <div className="flexbox centered" style={{ margin: '5px 0' }}>
-            {!url ? (
-              <Loader show={true} />
-            ) : (
-              <Button
-                className="button"
-                variant="contained"
-                href={`${url}/index.html?source=${encodeURIComponent(window.location)}`}
-                target="_blank"
-              >{`Go to ${url}`}</Button>
-            )}
+    <MenderTooltipClickable
+      className="tooltip onboard-icon onboard-tip"
+      id={onboardingSteps.ONBOARDING_FINISHED}
+      onboarding
+      startOpen
+      style={anchor}
+      PopperProps={{ style: { marginLeft: -30, marginTop: -20 } }}
+      title={
+        <div className="content">
+          <p>Great work! You updated your device with the new Release!</p>
+          <p>
+            Your device is now running the updated version of the software. At
+            <div className="flexbox centered" style={{ margin: '5px 0' }}>
+              {!url ? (
+                <Loader show={true} />
+              ) : (
+                <Button
+                  className="button"
+                  variant="contained"
+                  href={`${url}/index.html?source=${encodeURIComponent(window.location)}`}
+                  target="_blank"
+                >{`Go to ${url}`}</Button>
+              )}
+            </div>
+            you should now see &quot;Hello world&quot; in place of the webpage you saw previously. If you continue to see the webpage you saw previously you
+            might have to refresh the page.
+          </p>
+          <p>You&apos;ve now got a good foundation in how to use Mender. Look for more help hints in the UI as you go along.</p>
+          What next?
+          <div>
+            Proceed to one of the following tutorials (listed in recommended order):
+            <ol>
+              <li key="deploy-a-system-update">
+                <a href={`https://docs.mender.io/${docsVersion}get-started/deploy-a-system-update`} target="_blank" rel="noopener noreferrer">
+                  Deploy a system update
+                </a>
+              </li>
+              <li key="deploy-a-container-update">
+                <a href={`https://docs.mender.io/${docsVersion}get-started/deploy-a-container-update`} target="_blank" rel="noopener noreferrer">
+                  Deploy a container update
+                </a>
+              </li>
+            </ol>
           </div>
-          you should now see &quot;Hello world&quot; in place of the webpage you saw previously. If you continue to see the webpage you saw previously you might
-          have to refresh the page.
-        </p>
-        <p>You&apos;ve now got a good foundation in how to use Mender. Look for more help hints in the UI as you go along.</p>
-        What next?
-        <div>
-          Proceed to one of the following tutorials (listed in recommended order):
-          <ol>
-            <li key="deploy-a-system-update">
-              <a href={`https://docs.mender.io/${docsVersion}get-started/deploy-a-system-update`} target="_blank" rel="noopener noreferrer">
-                Deploy a system update
-              </a>
-            </li>
-            <li key="deploy-a-container-update">
-              <a href={`https://docs.mender.io/${docsVersion}get-started/deploy-a-container-update`} target="_blank" rel="noopener noreferrer">
-                Deploy a container update
-              </a>
-            </li>
-          </ol>
+          <div className="flexbox">
+            <div style={{ flexGrow: 1 }} />
+            <Button variant="contained" color="secondary" onClick={() => setOnboardingComplete(true)}>
+              Close
+            </Button>
+          </div>
         </div>
-        <div className="flexbox">
-          <div style={{ flexGrow: 1 }} />
-          <Button variant="contained" color="secondary" onClick={() => setOnboardingComplete(true)}>
-            Close
-          </Button>
-        </div>
-      </ReactTooltip>
-    </div>
+      }
+    >
+      <CheckCircleIcon />
+    </MenderTooltipClickable>
   );
 };
 

--- a/src/js/components/helptips/onboardingcompletetip.test.js
+++ b/src/js/components/helptips/onboardingcompletetip.test.js
@@ -31,7 +31,7 @@ describe('OnboardingCompleteTip Component', () => {
         <OnboardingCompleteTip targetUrl="https://test.com" />
       </Provider>
     );
-    const view = baseElement.firstChild.firstChild;
+    const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
   });

--- a/src/js/components/helptips/onboardingtips.js
+++ b/src/js/components/helptips/onboardingtips.js
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import ReactTooltip from 'react-tooltip';
 
 import { IconButton } from '@material-ui/core';
 import { ArrowUpward as ArrowUpwardIcon, Close as CloseIcon, Schedule as HelpIcon } from '@material-ui/icons';
@@ -10,6 +9,7 @@ import { ArrowUpward as ArrowUpwardIcon, Close as CloseIcon, Schedule as HelpIco
 import { setSnackbar } from '../../actions/appActions';
 import { setShowDismissOnboardingTipsDialog } from '../../actions/onboardingActions';
 import { setShowConnectingDialog } from '../../actions/userActions';
+import { MenderTooltipClickable } from '../common/mendertooltip';
 
 const WelcomeSnackTipComponent = ({ progress, setSnackbar }) => {
   const onClose = () => setSnackbar('');
@@ -61,29 +61,33 @@ const mapDispatchToProps = dispatch => {
 
 export const WelcomeSnackTip = connect(null, mapDispatchToProps)(WelcomeSnackTipComponent);
 
-const DevicePendingTipComponent = ({ setShowConnectingDialog, setShowDismissOnboardingTipsDialog }) => {
-  const tipRef = useRef(null);
-  useEffect(() => {
-    ReactTooltip.show(tipRef.current);
-  }, []);
-
-  return (
-    <div className="onboard-tip" style={{ left: '50%', top: '50%' }}>
-      <a className="tooltip onboard-icon" data-tip data-for="pending-device-onboarding-tip" data-event="click focus" data-event-off="dblclick" ref={tipRef}>
+const DevicePendingTipComponent = ({ setShowConnectingDialog, setShowDismissOnboardingTipsDialog }) => (
+  <div style={{ display: 'grid', placeItems: 'center' }}>
+    <MenderTooltipClickable
+      onboarding
+      interactive
+      title={
+        <>
+          <p>It may take a few moments before your device appears.</p>
+          <b className="clickable" onClick={() => setShowConnectingDialog(true)}>
+            Open the tutorial
+          </b>{' '}
+          again or <Link to="/help/get-started">go to the help pages</Link> if you have problems.
+          <div className="flexbox">
+            <div style={{ flexGrow: 1 }} />
+            <b className="clickable" onClick={() => setShowDismissOnboardingTipsDialog(true)}>
+              Dismiss
+            </b>
+          </div>
+        </>
+      }
+    >
+      <div className="onboard-icon">
         <HelpIcon />
-      </a>
-      <ReactTooltip id="pending-device-onboarding-tip" place="bottom" type="light" effect="solid" className="content" clickable={true}>
-        <p>It may take a few moments before your device appears.</p>
-        <a onClick={() => setShowConnectingDialog(true)}>Open the tutorial</a> again or <Link to="/help/get-started">go to the help pages</Link> if you have
-        problems.
-        <div className="flexbox">
-          <div style={{ flexGrow: 1 }} />
-          <a onClick={() => setShowDismissOnboardingTipsDialog(true)}>Dismiss</a>
-        </div>
-      </ReactTooltip>
-    </div>
-  );
-};
+      </div>
+    </MenderTooltipClickable>
+  </div>
+);
 
 const mappedActionCreators = dispatch => {
   return bindActionCreators({ setShowConnectingDialog, setShowDismissOnboardingTipsDialog }, dispatch);

--- a/src/js/components/settings/__snapshots__/organization.test.js.snap
+++ b/src/js/components/settings/__snapshots__/organization.test.js.snap
@@ -60,20 +60,16 @@ exports[`MyOrganization Component renders correctly 1`] = `
           <span
             class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
           >
-            <div>
-              <span
+            <div
+              class="flexbox center-aligned"
+            >
+              <div
                 style="padding-right: 10px;"
               >
                 Organization token
-              </span>
+              </div>
               <div
-                class="tooltip info"
-                currentitem="false"
-                data-event="click focus"
-                data-for="token-help"
-                data-tip="true"
-                id="token-info"
-                style="position: relative; display: inline; top: 6px;"
+                class=""
               >
                 <svg
                   aria-hidden="true"
@@ -85,20 +81,6 @@ exports[`MyOrganization Component renders correctly 1`] = `
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
                   />
                 </svg>
-              </div>
-              <div
-                class="__react_component_tooltip place-top type-dark"
-                data-id="tooltip"
-                id="token-help"
-              >
-                <h3>
-                  Organization token
-                </h3>
-                <p
-                  style="color: rgb(222, 207, 217); margin: 1em 0px;"
-                >
-                  This token is unique for your organization and ensures that only devices that you own are able to connect to your account.
-                </p>
               </div>
             </div>
           </span>
@@ -407,20 +389,16 @@ exports[`smaller components renders DeviceLimitExpansionNotification correctly 1
 `;
 
 exports[`smaller components renders OrgHeader correctly 1`] = `
-<div>
-  <span
+<div
+  class="flexbox center-aligned"
+>
+  <div
     style="padding-right: 10px;"
   >
     Organization token
-  </span>
+  </div>
   <div
-    class="tooltip info"
-    currentitem="false"
-    data-event="click focus"
-    data-for="token-help"
-    data-tip="true"
-    id="token-info"
-    style="position: relative; display: inline; top: 6px;"
+    class=""
   >
     <svg
       aria-hidden="true"
@@ -432,20 +410,6 @@ exports[`smaller components renders OrgHeader correctly 1`] = `
         d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
       />
     </svg>
-  </div>
-  <div
-    class="__react_component_tooltip place-top type-dark"
-    data-id="tooltip"
-    id="token-help"
-  >
-    <h3>
-      Organization token
-    </h3>
-    <p
-      style="color: rgb(222, 207, 217); margin: 1em 0px;"
-    >
-      This token is unique for your organization and ensures that only devices that you own are able to connect to your account.
-    </p>
   </div>
 </div>
 `;

--- a/src/js/components/settings/organization.js
+++ b/src/js/components/settings/organization.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import ReactTooltip from 'react-tooltip';
 import { Link } from 'react-router-dom';
 
 // material ui
@@ -18,26 +17,25 @@ import ExpandableAttribute from '../common/expandable-attribute';
 import CancelRequestDialog from './dialogs/cancelrequest';
 import OrganizationSettingsItem, { maxWidth, padding } from './organizationsettingsitem';
 import OrganizationPaymentSettings from './organizationpaymentsettings';
+import { MenderTooltipClickable } from '../common/mendertooltip';
 
 export const OrgHeader = () => (
-  <div>
-    <span style={{ paddingRight: 10 }}>Organization token</span>
-    <div
-      id="token-info"
-      className="tooltip info"
-      data-tip
-      style={{ position: 'relative', display: 'inline', top: '6px' }}
-      data-for="token-help"
-      data-event="click focus"
+  <div className="flexbox center-aligned">
+    <div style={{ paddingRight: 10 }}>Organization token</div>
+    <MenderTooltipClickable
+      disableHoverListener={false}
+      placement="top"
+      title={
+        <>
+          <h3>Organization token</h3>
+          <p style={{ color: colors.tooltipText, margin: '1em 0' }}>
+            This token is unique for your organization and ensures that only devices that you own are able to connect to your account.
+          </p>
+        </>
+      }
     >
       <InfoIcon />
-    </div>
-    <ReactTooltip id="token-help" globalEventOff="click" place="top" type="light" effect="solid" style={{}} className="react-tooltip">
-      <h3>Organization token</h3>
-      <p style={{ color: colors.tooltipText, margin: '1em 0' }}>
-        This token is unique for your organization and ensures that only devices that you own are able to connect to your account.
-      </p>
-    </ReactTooltip>
+    </MenderTooltipClickable>
   </div>
 );
 

--- a/src/js/components/user-management/login.js
+++ b/src/js/components/user-management/login.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Cookies from 'universal-cookie';
-import ReactTooltip from 'react-tooltip';
 
 import { Button } from '@material-ui/core';
 import { Help as HelpIcon } from '@material-ui/icons';
@@ -20,6 +19,7 @@ import FormCheckbox from '../common/forms/formcheckbox';
 
 import { OAuth2Providers } from './oauth2providers';
 import { getCurrentUser } from '../../selectors';
+import { MenderTooltipClickable } from '../common/mendertooltip';
 
 const cookies = new Cookies();
 
@@ -75,7 +75,7 @@ export const Login = ({ currentUser, isHosted, loginUser, logoutUser, setSnackba
   if (twoFARef.current) {
     twoFAAnchor = {
       right: -120,
-      top: twoFARef.current.parentElement.parentElement.offsetTop + twoFARef.current.parentElement.offsetHeight / 2
+      top: twoFARef.current.parentElement.parentElement.offsetTop + twoFARef.current.parentElement.parentElement.offsetHeight / 2
     };
   }
 
@@ -129,15 +129,20 @@ export const Login = ({ currentUser, isHosted, loginUser, logoutUser, setSnackba
       {isHosted && (
         <>
           {twoFARef.current && (
-            <div>
-              <div id="onboard-6" className="tooltip info" data-tip data-for="2fa-tip" data-event="click focus" style={twoFAAnchor}>
-                <HelpIcon />
-              </div>
-              <ReactTooltip id="2fa-tip" globalEventOff="click" place="right" effect="solid" className="react-tooltip info" style={{ maxWidth: 300 }}>
-                Two Factor Authentication is enabled for your account. If you haven&apos;t set up a 3rd party authentication app with a verification code,
-                please contact an administrator.
-              </ReactTooltip>
-            </div>
+            <MenderTooltipClickable
+              disableHoverListener={false}
+              placement="right"
+              className="absolute"
+              style={twoFAAnchor}
+              title={
+                <div style={{ maxWidth: 300 }}>
+                  Two Factor Authentication is enabled for your account. If you haven&apos;t set up a 3rd party authentication app with a verification code,
+                  please contact an administrator.
+                </div>
+              }
+            >
+              <HelpIcon />
+            </MenderTooltipClickable>
           )}
           <div className="margin-top text-muted">
             <div className="flexbox centered">

--- a/src/js/themes/mender-theme.js
+++ b/src/js/themes/mender-theme.js
@@ -17,6 +17,7 @@ export const colors = {
   borderColor: '#e0e0e0',
   expansionBackground: '#f7f7f7',
   disabledColor: 'rgba(0, 0, 0, 0.54)',
+  placeholder: '#e7e7e7',
   errorStyleColor: '#ab1000',
   successStyleColor: green,
   red: '#8f0d0d',

--- a/src/js/utils/onboardingmanager.js
+++ b/src/js/utils/onboardingmanager.js
@@ -125,7 +125,7 @@ export const onboardingSteps = {
     progress: 2
   },
   [stepNames.DEPLOYMENTS_PAST]: {
-    condition: { extra: () => !window.location.hash.includes(DEPLOYMENT_STATES.finished) },
+    condition: { min: stepNames.DEPLOYMENTS_INPROGRESS, extra: () => !window.location.hash.includes(DEPLOYMENT_STATES.finished) },
     component: DeploymentsPast,
     progress: 3
   },
@@ -188,7 +188,7 @@ export const onboardingSteps = {
     specialComponent: <WelcomeSnackTip progress={4} />
   },
   [stepNames.ONBOARDING_CANCELED]: {
-    condition: () => true,
+    condition: { extra: () => true },
     specialComponent: <div />,
     progress: 3
   }
@@ -196,15 +196,12 @@ export const onboardingSteps = {
 
 const getOnboardingStepCompleted = (id, progress, complete, showHelptips, showTips) => {
   const keys = Object.keys(onboardingSteps);
-  const { min = id, max = id, extra } = Object.entries(onboardingSteps).reduce(
-    (accu, [key, value]) => {
-      if (key === id) {
-        return value.condition;
-      }
-      return accu;
-    },
-    { min: '' }
-  );
+  const { min = id, max = id, extra } = Object.entries(onboardingSteps).reduce((accu, [key, value]) => {
+    if (key === id) {
+      return value.condition;
+    }
+    return accu;
+  }, {});
   const progressIndex = keys.findIndex(step => step === progress);
   return (
     !complete &&

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -106,8 +106,6 @@ a.warning:hover {
 }
 
 .box-sizing (@type: border-box) {
-  -webkit-box-sizing: @type;
-  -moz-box-sizing: @type;
   box-sizing: @type;
 }
 
@@ -419,6 +417,7 @@ ul.link-list {
 #trialVersion,
 #announcement {
   font-size: 14px;
+  height: 100%;
   max-height: 56px;
   min-width: 164px;
   overflow: hidden;
@@ -696,6 +695,16 @@ ul.link-list {
   z-index: 1000;
   color: @placeholder;
   border: white 1px solid;
+  &.top,
+  &.bottom {
+    .animation(bouncedownup 1.3s infinite);
+  }
+  &.left {
+    .animation(bouncerightleft 1.3s infinite);
+  }
+  &.right {
+    .animation(bounceleftright 1.3s infinite);
+  }
 }
 
 .dialog-content {
@@ -725,68 +734,32 @@ ul.link-list {
       margin-bottom: 2 * @defaultGutterWidth;
     }
   }
-  .react-tooltip {
-    width: 300px;
-  }
 }
 
 .onboard-tip {
   pointer-events: auto;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
   position: absolute;
-  z-index: 1500;
-
+  z-index: 1600;
   a {
     color: @placeholder;
     text-decoration: underline;
   }
-  .onboard-icon {
-    &.top,
-    &.bottom {
-      .animation(bouncedownup 1.3s infinite);
-    }
-    &.left {
-      .animation(bouncerightleft 1.3s infinite);
-    }
-    &.right {
-      .animation(bounceleftright 1.3s infinite);
-    }
+}
+.MuiTooltip-tooltip .content {
+  > div:first-of-type {
+    padding-top: @defaultGutterWidth;
+    padding-bottom: 10px;
   }
-
-  .__react_component_tooltip.content {
-    background-color: @linkgreen;
-    font-size: 14px;
-    color: @placeholder;
-    margin: 0;
-    width: 350px;
-    padding: 12px 18px;
-    text-align: left;
-    &.top {
-      margin-top: @defaultGutterWidth;
-    }
-    &.bottom {
-      margin-top: -1 * @defaultGutterWidth;
-    }
-    &.right {
-      margin-left: -1 * @defaultGutterWidth;
-    }
-    &.left {
-      margin-left: @defaultGutterWidth;
-    }
-    > div:first-of-type {
-      padding-top: @defaultGutterWidth;
-      padding-bottom: 10px;
-    }
-    .flexbox {
-      justify-content: space-between;
-    }
-    .centered {
-      justify-content: center;
-    }
-    .button {
-      color: @text;
-      text-decoration: inherit;
-    }
+  .flexbox {
+    justify-content: space-between;
+  }
+  .centered {
+    justify-content: center;
+  }
+  .button {
+    color: @text;
+    text-decoration: inherit;
   }
 }
 .onboard-snack {
@@ -904,47 +877,6 @@ ul.link-list {
   }
   .link {
     font-size: small;
-  }
-}
-
-.react-tooltip {
-  background-color: @mendermaroon !important;
-  pointer-events: auto !important;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
-  text-align: left;
-  max-width: 600px;
-  color: @textsecondary !important;
-  &.info {
-    max-width: 300px;
-    color: @textmuted !important;
-    background-color: @placeholder !important;
-    &.place-top:after {
-      border-top-color: @placeholder !important;
-    }
-  }
-  p {
-    font-size: 14px;
-  }
-
-  a {
-    color: @linksecondary;
-  }
-
-  hr {
-    margin-bottom: @defaultGutterWidth;
-  }
-
-  &.place-bottom:after {
-    border-bottom-color: @mendermaroon !important;
-  }
-  &.place-right:after {
-    border-right-color: @mendermaroon !important;
-  }
-  &.place-left:after {
-    border-left-color: @mendermaroon !important;
-  }
-  &.place-top:after {
-    border-top-color: @mendermaroon !important;
   }
 }
 
@@ -2316,7 +2248,7 @@ span.day {
   }
 }
 
-@keyframes bouncerightleft {
+@keyframes bounceleftright {
   0% {
     left: 0;
     animation-timing-function: ease-out;
@@ -2369,57 +2301,33 @@ span.day {
 
 /* LESS MIXINS */
 .flip-horizontal {
-  -moz-transform: scale(-1, 1);
-  -webkit-transform: scale(-1, 1);
-  -o-transform: scale(-1, 1);
-  -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 
 .scale (@factor) {
-  -webkit-transform: scale(@factor);
-  -moz-transform: scale(@factor);
-  -ms-transform: scale(@factor);
-  -o-transform: scale(@factor);
+  transform: scale(@factor);
 }
 
 .transition (@transition) {
-  -webkit-transition: @transition;
-  -moz-transition: @transition;
-  -ms-transition: @transition;
-  -o-transition: @transition;
+  transition: @transition;
 }
 
 .animation (@animation) {
-  -webkit-animation: @animation;
-  -moz-animation: @animation;
-  -ms-animation: @animation;
-  -o-animation: @animation;
+  animation: @animation;
 }
 
 .opacity (@opacity: 0.5) {
-  -webkit-opacity: @opacity;
-  -moz-opacity: @opacity;
   opacity: @opacity;
 }
 
 .rotateX (@deg) {
-  -webkit-transform: rotateX(@deg);
-  -moz-transform: rotateX(@deg);
-  -ms-transform: rotateX(@deg);
-  -o-transform: rotateX(@deg);
+  transform: rotateX(@deg);
 }
 .rotateY (@deg) {
-  -webkit-transform: rotateY(@deg);
-  -moz-transform: rotateY(@deg);
-  -ms-transform: rotateY(@deg);
-  -o-transform: rotateY(@deg);
+  transform: rotateY(@deg);
 }
 .rotate (@deg) {
-  -webkit-transform: rotate(@deg);
-  -moz-transform: rotate(@deg);
-  -ms-transform: rotate(@deg);
-  -o-transform: rotate(@deg);
+  transform: rotate(@deg);
 }
 
 @keyframes highlight {


### PR DESCRIPTION
the react-tooltip removal is needed to allow keeping up with react releases - or change all of the tooltips to the next major version in these (which would also come with more code changes)