### PR TITLE
MEN-4771 xtermjs interprets string as UTF-16

### DIFF
--- a/src/js/components/devices/troubleshoot/terminal.js
+++ b/src/js/components/devices/troubleshoot/terminal.js
@@ -171,7 +171,7 @@ export const Terminal = ({
           }
         }
         case MessageTypes.Shell:
-          return term.write(byteArrayToString(body));
+          return term.write(new Uint8Array(body));
         case MessageTypes.Stop:
           return cleanupSocket();
         case MessageTypes.Ping: {


### PR DESCRIPTION
According to: https://xtermjs.org/docs/guides/encoding
string data passed to write is interpreted as UTF-16 (!)

Changelog: title
Signed-off-by: Peter Grzybowski <peter@northern.tech>
(cherry picked from commit 1c3de9f30782b7cd4c6834dcf83c138f5e6d2ed2)