### PR TITLE
MEN-4411: Show dates formatted according to user locale

### DIFF
--- a/src/js/components/artifacts/artifactPayload.js
+++ b/src/js/components/artifacts/artifactPayload.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import Time from 'react-time';
 import { List, ListItem, ListItemText, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import { FileSize, getFormattedSize } from './../../helpers';
 import { colors } from '../../themes/mender-theme';
-import LocaleFormatString from '../common/timeformat';
+import LocaleTime from '../common/localetime';
 
 export const inlineHeadingStyle = { position: 'absolute', background: colors.expansionBackground, top: -35, padding: 10 };
 
@@ -70,7 +69,7 @@ export const ArtifactPayload = ({ index, payload: { files: payloadFiles, meta_da
                   <TableCell>{file.name}</TableCell>
                   <TableCell style={{ wordBreak: 'break-word' }}>{file.checksum}</TableCell>
                   <TableCell>
-                    <Time value={file.date} format={LocaleFormatString()} />
+                    <LocaleTime value={file.date} />
                   </TableCell>
                   <TableCell>
                     <FileSize fileSize={file.size} />

--- a/src/js/components/artifacts/artifactPayload.js
+++ b/src/js/components/artifacts/artifactPayload.js
@@ -3,6 +3,7 @@ import Time from 'react-time';
 import { List, ListItem, ListItemText, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import { FileSize, getFormattedSize } from './../../helpers';
 import { colors } from '../../themes/mender-theme';
+import LocaleFormatString from '../common/timeformat';
 
 export const inlineHeadingStyle = { position: 'absolute', background: colors.expansionBackground, top: -35, padding: 10 };
 
@@ -69,7 +70,7 @@ export const ArtifactPayload = ({ index, payload: { files: payloadFiles, meta_da
                   <TableCell>{file.name}</TableCell>
                   <TableCell style={{ wordBreak: 'break-word' }}>{file.checksum}</TableCell>
                   <TableCell>
-                    <Time value={file.date} format="YYYY-MM-DD HH:mm" />
+                    <Time value={file.date} format={LocaleFormatString()} />
                   </TableCell>
                   <TableCell>
                     <FileSize fileSize={file.size} />

--- a/src/js/components/artifacts/releaserepositoryitem.js
+++ b/src/js/components/artifacts/releaserepositoryitem.js
@@ -10,6 +10,7 @@ import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
 import { formatTime, FileSize } from '../../helpers';
 import { colors } from '../../themes/mender-theme';
 import SelectedArtifact from './selectedartifact';
+import LocaleFormatString from '../common/timeformat';
 
 export const ReleaseRepositoryItem = ({ artifact, expanded, index, itemRef, onEdit, onExpanded, onRowSelection }) => {
   useEffect(() => {
@@ -32,7 +33,7 @@ export const ReleaseRepositoryItem = ({ artifact, expanded, index, itemRef, onEd
           <Tooltip title={compatible} placement="top-start">
             <div className="text-overflow">{compatible}</div>
           </Tooltip>
-          <Time value={formatTime(artifact.modified)} format="YYYY-MM-DD HH:mm" />
+          <Time value={formatTime(artifact.modified)} format={LocaleFormatString()} />
           <div style={{ maxWidth: '100vw' }}>{artifactType}</div>
           <FileSize fileSize={artifact.size} />
           <IconButton className="expandButton">{expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}</IconButton>

--- a/src/js/components/artifacts/releaserepositoryitem.js
+++ b/src/js/components/artifacts/releaserepositoryitem.js
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import Time from 'react-time';
 
 // material ui
 import { Accordion, AccordionDetails, AccordionSummary, IconButton, Tooltip } from '@material-ui/core';
@@ -10,7 +9,7 @@ import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
 import { formatTime, FileSize } from '../../helpers';
 import { colors } from '../../themes/mender-theme';
 import SelectedArtifact from './selectedartifact';
-import LocaleFormatString from '../common/timeformat';
+import LocaleTime from '../common/localetime';
 
 export const ReleaseRepositoryItem = ({ artifact, expanded, index, itemRef, onEdit, onExpanded, onRowSelection }) => {
   useEffect(() => {
@@ -33,7 +32,7 @@ export const ReleaseRepositoryItem = ({ artifact, expanded, index, itemRef, onEd
           <Tooltip title={compatible} placement="top-start">
             <div className="text-overflow">{compatible}</div>
           </Tooltip>
-          <Time value={formatTime(artifact.modified)} format={LocaleFormatString()} />
+          <LocaleTime value={formatTime(artifact.modified)} />
           <div style={{ maxWidth: '100vw' }}>{artifactType}</div>
           <FileSize fileSize={artifact.size} />
           <IconButton className="expandButton">{expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}</IconButton>

--- a/src/js/components/auditlogs/auditlogslist.js
+++ b/src/js/components/auditlogs/auditlogslist.js
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import Time from 'react-time';
 import { Link } from 'react-router-dom';
 
 import { ArrowRightAlt as ArrowRightAltIcon, Sort as SortIcon } from '@material-ui/icons';
@@ -8,7 +7,7 @@ import Loader from '../common/loader';
 import Pagination from '../common/pagination';
 import EventDetailsDrawer from './eventdetailsdrawer';
 import { SORTING_OPTIONS } from '../../constants/appConstants';
-import LocaleFormatString from '../common/timeformat';
+import { LocaleTime } from '../common/localetime';
 
 export const defaultRowsPerPage = 20;
 
@@ -80,7 +79,7 @@ const ChangeDetailsDescriptor = (item, index) => {
   const Comp = mapChangeToContent(item).component;
   return <Comp key={`${item.time}-${index}`} item={item} />;
 };
-const TimeWrapper = (item, index) => <Time key={`${item.time}-${index}`} value={item.time} format={LocaleFormatString()} />;
+const TimeWrapper = (item, index) => <LocaleTime key={`${item.time}-${index}`} value={item.time} />;
 
 const auditLogColumns = [
   { title: 'User', sortable: false, render: UserDescriptor },

--- a/src/js/components/auditlogs/auditlogslist.js
+++ b/src/js/components/auditlogs/auditlogslist.js
@@ -8,6 +8,7 @@ import Loader from '../common/loader';
 import Pagination from '../common/pagination';
 import EventDetailsDrawer from './eventdetailsdrawer';
 import { SORTING_OPTIONS } from '../../constants/appConstants';
+import LocaleFormatString from '../common/timeformat';
 
 export const defaultRowsPerPage = 20;
 
@@ -79,7 +80,7 @@ const ChangeDetailsDescriptor = (item, index) => {
   const Comp = mapChangeToContent(item).component;
   return <Comp key={`${item.time}-${index}`} item={item} />;
 };
-const TimeWrapper = (item, index) => <Time key={`${item.time}-${index}`} value={item.time} format="YYYY-MM-DD HH:mm" />;
+const TimeWrapper = (item, index) => <Time key={`${item.time}-${index}`} value={item.time} format={LocaleFormatString()} />;
 
 const auditLogColumns = [
   { title: 'User', sortable: false, render: UserDescriptor },

--- a/src/js/components/auditlogs/auditlogslist.js
+++ b/src/js/components/auditlogs/auditlogslist.js
@@ -7,7 +7,7 @@ import Loader from '../common/loader';
 import Pagination from '../common/pagination';
 import EventDetailsDrawer from './eventdetailsdrawer';
 import { SORTING_OPTIONS } from '../../constants/appConstants';
-import { LocaleTime } from '../common/localetime';
+import LocaleTime from '../common/localetime';
 
 export const defaultRowsPerPage = 20;
 

--- a/src/js/components/auditlogs/eventdetails/portforward.js
+++ b/src/js/components/auditlogs/eventdetails/portforward.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import Time from 'react-time';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
 
@@ -8,7 +7,7 @@ import { getDeviceById, getSessionDetails } from '../../../actions/deviceActions
 import { getIdAttribute } from '../../../selectors';
 import theme from '../../../themes/mender-theme';
 import Loader from '../../common/loader';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 import DeviceDetails, { DetailInformation } from './devicedetails';
 
 momentDurationFormatSetup(moment);
@@ -36,8 +35,8 @@ export const PortForward = ({ device, idAttribute, item, getDeviceById, getSessi
 
   const sessionMeta = {
     'Session ID': item.meta.session_id[0],
-    'Start time': <Time value={sessionDetails.start} format={LocaleFormatString()} />,
-    'End time': <Time value={sessionDetails.end} format={LocaleFormatString()} />,
+    'Start time': <LocaleTime value={sessionDetails.start} />,
+    'End time': <LocaleTime value={sessionDetails.end} />,
     'Duration': moment.duration(moment(sessionDetails.end).diff(sessionDetails.start)).format('*hh:*mm:ss:SSS'),
     User: item.actor.email
   };

--- a/src/js/components/auditlogs/eventdetails/portforward.js
+++ b/src/js/components/auditlogs/eventdetails/portforward.js
@@ -8,6 +8,7 @@ import { getDeviceById, getSessionDetails } from '../../../actions/deviceActions
 import { getIdAttribute } from '../../../selectors';
 import theme from '../../../themes/mender-theme';
 import Loader from '../../common/loader';
+import LocaleFormatString from '../../common/timeformat';
 import DeviceDetails, { DetailInformation } from './devicedetails';
 
 momentDurationFormatSetup(moment);
@@ -35,8 +36,8 @@ export const PortForward = ({ device, idAttribute, item, getDeviceById, getSessi
 
   const sessionMeta = {
     'Session ID': item.meta.session_id[0],
-    'Start time': <Time value={sessionDetails.start} format="YYYY-MM-DD HH:mm" />,
-    'End time': <Time value={sessionDetails.end} format="YYYY-MM-DD HH:mm" />,
+    'Start time': <Time value={sessionDetails.start} format={LocaleFormatString()} />,
+    'End time': <Time value={sessionDetails.end} format={LocaleFormatString()} />,
     'Duration': moment.duration(moment(sessionDetails.end).diff(sessionDetails.start)).format('*hh:*mm:ss:SSS'),
     User: item.actor.email
   };

--- a/src/js/components/auditlogs/eventdetails/terminalsession.js
+++ b/src/js/components/auditlogs/eventdetails/terminalsession.js
@@ -8,6 +8,7 @@ import { getDeviceById, getSessionDetails } from '../../../actions/deviceActions
 import { getIdAttribute } from '../../../selectors';
 import theme from '../../../themes/mender-theme';
 import Loader from '../../common/loader';
+import LocaleFormatString from '../../common/timeformat';
 import DeviceDetails, { DetailInformation } from './devicedetails';
 import TerminalPlayer from './terminalplayer';
 
@@ -36,8 +37,8 @@ export const TerminalSession = ({ device, idAttribute, item, getDeviceById, getS
 
   const sessionMeta = {
     'Session ID': item.meta.session_id[0],
-    'Start time': <Time value={sessionDetails.start} format="YYYY-MM-DD HH:mm" />,
-    'End time': <Time value={sessionDetails.end} format="YYYY-MM-DD HH:mm" />,
+    'Start time': <Time value={sessionDetails.start} format={LocaleFormatString()} />,
+    'End time': <Time value={sessionDetails.end} format={LocaleFormatString()} />,
     'Duration': moment.duration(moment(sessionDetails.end).diff(sessionDetails.start)).format('*hh:*mm:ss:SSS'),
     User: item.actor.email
   };

--- a/src/js/components/auditlogs/eventdetails/terminalsession.js
+++ b/src/js/components/auditlogs/eventdetails/terminalsession.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import Time from 'react-time';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
 
@@ -8,7 +7,7 @@ import { getDeviceById, getSessionDetails } from '../../../actions/deviceActions
 import { getIdAttribute } from '../../../selectors';
 import theme from '../../../themes/mender-theme';
 import Loader from '../../common/loader';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 import DeviceDetails, { DetailInformation } from './devicedetails';
 import TerminalPlayer from './terminalplayer';
 
@@ -37,8 +36,8 @@ export const TerminalSession = ({ device, idAttribute, item, getDeviceById, getS
 
   const sessionMeta = {
     'Session ID': item.meta.session_id[0],
-    'Start time': <Time value={sessionDetails.start} format={LocaleFormatString()} />,
-    'End time': <Time value={sessionDetails.end} format={LocaleFormatString()} />,
+    'Start time': <LocaleTime value={sessionDetails.start} />,
+    'End time': <LocaleTime value={sessionDetails.end} />,
     'Duration': moment.duration(moment(sessionDetails.end).diff(sessionDetails.start)).format('*hh:*mm:ss:SSS'),
     User: item.actor.email
   };

--- a/src/js/components/common/localetime.js
+++ b/src/js/components/common/localetime.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Time from 'react-time';
+import LocaleFormatString from './timeformat';
+
+export function LocaleTime(props) {
+  return <Time {...props} format={LocaleFormatString()} />;
+}
+export default LocaleTime;

--- a/src/js/components/common/relative-time.js
+++ b/src/js/components/common/relative-time.js
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import Time from 'react-time';
 import { Tooltip } from '@material-ui/core';
+import LocaleFormatString from './timeformat';
 
 const cutoff = -5 * 60;
 
@@ -22,7 +23,8 @@ export default class RelativeTime extends React.Component {
   render() {
     const { updateTime } = this.state;
     const { className, shouldCount = 'both' } = this.props;
-    let timeDisplay = updateTime ? <Time className={className} value={updateTime} format="YYYY-MM-DD HH:mm" /> : <div className={className}>-</div>;
+
+    let timeDisplay = updateTime ? <Time className={className} value={updateTime} format={LocaleFormatString()} /> : <div className={className}>-</div>;
     const diffSeconds = updateTime ? updateTime.diff(moment(), 'seconds') : 0;
     if (
       updateTime &&

--- a/src/js/components/common/relative-time.js
+++ b/src/js/components/common/relative-time.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import Time from 'react-time';
 import { Tooltip } from '@material-ui/core';
-import LocaleFormatString from './timeformat';
+import LocaleTime from './localetime';
 
 const cutoff = -5 * 60;
 
@@ -24,7 +23,7 @@ export default class RelativeTime extends React.Component {
     const { updateTime } = this.state;
     const { className, shouldCount = 'both' } = this.props;
 
-    let timeDisplay = updateTime ? <Time className={className} value={updateTime} format={LocaleFormatString()} /> : <div className={className}>-</div>;
+    let timeDisplay = updateTime ? <LocaleTime className={className} value={updateTime} /> : <div className={className}>-</div>;
     const diffSeconds = updateTime ? updateTime.diff(moment(), 'seconds') : 0;
     if (
       updateTime &&

--- a/src/js/components/common/timeformat.js
+++ b/src/js/components/common/timeformat.js
@@ -1,11 +1,16 @@
 import moment from 'moment';
+// import { getUserSettings } from '../../selectors';
 
-export function LocaleFormatString(stripTime = false) {
-  console.log(moment.locale());
+export function LocaleFormatString(stripTime) {
+  // Get the saved user locale
+  console.log('Current user locale: ' + moment.locale());
+  // const { locale = 'automatic' } = getUserSettings();
+  // console.log('Stored locale: ' + locale);
+  var curLocale = moment.localeData('de');
   if (stripTime) {
-    return moment().creationData().locale._longDateFormat.L;
+    return curLocale.longDateFormat('L');
   }
-  return moment().creationData().locale._longDateFormat.L + ' ' + moment().creationData().locale._longDateFormat.LT;
+  return curLocale.longDateFormat('L') + ' ' + curLocale.longDateFormat('LT');
 }
 
 export default LocaleFormatString;

--- a/src/js/components/common/timeformat.js
+++ b/src/js/components/common/timeformat.js
@@ -1,0 +1,11 @@
+import moment from 'moment';
+
+export function LocaleFormatString(stripTime = false) {
+  console.log(moment.locale());
+  if (stripTime) {
+    return moment().creationData().locale._longDateFormat.L;
+  }
+  return moment().creationData().locale._longDateFormat.L + ' ' + moment().creationData().locale._longDateFormat.LT;
+}
+
+export default LocaleFormatString;

--- a/src/js/components/dashboard/widgets/completeddeployments.js
+++ b/src/js/components/dashboard/widgets/completeddeployments.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import Time from 'react-time';
 
 // material ui
 import { BaseWidget } from './baseWidget';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 const headerStyle = { justifyContent: 'flex-end' };
 const countStyle = { fontSize: 36, marginRight: '1vw' };
@@ -20,7 +19,7 @@ export const CompletedDeployments = props => {
     counter: (
       <div className="completionInfo">
         <div>since last login on</div>
-        <Time value={cutoffDate} format={LocaleFormatString(true)} />
+        <LocaleTime value={cutoffDate} />
       </div>
     ),
     targetLabel: 'View reports'

--- a/src/js/components/dashboard/widgets/completeddeployments.js
+++ b/src/js/components/dashboard/widgets/completeddeployments.js
@@ -3,6 +3,7 @@ import Time from 'react-time';
 
 // material ui
 import { BaseWidget } from './baseWidget';
+import LocaleFormatString from '../../common/timeformat';
 
 const headerStyle = { justifyContent: 'flex-end' };
 const countStyle = { fontSize: 36, marginRight: '1vw' };
@@ -19,7 +20,7 @@ export const CompletedDeployments = props => {
     counter: (
       <div className="completionInfo">
         <div>since last login on</div>
-        <Time value={cutoffDate} format="YYYY-MM-DD" />
+        <Time value={cutoffDate} format={LocaleFormatString(true)} />
       </div>
     ),
     targetLabel: 'View reports'

--- a/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
+++ b/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
@@ -6,7 +6,7 @@ import { Button, LinearProgress, TableCell, TableRow } from '@material-ui/core';
 
 import { formatTime } from '../../../helpers';
 import DeviceIdentityDisplay from '../../common/deviceidentity';
-import { LocaleTime } from '../../common/localetime';
+import LocaleTime from '../../common/localetime';
 
 const stateTitleMap = {
   noartifact: 'No compatible artifact found',

--- a/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
+++ b/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
@@ -7,6 +7,7 @@ import { Button, LinearProgress, TableCell, TableRow } from '@material-ui/core';
 
 import { formatTime } from '../../../helpers';
 import DeviceIdentityDisplay from '../../common/deviceidentity';
+import LocaleFormatString from '../../common/timeformat';
 
 const stateTitleMap = {
   noartifact: 'No compatible artifact found',
@@ -53,8 +54,8 @@ const DeploymentDeviceListItem = ({ device, idAttribute, viewLog, retries: maxRe
       </TableCell>
       <TableCell>{deviceTypes.length ? deviceTypes.join(',') : '-'}</TableCell>
       <TableCell>{currentArtifactLink}</TableCell>
-      <TableCell>{created ? <Time value={formatTime(created)} format="YYYY-MM-DD HH:mm" /> : '-'}</TableCell>
-      <TableCell>{finished ? <Time value={formatTime(finished)} format="YYYY-MM-DD HH:mm" /> : '-'}</TableCell>
+      <TableCell>{created ? <Time value={formatTime(created)} format={LocaleFormatString()} /> : '-'}</TableCell>
+      <TableCell>{finished ? <Time value={formatTime(finished)} format={LocaleFormatString()} /> : '-'}</TableCell>
       {retries ? (
         <TableCell>
           {attempts || 1}/{(retries || maxRetries) + 1}

--- a/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
+++ b/src/js/components/deployments/deployment-report/deploymentdevicelistitem.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Time from 'react-time';
 
 // material ui
 import { Button, LinearProgress, TableCell, TableRow } from '@material-ui/core';
 
 import { formatTime } from '../../../helpers';
 import DeviceIdentityDisplay from '../../common/deviceidentity';
-import LocaleFormatString from '../../common/timeformat';
+import { LocaleTime } from '../../common/localetime';
 
 const stateTitleMap = {
   noartifact: 'No compatible artifact found',
@@ -54,8 +53,8 @@ const DeploymentDeviceListItem = ({ device, idAttribute, viewLog, retries: maxRe
       </TableCell>
       <TableCell>{deviceTypes.length ? deviceTypes.join(',') : '-'}</TableCell>
       <TableCell>{currentArtifactLink}</TableCell>
-      <TableCell>{created ? <Time value={formatTime(created)} format={LocaleFormatString()} /> : '-'}</TableCell>
-      <TableCell>{finished ? <Time value={formatTime(finished)} format={LocaleFormatString()} /> : '-'}</TableCell>
+      <TableCell>{created ? <LocaleTime value={formatTime(created)} /> : '-'}</TableCell>
+      <TableCell>{finished ? <LocaleTime value={formatTime(finished)} /> : '-'}</TableCell>
       {retries ? (
         <TableCell>
           {attempts || 1}/{(retries || maxRetries) + 1}

--- a/src/js/components/deployments/deployment-report/overview.js
+++ b/src/js/components/deployments/deployment-report/overview.js
@@ -10,7 +10,7 @@ import successImage from '../../../../assets/img/largeSuccess.png';
 import failImage from '../../../../assets/img/largeFail.png';
 import { DEPLOYMENT_STATES, DEPLOYMENT_TYPES } from '../../../constants/deploymentConstants';
 import { TwoColumnData } from '../../common/configurationobject';
-import { LocaleTime } from '../../common/localetime';
+import LocaleTime from '../../common/localetime';
 import theme from '../../../themes/mender-theme';
 import { defaultColumnDataProps } from '../report';
 

--- a/src/js/components/deployments/deployment-report/overview.js
+++ b/src/js/components/deployments/deployment-report/overview.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Time from 'react-time';
 import pluralize from 'pluralize';
 import isUUID from 'validator/lib/isUUID';
 
@@ -11,7 +10,7 @@ import successImage from '../../../../assets/img/largeSuccess.png';
 import failImage from '../../../../assets/img/largeFail.png';
 import { DEPLOYMENT_STATES, DEPLOYMENT_TYPES } from '../../../constants/deploymentConstants';
 import { TwoColumnData } from '../../common/configurationobject';
-import LocaleFormatString from '../../common/timeformat';
+import { LocaleTime } from '../../common/localetime';
 import theme from '../../../themes/mender-theme';
 import { defaultColumnDataProps } from '../report';
 
@@ -66,7 +65,7 @@ export const DeploymentOverview = ({ creator, deployment, onScheduleClick }) => 
   const createdBy = creator ? { 'Created by': creator } : {};
   const deploymentInfo2 = {
     ...createdBy,
-    'Created at': <Time value={creationTime} format={LocaleFormatString()} />
+    'Created at': <LocaleTime value={creationTime} />
   };
 
   return (

--- a/src/js/components/deployments/deployment-report/overview.js
+++ b/src/js/components/deployments/deployment-report/overview.js
@@ -11,6 +11,7 @@ import successImage from '../../../../assets/img/largeSuccess.png';
 import failImage from '../../../../assets/img/largeFail.png';
 import { DEPLOYMENT_STATES, DEPLOYMENT_TYPES } from '../../../constants/deploymentConstants';
 import { TwoColumnData } from '../../common/configurationobject';
+import LocaleFormatString from '../../common/timeformat';
 import theme from '../../../themes/mender-theme';
 import { defaultColumnDataProps } from '../report';
 
@@ -65,7 +66,7 @@ export const DeploymentOverview = ({ creator, deployment, onScheduleClick }) => 
   const createdBy = creator ? { 'Created by': creator } : {};
   const deploymentInfo2 = {
     ...createdBy,
-    'Created at': <Time value={creationTime} format="YYYY-MM-DD HH:mm" />
+    'Created at': <Time value={creationTime} format={LocaleFormatString()} />
   };
 
   return (

--- a/src/js/components/deployments/deployment-report/rolloutschedule.js
+++ b/src/js/components/deployments/deployment-report/rolloutschedule.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Time from 'react-time';
 import pluralize from 'pluralize';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
@@ -10,7 +9,7 @@ import { ArrowForward } from '@material-ui/icons';
 import { formatTime, getPhaseDeviceCount, getRemainderPercent, groupDeploymentStats } from '../../../helpers';
 import theme, { colors } from '../../../themes/mender-theme';
 import { TwoColumnData } from '../../common/configurationobject';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 import { getPhaseStartTime } from '../createdeployment';
 import { ProgressChart } from '../progressChart';
 import { defaultColumnDataProps } from '../report';
@@ -49,7 +48,7 @@ export const RolloutSchedule = ({ deployment, innerRef, onAbort, onUpdateControl
   if (now.isSameOrAfter(currentPhaseStartTime)) {
     currentPhaseTime = currentPhaseIndex + 1;
   }
-  const endTime = finished ? <Time value={formatTime(finished)} format={LocaleFormatString()} /> : filterId ? 'N/A' : '-';
+  const endTime = finished ? <LocaleTime value={formatTime(finished)} /> : filterId ? 'N/A' : '-';
   return (
     <>
       <h4 className="dashboard-header margin-top-large" ref={innerRef}>
@@ -61,7 +60,7 @@ export const RolloutSchedule = ({ deployment, innerRef, onAbort, onUpdateControl
             <TwoColumnData
               {...defaultColumnDataProps}
               config={{
-                'Start time': <Time value={formatTime(creationTime)} format={LocaleFormatString()} />,
+                'Start time': <LocaleTime value={formatTime(creationTime)} />,
                 'Current phase': currentPhaseTime
               }}
             />
@@ -95,7 +94,7 @@ export const RolloutSchedule = ({ deployment, innerRef, onAbort, onUpdateControl
           const deviceCountText = !filterId ? ` (${deviceCount} ${pluralize('device', deviceCount)})` : '';
           const startTime = phase.start_ts ?? getPhaseStartTime(phases, index, start_time);
           const phaseObject = {
-            'Start time': <Time value={startTime} format={LocaleFormatString()} />,
+            'Start time': <LocaleTime value={startTime} />,
             'Batch size': <div className="text-muted">{`${phase.batch_size}%${deviceCountText}`}</div>
           };
           let phaseTitle = status !== DEPLOYMENT_STATES.scheduled ? <div className="text-muted">Complete</div> : null;

--- a/src/js/components/deployments/deployment-report/rolloutschedule.js
+++ b/src/js/components/deployments/deployment-report/rolloutschedule.js
@@ -10,6 +10,7 @@ import { ArrowForward } from '@material-ui/icons';
 import { formatTime, getPhaseDeviceCount, getRemainderPercent, groupDeploymentStats } from '../../../helpers';
 import theme, { colors } from '../../../themes/mender-theme';
 import { TwoColumnData } from '../../common/configurationobject';
+import LocaleFormatString from '../../common/timeformat';
 import { getPhaseStartTime } from '../createdeployment';
 import { ProgressChart } from '../progressChart';
 import { defaultColumnDataProps } from '../report';
@@ -48,7 +49,7 @@ export const RolloutSchedule = ({ deployment, innerRef, onAbort, onUpdateControl
   if (now.isSameOrAfter(currentPhaseStartTime)) {
     currentPhaseTime = currentPhaseIndex + 1;
   }
-  const endTime = finished ? <Time value={formatTime(finished)} format="YYYY-MM-DD HH:mm" /> : filterId ? 'N/A' : '-';
+  const endTime = finished ? <Time value={formatTime(finished)} format={LocaleFormatString()} /> : filterId ? 'N/A' : '-';
   return (
     <>
       <h4 className="dashboard-header margin-top-large" ref={innerRef}>
@@ -60,7 +61,7 @@ export const RolloutSchedule = ({ deployment, innerRef, onAbort, onUpdateControl
             <TwoColumnData
               {...defaultColumnDataProps}
               config={{
-                'Start time': <Time value={formatTime(creationTime)} format="YYYY-MM-DD HH:mm" />,
+                'Start time': <Time value={formatTime(creationTime)} format={LocaleFormatString()} />,
                 'Current phase': currentPhaseTime
               }}
             />
@@ -94,7 +95,7 @@ export const RolloutSchedule = ({ deployment, innerRef, onAbort, onUpdateControl
           const deviceCountText = !filterId ? ` (${deviceCount} ${pluralize('device', deviceCount)})` : '';
           const startTime = phase.start_ts ?? getPhaseStartTime(phases, index, start_time);
           const phaseObject = {
-            'Start time': <Time value={startTime} format="YYYY-MM-DD HH:mm" />,
+            'Start time': <Time value={startTime} format={LocaleFormatString()} />,
             'Batch size': <div className="text-muted">{`${phase.batch_size}%${deviceCountText}`}</div>
           };
           let phaseTitle = status !== DEPLOYMENT_STATES.scheduled ? <div className="text-muted">Complete</div> : null;

--- a/src/js/components/deployments/deployment-wizard/phasesettings.js
+++ b/src/js/components/deployments/deployment-wizard/phasesettings.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import pluralize from 'pluralize';
-import Time from 'react-time';
 
 import Chip from '@material-ui/core/Chip';
 import AddIcon from '@material-ui/icons/Add';
@@ -10,7 +9,7 @@ import CancelIcon from '@material-ui/icons/Cancel';
 import { getPhaseStartTime } from '../createdeployment';
 import { getPhaseDeviceCount, getRemainderPercent } from '../../../helpers';
 import theme from '../../../themes/mender-theme';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 export const PhaseSettings = ({ classNames, deploymentObject = {}, disabled, filterId, numberDevices, setDeploymentSettings }) => {
   const { phases = [] } = deploymentObject;
@@ -123,7 +122,7 @@ export const PhaseSettings = ({ classNames, deploymentObject = {}, disabled, fil
           {!filterId && deviceCount < 1 && <div className="warning">Phases must have at least 1 device</div>}
         </TableCell>
         <TableCell>
-          <Time value={getPhaseStartTime(phases, index, startTime)} format={LocaleFormatString()} />
+          <LocaleTime value={getPhaseStartTime(phases, index, startTime)} />
         </TableCell>
         <TableCell>
           {phase.delay && index !== phases.length - 1 ? (

--- a/src/js/components/deployments/deployment-wizard/phasesettings.js
+++ b/src/js/components/deployments/deployment-wizard/phasesettings.js
@@ -10,6 +10,7 @@ import CancelIcon from '@material-ui/icons/Cancel';
 import { getPhaseStartTime } from '../createdeployment';
 import { getPhaseDeviceCount, getRemainderPercent } from '../../../helpers';
 import theme from '../../../themes/mender-theme';
+import LocaleFormatString from '../../common/timeformat';
 
 export const PhaseSettings = ({ classNames, deploymentObject = {}, disabled, filterId, numberDevices, setDeploymentSettings }) => {
   const { phases = [] } = deploymentObject;
@@ -122,7 +123,7 @@ export const PhaseSettings = ({ classNames, deploymentObject = {}, disabled, fil
           {!filterId && deviceCount < 1 && <div className="warning">Phases must have at least 1 device</div>}
         </TableCell>
         <TableCell>
-          <Time value={getPhaseStartTime(phases, index, startTime)} format="YYYY-MM-DD HH:mm" />
+          <Time value={getPhaseStartTime(phases, index, startTime)} format={LocaleFormatString()} />
         </TableCell>
         <TableCell>
           {phase.delay && index !== phases.length - 1 ? (

--- a/src/js/components/deployments/deployment-wizard/review.js
+++ b/src/js/components/deployments/deployment-wizard/review.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Time from 'react-time';
 import pluralize from 'pluralize';
 
 import { Chip, List, ListItem, ListItemText } from '@material-ui/core';
@@ -11,7 +10,7 @@ import ExpandableAttribute from '../../common/expandable-attribute';
 import { getPhaseStartTime } from '../createdeployment';
 import ConfigurationObject from '../../common/configurationobject';
 import RolloutSteps from './rolloutsteps';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 export const RolloutSchedule = ({ deployment, deploymentDeviceCount, filterId, phases, start_time }) => {
   return (
@@ -31,7 +30,7 @@ export const RolloutSchedule = ({ deployment, deploymentDeviceCount, filterId, p
             <div className="flexbox column" key={startTime}>
               <Chip size="small" label={`Phase ${index + 1}`} />
               <div>
-                <Time value={startTime} format={LocaleFormatString()} />
+                <LocaleTime value={startTime} />
               </div>
               <div>{`${row.batch_size}%${deviceCountText}`}</div>
             </div>
@@ -66,10 +65,10 @@ const Review = ({ deployment = {}, deploymentObject = {}, docsVersion, filterId,
     { primary: 'Release', secondary: release.Name },
     { primary: 'Device types compatible', secondary: release.device_types_compatible.join(', ') },
     { primary: 'Number of attempts per device', secondary: retries },
-    { primary: 'Start time', secondary: <Time value={start_time} format={LocaleFormatString()} />, secondaryTypographyProps: { title: start_time } },
+    { primary: 'Start time', secondary: <LocaleTime value={start_time} />, secondaryTypographyProps: { title: start_time } },
     {
       primary: 'End time',
-      secondary: end_time ? <Time value={end_time} format={LocaleFormatString()} /> : '-',
+      secondary: end_time ? <LocaleTime value={end_time} /> : '-',
       secondaryTypographyProps: { title: end_time || '-' }
     }
   ];

--- a/src/js/components/deployments/deployment-wizard/review.js
+++ b/src/js/components/deployments/deployment-wizard/review.js
@@ -11,6 +11,7 @@ import ExpandableAttribute from '../../common/expandable-attribute';
 import { getPhaseStartTime } from '../createdeployment';
 import ConfigurationObject from '../../common/configurationobject';
 import RolloutSteps from './rolloutsteps';
+import LocaleFormatString from '../../common/timeformat';
 
 export const RolloutSchedule = ({ deployment, deploymentDeviceCount, filterId, phases, start_time }) => {
   return (
@@ -30,7 +31,7 @@ export const RolloutSchedule = ({ deployment, deploymentDeviceCount, filterId, p
             <div className="flexbox column" key={startTime}>
               <Chip size="small" label={`Phase ${index + 1}`} />
               <div>
-                <Time value={startTime} format="YYYY-MM-DD HH:mm" />
+                <Time value={startTime} format={LocaleFormatString()} />
               </div>
               <div>{`${row.batch_size}%${deviceCountText}`}</div>
             </div>
@@ -65,10 +66,10 @@ const Review = ({ deployment = {}, deploymentObject = {}, docsVersion, filterId,
     { primary: 'Release', secondary: release.Name },
     { primary: 'Device types compatible', secondary: release.device_types_compatible.join(', ') },
     { primary: 'Number of attempts per device', secondary: retries },
-    { primary: 'Start time', secondary: <Time value={start_time} format="YYYY-MM-DD HH:mm" />, secondaryTypographyProps: { title: start_time } },
+    { primary: 'Start time', secondary: <Time value={start_time} format={LocaleFormatString()} />, secondaryTypographyProps: { title: start_time } },
     {
       primary: 'End time',
-      secondary: end_time ? <Time value={end_time} format="YYYY-MM-DD HH:mm" /> : '-',
+      secondary: end_time ? <Time value={end_time} format={LocaleFormatString()} /> : '-',
       secondaryTypographyProps: { title: end_time || '-' }
     }
   ];

--- a/src/js/components/deployments/progressChart.js
+++ b/src/js/components/deployments/progressChart.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
-import Time from 'react-time';
 import pluralize from 'pluralize';
 
 import { SvgIcon, Tooltip } from '@material-ui/core';
@@ -9,7 +8,7 @@ import { RotateLeftOutlined, Warning as WarningIcon } from '@material-ui/icons';
 import { mdiDotsHorizontalCircleOutline as QueuedIcon, mdiSleep as SleepIcon } from '@mdi/js';
 
 import { groupDeploymentStats } from '../../helpers';
-import LocaleFormatString from '../common/timeformat';
+import { LocaleTime } from '../common/localetime';
 
 momentDurationFormatSetup(moment);
 
@@ -155,7 +154,7 @@ export const ProgressDisplay = ({ className = '', deployment, status }) => {
         {phases.length > 1 && phases.length > currentPhaseIndex + 1 ? (
           <div>
             <span>Time until next phase: </span>
-            <Tooltip title={<Time value={nextPhaseStart.toDate()} format={LocaleFormatString()} />} placement="top">
+            <Tooltip title={<LocaleTime value={nextPhaseStart.toDate()} />} placement="top">
               <span>{`${duration.format('d [days] hh [h] mm [m] ss [s]')}`}</span>
             </Tooltip>
           </div>

--- a/src/js/components/deployments/progressChart.js
+++ b/src/js/components/deployments/progressChart.js
@@ -9,6 +9,7 @@ import { RotateLeftOutlined, Warning as WarningIcon } from '@material-ui/icons';
 import { mdiDotsHorizontalCircleOutline as QueuedIcon, mdiSleep as SleepIcon } from '@mdi/js';
 
 import { groupDeploymentStats } from '../../helpers';
+import LocaleFormatString from '../common/timeformat';
 
 momentDurationFormatSetup(moment);
 
@@ -154,7 +155,7 @@ export const ProgressDisplay = ({ className = '', deployment, status }) => {
         {phases.length > 1 && phases.length > currentPhaseIndex + 1 ? (
           <div>
             <span>Time until next phase: </span>
-            <Tooltip title={<Time value={nextPhaseStart.toDate()} format="YYYY-MM-DD HH:mm" />} placement="top">
+            <Tooltip title={<Time value={nextPhaseStart.toDate()} format={LocaleFormatString()} />} placement="top">
               <span>{`${duration.format('d [days] hh [h] mm [m] ss [s]')}`}</span>
             </Tooltip>
           </div>

--- a/src/js/components/deployments/progressChart.js
+++ b/src/js/components/deployments/progressChart.js
@@ -8,7 +8,7 @@ import { RotateLeftOutlined, Warning as WarningIcon } from '@material-ui/icons';
 import { mdiDotsHorizontalCircleOutline as QueuedIcon, mdiSleep as SleepIcon } from '@mdi/js';
 
 import { groupDeploymentStats } from '../../helpers';
-import { LocaleTime } from '../common/localetime';
+import LocaleTime from '../common/localetime';
 
 momentDurationFormatSetup(moment);
 

--- a/src/js/components/devices/base-devices.js
+++ b/src/js/components/devices/base-devices.js
@@ -8,10 +8,11 @@ import preauthImage from '../../../assets/img/preauthorize.png';
 
 import DeviceStatus from './device-status';
 import RelativeTime from '../common/relative-time';
+import LocaleFormatString from '../common/timeformat';
 
 export const RelativeDeviceTime = device => <RelativeTime updateTime={device.updated_ts} />;
 export const DeviceStatusHeading = device => <DeviceStatus device={device} />;
-export const DeviceCreationTime = device => (device.created_ts ? <Time value={device.created_ts} format="YYYY-MM-DD HH:mm" /> : '-');
+export const DeviceCreationTime = device => (device.created_ts ? <Time value={device.created_ts} format={LocaleFormatString()} /> : '-');
 export const DeviceExpansion = () => (
   <div className="bold flexbox center-aligned link-color margin-right-small uppercased" style={{ whiteSpace: 'nowrap' }}>
     view details <ArrowRightAltIcon />

--- a/src/js/components/devices/base-devices.js
+++ b/src/js/components/devices/base-devices.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Time from 'react-time';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
@@ -8,11 +7,11 @@ import preauthImage from '../../../assets/img/preauthorize.png';
 
 import DeviceStatus from './device-status';
 import RelativeTime from '../common/relative-time';
-import LocaleFormatString from '../common/timeformat';
+import LocaleTime from '../common/localetime';
 
 export const RelativeDeviceTime = device => <RelativeTime updateTime={device.updated_ts} />;
 export const DeviceStatusHeading = device => <DeviceStatus device={device} />;
-export const DeviceCreationTime = device => (device.created_ts ? <Time value={device.created_ts} format={LocaleFormatString()} /> : '-');
+export const DeviceCreationTime = device => (device.created_ts ? <LocaleTime value={device.created_ts} /> : '-');
 export const DeviceExpansion = () => (
   <div className="bold flexbox center-aligned link-color margin-right-small uppercased" style={{ whiteSpace: 'nowrap' }}>
     view details <ArrowRightAltIcon />

--- a/src/js/components/devices/device-details/authsets/authsetlistitem.js
+++ b/src/js/components/devices/device-details/authsets/authsetlistitem.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Time from 'react-time';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 // material ui
@@ -10,7 +9,7 @@ import { DEVICE_DISMISSAL_STATE, DEVICE_STATES } from '../../../../constants/dev
 import { formatTime } from '../../../../helpers';
 import theme from '../../../../themes/mender-theme';
 import Loader from '../../../common/loader';
-import LocaleFormatString from '../../../common/timeformat';
+import LocaleTime from '../../../common/localetime';
 
 const padder = <div key="padder" style={{ flexGrow: 1 }}></div>;
 
@@ -204,7 +203,7 @@ const AuthsetListItem = ({ authset, confirm, device, isExpanded, limitMaxed, loa
         {authsetStatus}
         <div className="capitalized">{authset.status}</div>
         {key}
-        <Time value={formatTime(authset.ts)} format={LocaleFormatString()} />
+        <LocaleTime value={formatTime(authset.ts)} />
         {loading === authset.id ? (
           <div>
             Updating status <Loader table={true} waiting={true} show={true} style={{ height: '4px', marginLeft: '10px' }} />

--- a/src/js/components/devices/device-details/authsets/authsetlistitem.js
+++ b/src/js/components/devices/device-details/authsets/authsetlistitem.js
@@ -10,6 +10,7 @@ import { DEVICE_DISMISSAL_STATE, DEVICE_STATES } from '../../../../constants/dev
 import { formatTime } from '../../../../helpers';
 import theme from '../../../../themes/mender-theme';
 import Loader from '../../../common/loader';
+import LocaleFormatString from '../../../common/timeformat';
 
 const padder = <div key="padder" style={{ flexGrow: 1 }}></div>;
 
@@ -203,7 +204,7 @@ const AuthsetListItem = ({ authset, confirm, device, isExpanded, limitMaxed, loa
         {authsetStatus}
         <div className="capitalized">{authset.status}</div>
         {key}
-        <Time value={formatTime(authset.ts)} format="YYYY-MM-DD HH:mm" />
+        <Time value={formatTime(authset.ts)} format={LocaleFormatString()} />
         {loading === authset.id ? (
           <div>
             Updating status <Loader table={true} waiting={true} show={true} style={{ height: '4px', marginLeft: '10px' }} />

--- a/src/js/components/devices/device-details/configuration.js
+++ b/src/js/components/devices/device-details/configuration.js
@@ -23,6 +23,7 @@ import { ConfigureAddOnTip, ConfigureRaspberryLedTip, ConfigureTimezoneTip } fro
 import Loader from '../../common/loader';
 import ConfigImportDialog from './configimportdialog';
 import DeviceDataCollapse from './devicedatacollapse';
+import LocaleFormatString from '../../common/timeformat';
 
 const buttonStyle = { marginLeft: 30 };
 const iconStyle = { margin: 12 };
@@ -49,7 +50,7 @@ export const ConfigUpToDateNote = ({ updated_ts = defaultReportTimeStamp }) => (
         Configuration up-to-date on the device
       </Typography>
       <Typography variant="caption" className="text-muted" style={textStyle}>
-        Updated: {<Time value={updated_ts} format="YYYY-MM-DD HH:mm" />}
+        Updated: {<Time value={updated_ts} format={LocaleFormatString()} />}
       </Typography>
     </div>
   </div>
@@ -59,7 +60,7 @@ export const ConfigEmptyNote = ({ updated_ts = '' }) => (
   <div className="flexbox column margin-small">
     <Typography variant="subtitle2">The device appears to either have an empty configuration or not to have reported a configuration yet.</Typography>
     <Typography variant="caption" className="text-muted" style={textStyle}>
-      Updated: {<Time value={updated_ts} format="YYYY-MM-DD HH:mm" />}
+      Updated: {<Time value={updated_ts} format={LocaleFormatString()} />}
     </Typography>
   </div>
 );

--- a/src/js/components/devices/device-details/configuration.js
+++ b/src/js/components/devices/device-details/configuration.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import Time from 'react-time';
 
 import { Button, Checkbox, FormControlLabel, Typography } from '@material-ui/core';
 import {
@@ -23,7 +22,7 @@ import { ConfigureAddOnTip, ConfigureRaspberryLedTip, ConfigureTimezoneTip } fro
 import Loader from '../../common/loader';
 import ConfigImportDialog from './configimportdialog';
 import DeviceDataCollapse from './devicedatacollapse';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 const buttonStyle = { marginLeft: 30 };
 const iconStyle = { margin: 12 };
@@ -50,7 +49,7 @@ export const ConfigUpToDateNote = ({ updated_ts = defaultReportTimeStamp }) => (
         Configuration up-to-date on the device
       </Typography>
       <Typography variant="caption" className="text-muted" style={textStyle}>
-        Updated: {<Time value={updated_ts} format={LocaleFormatString()} />}
+        Updated: {<LocaleTime value={updated_ts} />}
       </Typography>
     </div>
   </div>
@@ -60,7 +59,7 @@ export const ConfigEmptyNote = ({ updated_ts = '' }) => (
   <div className="flexbox column margin-small">
     <Typography variant="subtitle2">The device appears to either have an empty configuration or not to have reported a configuration yet.</Typography>
     <Typography variant="caption" className="text-muted" style={textStyle}>
-      Updated: {<Time value={updated_ts} format={LocaleFormatString()} />}
+      Updated: {<LocaleTime value={updated_ts} />}
     </Typography>
   </div>
 );

--- a/src/js/components/devices/device-details/connection.js
+++ b/src/js/components/devices/device-details/connection.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Time from 'react-time';
 import ReactTooltip from 'react-tooltip';
 
 import { Button, Typography, SvgIcon } from '@material-ui/core';
@@ -9,7 +8,7 @@ import { ImportExport as ImportExportIcon, InfoOutlined as InfoIcon, Launch as L
 import theme from '../../../themes/mender-theme';
 import { DEVICE_CONNECT_STATES } from '../../../constants/deviceConstants';
 import DeviceDataCollapse from './devicedatacollapse';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 const buttonStyle = { textTransform: 'none', textAlign: 'left' };
 export const PortForwardLink = ({ docsVersion }) => (
@@ -62,7 +61,7 @@ export const DeviceConnectionMissingNote = ({ style, docsVersion }) => (
 
 export const DeviceDisconnectedNote = ({ docsVersion, lastConnectionTs, style }) => (
   <DeviceConnectionNote style={style}>
-    The troubleshoot add-on is not currently connected on this device, it was last connected on <Time value={lastConnectionTs} format={LocaleFormatString()} />.
+    The troubleshoot add-on is not currently connected on this device, it was last connected on <LocaleTime value={lastConnectionTs} />.
     <br />
     Please{' '}
     <a target="_blank" rel="noopener noreferrer" href={`https://docs.mender.io/${docsVersion}add-ons/remote-terminal`}>

--- a/src/js/components/devices/device-details/connection.js
+++ b/src/js/components/devices/device-details/connection.js
@@ -9,6 +9,7 @@ import { ImportExport as ImportExportIcon, InfoOutlined as InfoIcon, Launch as L
 import theme from '../../../themes/mender-theme';
 import { DEVICE_CONNECT_STATES } from '../../../constants/deviceConstants';
 import DeviceDataCollapse from './devicedatacollapse';
+import LocaleFormatString from '../../common/timeformat';
 
 const buttonStyle = { textTransform: 'none', textAlign: 'left' };
 export const PortForwardLink = ({ docsVersion }) => (
@@ -61,7 +62,7 @@ export const DeviceConnectionMissingNote = ({ style, docsVersion }) => (
 
 export const DeviceDisconnectedNote = ({ docsVersion, lastConnectionTs, style }) => (
   <DeviceConnectionNote style={style}>
-    The troubleshoot add-on is not currently connected on this device, it was last connected on <Time value={lastConnectionTs} format="YYYY-MM-DD HH:mm" />.
+    The troubleshoot add-on is not currently connected on this device, it was last connected on <Time value={lastConnectionTs} format={LocaleFormatString()} />.
     <br />
     Please{' '}
     <a target="_blank" rel="noopener noreferrer" href={`https://docs.mender.io/${docsVersion}add-ons/remote-terminal`}>

--- a/src/js/components/devices/device-details/identity.js
+++ b/src/js/components/devices/device-details/identity.js
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
-import Time from 'react-time';
 
 import { DEVICE_STATES } from '../../../constants/deviceConstants';
 import { TwoColumnData } from '../../common/configurationobject';
 import DeviceNameInput from '../../common/devicenameinput';
 import DeviceDataCollapse from './devicedatacollapse';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 const style = { maxWidth: '80%', gridTemplateColumns: 'minmax(max-content, 150px) auto' };
 const previewStyle = { ...style, marginBottom: 5 };
@@ -39,7 +38,7 @@ export const DeviceIdentity = ({ device, setSnackbar }) => {
 
   let extendedContent = remainingIdentity;
   if (created_ts) {
-    const createdTime = <Time value={created_ts} format={LocaleFormatString()} />;
+    const createdTime = <LocaleTime value={created_ts} />;
     extendedContent[status === DEVICE_STATES.preauth ? 'Date added' : 'First request'] = createdTime;
   }
 

--- a/src/js/components/devices/device-details/identity.js
+++ b/src/js/components/devices/device-details/identity.js
@@ -5,6 +5,7 @@ import { DEVICE_STATES } from '../../../constants/deviceConstants';
 import { TwoColumnData } from '../../common/configurationobject';
 import DeviceNameInput from '../../common/devicenameinput';
 import DeviceDataCollapse from './devicedatacollapse';
+import LocaleFormatString from '../../common/timeformat';
 
 const style = { maxWidth: '80%', gridTemplateColumns: 'minmax(max-content, 150px) auto' };
 const previewStyle = { ...style, marginBottom: 5 };
@@ -38,7 +39,7 @@ export const DeviceIdentity = ({ device, setSnackbar }) => {
 
   let extendedContent = remainingIdentity;
   if (created_ts) {
-    const createdTime = <Time value={created_ts} format="YYYY-MM-DD HH:mm" />;
+    const createdTime = <Time value={created_ts} format={LocaleFormatString()} />;
     extendedContent[status === DEVICE_STATES.preauth ? 'Date added' : 'First request'] = createdTime;
   }
 

--- a/src/js/components/devices/device-details/monitoring.js
+++ b/src/js/components/devices/device-details/monitoring.js
@@ -4,6 +4,7 @@ import Time from 'react-time';
 import theme from '../../../themes/mender-theme';
 import DeviceDataCollapse from './devicedatacollapse';
 import { DeviceOfflineHeaderNotification, NoAlertsHeaderNotification, severityMap } from './notifications';
+import LocaleFormatString from '../../common/timeformat';
 
 const MonitoringAlert = ({ alert, onDetailsClick, style }) => {
   const { description, lines_before = [], lines_after = [], line_matching = '' } = alert.subject.details;
@@ -15,7 +16,7 @@ const MonitoringAlert = ({ alert, onDetailsClick, style }) => {
         <b>{alert.name}</b>
       </div>
       <div>{alert.level}</div>
-      <Time value={alert.timestamp} format="YYYY-MM-DD HH:mm" />
+      <Time value={alert.timestamp} format={LocaleFormatString()} />
       {(lines.length || description) && <a onClick={() => onDetailsClick(alert)}>view {lines.length ? 'log' : 'details'}</a>}
     </div>
   );
@@ -57,7 +58,7 @@ export const DeviceMonitoring = ({ alerts, device, getAlerts, innerRef, isOfflin
       title={
         <div className="flexbox center-aligned" ref={innerRef}>
           <h4 className="margin-right">Monitoring</h4>
-          <Time className="text-muted" value={updated_ts} format="YYYY-MM-DD HH:mm" />
+          <Time className="text-muted" value={updated_ts} format={LocaleFormatString()} />
         </div>
       }
     >

--- a/src/js/components/devices/device-details/monitoring.js
+++ b/src/js/components/devices/device-details/monitoring.js
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import Time from 'react-time';
 
 import theme from '../../../themes/mender-theme';
 import DeviceDataCollapse from './devicedatacollapse';
 import { DeviceOfflineHeaderNotification, NoAlertsHeaderNotification, severityMap } from './notifications';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 const MonitoringAlert = ({ alert, onDetailsClick, style }) => {
   const { description, lines_before = [], lines_after = [], line_matching = '' } = alert.subject.details;
@@ -16,7 +15,7 @@ const MonitoringAlert = ({ alert, onDetailsClick, style }) => {
         <b>{alert.name}</b>
       </div>
       <div>{alert.level}</div>
-      <Time value={alert.timestamp} format={LocaleFormatString()} />
+      <LocaleTime value={alert.timestamp} />
       {(lines.length || description) && <a onClick={() => onDetailsClick(alert)}>view {lines.length ? 'log' : 'details'}</a>}
     </div>
   );
@@ -58,7 +57,7 @@ export const DeviceMonitoring = ({ alerts, device, getAlerts, innerRef, isOfflin
       title={
         <div className="flexbox center-aligned" ref={innerRef}>
           <h4 className="margin-right">Monitoring</h4>
-          <Time className="text-muted" value={updated_ts} format={LocaleFormatString()} />
+          <LocaleTime className="text-muted" value={updated_ts} />
         </div>
       }
     >

--- a/src/js/components/devices/device-details/notifications.js
+++ b/src/js/components/devices/device-details/notifications.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import Time from 'react-time';
 
 import { ArrowDropDownCircleOutlined as ScrollDownIcon, CheckCircle as CheckIcon, Error as ErrorIcon, Help as HelpIcon } from '@material-ui/icons';
 import pluralize from 'pluralize';
 import theme from '../../../themes/mender-theme';
 import { DEVICE_ONLINE_CUTOFF } from '../../../constants/deviceConstants';
-import LocaleFormatString from '../../common/timeformat';
+import LocaleTime from '../../common/localetime';
 
 const severityIconStyle = { marginRight: theme.spacing(2) };
 const errorIcon = <ErrorIcon className="red" style={severityIconStyle} />;
@@ -46,7 +45,7 @@ const notificationSpaceStyle = { marginLeft: theme.spacing(), marginRight: theme
 
 export const LastConnection = ({ updated_ts }) => (
   <BaseNotification severity={monitoringSeverities.CRITICAL}>
-    Device has not connected to the server since <Time value={updated_ts} format={LocaleFormatString()} style={notificationSpaceStyle} />
+    Device has not connected to the server since <LocaleTime value={updated_ts} style={notificationSpaceStyle} />
   </BaseNotification>
 );
 

--- a/src/js/components/devices/device-details/notifications.js
+++ b/src/js/components/devices/device-details/notifications.js
@@ -5,6 +5,7 @@ import { ArrowDropDownCircleOutlined as ScrollDownIcon, CheckCircle as CheckIcon
 import pluralize from 'pluralize';
 import theme from '../../../themes/mender-theme';
 import { DEVICE_ONLINE_CUTOFF } from '../../../constants/deviceConstants';
+import LocaleFormatString from '../../common/timeformat';
 
 const severityIconStyle = { marginRight: theme.spacing(2) };
 const errorIcon = <ErrorIcon className="red" style={severityIconStyle} />;
@@ -45,7 +46,7 @@ const notificationSpaceStyle = { marginLeft: theme.spacing(), marginRight: theme
 
 export const LastConnection = ({ updated_ts }) => (
   <BaseNotification severity={monitoringSeverities.CRITICAL}>
-    Device has not connected to the server since <Time value={updated_ts} format="YYYY-MM-DD HH:mm" style={notificationSpaceStyle} />
+    Device has not connected to the server since <Time value={updated_ts} format={LocaleFormatString()} style={notificationSpaceStyle} />
   </BaseNotification>
 );
 

--- a/src/js/components/devices/troubleshootdialog.js
+++ b/src/js/components/devices/troubleshootdialog.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import Dropzone from 'react-dropzone';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import Time from 'react-time';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
 
@@ -18,7 +17,7 @@ import { DEVICE_MESSAGE_TYPES as MessageTypes, DEVICE_MESSAGE_PROTOCOLS as Messa
 import theme, { colors } from '../../themes/mender-theme';
 import Terminal from './troubleshoot/terminal';
 import FileTransfer from './troubleshoot/filetransfer';
-import LocaleFormatString from '../common/timeformat';
+import LocaleTime from '../common/localetime';
 
 momentDurationFormatSetup(moment);
 const MessagePack = msgpack5();
@@ -202,7 +201,7 @@ export const TroubleshootDialog = ({
               <b>Session status:</b> {sessionId ? 'connected' : 'disconnected'}
             </div>
             <div>
-              <b>Connection start:</b> {startTime ? <Time value={startTime} format={LocaleFormatString()} /> : '-'}
+              <b>Connection start:</b> {startTime ? <LocaleTime value={startTime} /> : '-'}
             </div>
             <div>
               <b>Duration:</b> {`${duration.format('hh:mm:ss', { trim: false })}`}

--- a/src/js/components/devices/troubleshootdialog.js
+++ b/src/js/components/devices/troubleshootdialog.js
@@ -18,6 +18,7 @@ import { DEVICE_MESSAGE_TYPES as MessageTypes, DEVICE_MESSAGE_PROTOCOLS as Messa
 import theme, { colors } from '../../themes/mender-theme';
 import Terminal from './troubleshoot/terminal';
 import FileTransfer from './troubleshoot/filetransfer';
+import LocaleFormatString from '../common/timeformat';
 
 momentDurationFormatSetup(moment);
 const MessagePack = msgpack5();
@@ -201,7 +202,7 @@ export const TroubleshootDialog = ({
               <b>Session status:</b> {sessionId ? 'connected' : 'disconnected'}
             </div>
             <div>
-              <b>Connection start:</b> {startTime ? <Time value={startTime} format="YYYY-MM-DD HH:mm" /> : '-'}
+              <b>Connection start:</b> {startTime ? <Time value={startTime} format={LocaleFormatString()} /> : '-'}
             </div>
             <div>
               <b>Duration:</b> {`${duration.format('hh:mm:ss', { trim: false })}`}

--- a/src/js/components/user-management/selfusermanagement.js
+++ b/src/js/components/user-management/selfusermanagement.js
@@ -159,7 +159,7 @@ export const SelfUserManagement = ({
             value={locale}
           >
             <MenuItem value={window.navigator.userLanguage || window.navigator.language}>Automatic</MenuItem>
-            <MenuItem value="en">Langlais</MenuItem>
+            <MenuItem value="en">Retard mode</MenuItem>
             <MenuItem value="de">Deutsche telekom</MenuItem>
             <MenuItem value="es">Spanglish</MenuItem>
           </Select>

--- a/src/js/components/user-management/selfusermanagement.js
+++ b/src/js/components/user-management/selfusermanagement.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import moment from 'moment';
 
 import { Button, FormControl, MenuItem, Select, Switch, TextField } from '@material-ui/core';
 
@@ -147,23 +146,25 @@ export const SelfUserManagement = ({
           </p>
         </div>
       )}
-      <div className="flexbox space-between" style={{ alignItems: 'flex-start' }}>
-        <h2>Locale settings</h2>
+      <div>
+        <p className="help-content">User Locale</p>
         <FormControl>
           <Select
             onChange={event => {
-              saveUserSettings({ 'locale': event.target.value });
               console.log('Setting the user locale to: ' + event.target.value);
-              moment.locale(event.target.value);
+              saveUserSettings({ 'locale': event.target.value });
             }}
             value={locale}
           >
             <MenuItem value={window.navigator.userLanguage || window.navigator.language}>Automatic</MenuItem>
-            <MenuItem value="en">Retard mode</MenuItem>
-            <MenuItem value="de">Deutsche telekom</MenuItem>
-            <MenuItem value="es">Spanglish</MenuItem>
+            <MenuItem value="en">English</MenuItem>
+            <MenuItem value="de">Deutsch</MenuItem>
+            <MenuItem value="es">Spanish</MenuItem>
           </Select>
         </FormControl>
+        <p className="info" style={{ width: '75%', margin: 0 }}>
+          Change the user locale settings for the time format shown.
+        </p>
       </div>
     </div>
   );

--- a/src/js/components/user-management/selfusermanagement.js
+++ b/src/js/components/user-management/selfusermanagement.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
-import { Button, Switch, TextField } from '@material-ui/core';
+import { Button, FormControl, MenuItem, Select, Switch, TextField } from '@material-ui/core';
 
 import Form from '../common/forms/form';
 import TextInput from '../common/forms/textinput';
@@ -15,7 +16,17 @@ import { OAuth2Providers } from './oauth2providers';
 import TwoFactorAuthSetup from './twofactorauthsetup';
 import UserConstants from '../../constants/userConstants';
 
-export const SelfUserManagement = ({ canHave2FA, currentUser, editUser, hasTracking, hasTrackingConsent, isEnterprise, saveUserSettings, setSnackbar }) => {
+export const SelfUserManagement = ({
+  canHave2FA,
+  currentUser,
+  editUser,
+  hasTracking,
+  hasTrackingConsent,
+  isEnterprise,
+  saveUserSettings,
+  setSnackbar,
+  locale
+}) => {
   const [editEmail, setEditEmail] = useState(false);
   const [editPass, setEditPass] = useState(false);
   const [emailFormId, setEmailFormId] = useState(new Date());
@@ -136,6 +147,24 @@ export const SelfUserManagement = ({ canHave2FA, currentUser, editUser, hasTrack
           </p>
         </div>
       )}
+      <div className="flexbox space-between" style={{ alignItems: 'flex-start' }}>
+        <h2>Locale settings</h2>
+        <FormControl>
+          <Select
+            onChange={event => {
+              saveUserSettings({ 'locale': event.target.value });
+              console.log('Setting the user locale to: ' + event.target.value);
+              moment.locale(event.target.value);
+            }}
+            value={locale}
+          >
+            <MenuItem value={window.navigator.userLanguage || window.navigator.language}>Automatic</MenuItem>
+            <MenuItem value="en">Langlais</MenuItem>
+            <MenuItem value="de">Deutsche telekom</MenuItem>
+            <MenuItem value="es">Spanglish</MenuItem>
+          </Select>
+        </FormControl>
+      </div>
     </div>
   );
 };
@@ -145,12 +174,14 @@ const actionCreators = { editUser, saveGlobalSettings, saveUserSettings, setSnac
 const mapStateToProps = state => {
   const { plan = 'os' } = state.organization.organization;
   const isEnterprise = getIsEnterprise(state);
+  const { locale = 'automatic' } = getUserSettings(state);
   return {
     canHave2FA: isEnterprise || (state.app.features.isHosted && plan !== 'os'),
     currentUser: getCurrentUser(state),
     hasTracking: !!state.app.trackerCode,
     hasTrackingConsent: getUserSettings(state).trackingConsentGiven,
-    isEnterprise
+    isEnterprise,
+    locale
   };
 };
 

--- a/src/js/components/user-management/userlist.js
+++ b/src/js/components/user-management/userlist.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Time from 'react-time';
+import LocaleFormatString from '../common/timeformat';
 
 // material ui
 import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
@@ -36,7 +37,7 @@ const UserList = ({ currentUser, editUser, isAdmin: isAdminCurrentUser, isEnterp
         <TableRow key={user.id || index} hover>
           <TableCell>{user.email}</TableCell>
           <TableCell>
-            <Time value={user.created_ts} format="YYYY-MM-DD HH:mm" />
+            <Time value={user.created_ts} format={LocaleFormatString()} />
           </TableCell>
           <TableCell>
             <RelativeTime updateTime={user.updated_ts} />

--- a/src/js/components/user-management/userlist.js
+++ b/src/js/components/user-management/userlist.js
@@ -1,6 +1,6 @@
 import React from 'react';
 // import Time from 'react-time';
-import { LocaleTime } from '../common/localetime';
+import LocaleTime from '../common/localetime';
 
 // material ui
 import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';

--- a/src/js/components/user-management/userlist.js
+++ b/src/js/components/user-management/userlist.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import Time from 'react-time';
-import LocaleFormatString from '../common/timeformat';
+// import Time from 'react-time';
+import { LocaleTime } from '../common/localetime';
 
 // material ui
 import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
@@ -37,7 +37,7 @@ const UserList = ({ currentUser, editUser, isAdmin: isAdminCurrentUser, isEnterp
         <TableRow key={user.id || index} hover>
           <TableCell>{user.email}</TableCell>
           <TableCell>
-            <Time value={user.created_ts} format={LocaleFormatString()} />
+            <LocaleTime value={user.created_ts} />
           </TableCell>
           <TableCell>
             <RelativeTime updateTime={user.updated_ts} />

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -50,6 +50,7 @@ beforeAll(async () => {
     hostname: TEST_LOCATION,
     replace: jest.fn()
   };
+  delete window.navigator.userLanguage;
   window.navigator.userLanguage = 'en';
   delete window.sessionStorage;
   window.sessionStorage = {

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -50,6 +50,7 @@ beforeAll(async () => {
     hostname: TEST_LOCATION,
     replace: jest.fn()
   };
+  window.navigator.userLanguage = 'en';
   delete window.sessionStorage;
   window.sessionStorage = {
     ...oldWindowSessionStorage,


### PR DESCRIPTION
This changes the date-format string to rely on the locale, as defined by the
browser's locale settings, and can further be modified through a menu in 'User
Management', to override the standard.

The option is saved for the next session, as a standard user setting.

Changelog: Enable the user to pick the time locale, through the 'User
Management' interface. The default is to rely on the browser settings, but is
user modifiable through the drop-down menu.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>