### PR TITLE
fixed leaking refresh timer + aligned remaining timers as prevention

### DIFF
--- a/src/js/components/dashboard/deployments.js
+++ b/src/js/components/dashboard/deployments.js
@@ -31,22 +31,22 @@ const headerStyle = {
   justifyContent: 'flex-end'
 };
 
-let timer;
-
 export const Deployments = ({ clickHandle, finishedCount, inprogressCount, onboardingState, pendingCount, setSnackbar, styles }) => {
   const [lastDeploymentCheck, setLastDeploymentCheck] = useState();
   const [loading, setLoading] = useState(true);
   // eslint-disable-next-line no-unused-vars
   const size = useWindowSize();
   const deploymentsRef = useRef();
+  const timer = useRef();
 
   useEffect(() => {
     clearAllRetryTimers(setSnackbar);
-    timer = setInterval(getDeployments, refreshDeploymentsLength);
+    clearInterval(timer.current);
+    timer.current = setInterval(getDeployments, refreshDeploymentsLength);
     getDeployments();
     setLastDeploymentCheck(updateDeploymentCutoff(new Date()));
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
       clearAllRetryTimers(setSnackbar);
     };
   }, []);

--- a/src/js/components/deployments/inprogressdeployments.js
+++ b/src/js/components/deployments/inprogressdeployments.js
@@ -19,8 +19,6 @@ import useWindowSize from '../../utils/resizehook';
 
 export const minimalRefreshDeploymentsLength = 2000;
 
-let dynamicTimer;
-
 export const Progress = props => {
   const {
     abort,
@@ -44,21 +42,22 @@ export const Progress = props => {
   const size = useWindowSize();
 
   const inprogressRef = useRef();
+  const dynamicTimer = useRef();
 
   useEffect(() => {
-    clearTimeout(dynamicTimer);
+    clearTimeout(dynamicTimer.current);
     setupDeploymentsRefresh(minimalRefreshDeploymentsLength);
     return () => {
-      clearTimeout(dynamicTimer);
+      clearTimeout(dynamicTimer.current);
       clearAllRetryTimers(setSnackbar);
     };
   }, []);
 
   useEffect(() => {
-    clearTimeout(dynamicTimer);
+    clearTimeout(dynamicTimer.current);
     setupDeploymentsRefresh(minimalRefreshDeploymentsLength);
     return () => {
-      clearTimeout(dynamicTimer);
+      clearTimeout(dynamicTimer.current);
     };
   }, [pendingCount]);
 
@@ -75,8 +74,8 @@ export const Progress = props => {
       .then(() => {
         const currentRefreshDeploymentLength = Math.min(refreshDeploymentsLength, refreshLength * 2);
         setCurrentRefreshDeploymentLength(currentRefreshDeploymentLength);
-        clearTimeout(dynamicTimer);
-        dynamicTimer = setTimeout(setupDeploymentsRefresh, currentRefreshDeploymentLength);
+        clearTimeout(dynamicTimer.current);
+        dynamicTimer.current = setTimeout(setupDeploymentsRefresh, currentRefreshDeploymentLength);
       })
       .finally(() => setDoneLoading(true));
   };

--- a/src/js/components/deployments/pastdeployments.js
+++ b/src/js/components/deployments/pastdeployments.js
@@ -29,9 +29,6 @@ const headers = [...defaultHeaders.slice(0, defaultHeaders.length - 1), { title:
 
 const type = DEPLOYMENT_STATES.finished;
 
-let timer;
-let inputDelayTimer;
-
 export const Past = props => {
   const { advanceOnboarding, createClick, getDeploymentsByStatus, groups, onboardingState, past, pastSelectionState, setDeploymentsState, setSnackbar } = props;
   // eslint-disable-next-line no-unused-vars
@@ -40,6 +37,8 @@ export const Past = props => {
   const [tonight] = useState(new Date(new Date().setHours(23, 59, 59)).toISOString());
   const [loading, setLoading] = useState(false);
   const deploymentsRef = useRef();
+  const timer = useRef();
+  const inputDelayTimer = useRef();
   const { endDate, page, perPage, search: deviceGroup, startDate, total: count, type: deploymentType } = pastSelectionState;
 
   useEffect(() => {
@@ -63,10 +62,10 @@ export const Past = props => {
   }, []);
 
   useEffect(() => {
-    clearInterval(timer);
-    timer = setInterval(refreshPast, refreshDeploymentsLength);
+    clearInterval(timer.current);
+    timer.current = setInterval(refreshPast, refreshDeploymentsLength);
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
     };
   }, [page, perPage, startDate, endDate, deviceGroup, deploymentType]);
 
@@ -146,8 +145,8 @@ export const Past = props => {
   }
 
   const onFilterUpdate = (...args) => {
-    clearTimeout(inputDelayTimer);
-    inputDelayTimer = setTimeout(() => refreshPast(...args), 700);
+    clearTimeout(inputDelayTimer.current);
+    inputDelayTimer.current = setTimeout(() => refreshPast(...args), 700);
   };
 
   const onGroupFilterChange = (e, value) => {

--- a/src/js/components/deployments/progressChart.js
+++ b/src/js/components/deployments/progressChart.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
 import Time from 'react-time';
@@ -98,18 +98,18 @@ export const DeploymentStatusNotification = ({ status }) => (
   </div>
 );
 
-let timer;
 export const ProgressDisplay = ({ className = '', deployment, status }) => {
   const [time, setTime] = useState(new Date());
+  const timer = useRef();
 
   const { created, device_count, id, phases: deploymentPhases = [], max_devices } = deployment;
   const { inprogress: currentProgressCount, successes: totalSuccessCount, failures: totalFailureCount } = groupDeploymentStats(deployment);
   const totalDeviceCount = Math.max(device_count, max_devices || 0);
 
   useEffect(() => {
-    timer = setInterval(updateTime, 1000);
+    timer.current = setInterval(updateTime, 1000);
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
     };
   }, []);
 

--- a/src/js/components/deployments/scheduleddeployments.js
+++ b/src/js/components/deployments/scheduleddeployments.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Calendar, momentLocalizer } from 'react-big-calendar';
 import { connect } from 'react-redux';
 import moment from 'moment';
@@ -44,11 +44,10 @@ const tabs = {
 
 const type = DEPLOYMENT_STATES.scheduled;
 
-let timer;
-
 export const Scheduled = props => {
   const [calendarEvents, setCalendarEvents] = useState([]);
   const [tabIndex, setTabIndex] = useState(tabs.list.index);
+  const timer = useRef();
 
   const { abort, createClick, getDeploymentsByStatus, isEnterprise, items, openReport, scheduledState, setDeploymentsState, setSnackbar } = props;
   const { page, perPage, total: count } = scheduledState;
@@ -67,10 +66,10 @@ export const Scheduled = props => {
     if (!isEnterprise) {
       return;
     }
-    clearInterval(timer);
-    timer = setInterval(refreshDeployments, refreshDeploymentsLength);
+    clearInterval(timer.current);
+    timer.current = setInterval(refreshDeployments, refreshDeploymentsLength);
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
     };
   }, [isEnterprise, page, perPage]);
 

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -28,7 +28,6 @@ import DeviceIssuesSelection from './widgets/issueselection';
 
 const refreshDeviceLength = 10000;
 const { page: defaultPage, perPage: defaultPerPage } = DEVICE_LIST_DEFAULTS;
-let timer;
 
 const idAttributeTitleMap = {
   id: 'Device ID',
@@ -81,6 +80,7 @@ export const Authorized = props => {
   const [showFilters, setShowFilters] = useState(false);
   const deviceListRef = useRef();
   const authorizeRef = useRef();
+  const timer = useRef();
 
   // eslint-disable-next-line no-unused-vars
   const size = useWindowSize();
@@ -102,7 +102,7 @@ export const Authorized = props => {
       setDeviceFilters(groupFilters);
     }
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
       clearAllRetryTimers(setSnackbar);
     };
   }, []);
@@ -141,8 +141,8 @@ export const Authorized = props => {
       return;
     }
     onSelectionChange([]);
-    clearInterval(timer);
-    timer = setInterval(getDevices, refreshDeviceLength);
+    clearInterval(timer.current);
+    timer.current = setInterval(getDevices, refreshDeviceLength);
     getDevices();
     availableIssueOptions.map(({ key }) => getIssueCountsByType(key, { filters, group: selectedGroup, state: selectedState }));
     availableIssueOptions.includes(DEVICE_ISSUE_OPTIONS.authRequests.key)
@@ -385,7 +385,6 @@ export const Authorized = props => {
               onSort={onSortChange}
               pageLoading={pageLoading}
               pageTotal={deviceCount}
-              refreshDevices={getDevices}
               sortingNotes={sortingNotes}
             />
             {showHelptips && <ExpandDevice />}

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
@@ -194,7 +194,6 @@ export const generateBrowserLocation = (selectedState, filters, selectedGroup, l
   return { pathname, search };
 };
 
-let deviceTimer;
 const refreshLength = 10000;
 
 export const DeviceGroups = ({
@@ -246,6 +245,7 @@ export const DeviceGroups = ({
   const [removeGroup, setRemoveGroup] = useState(false);
   const [tmpDevices, setTmpDevices] = useState([]);
   const [isReconciling, setIsReconciling] = useState(false);
+  const deviceTimer = useRef();
 
   const { state: selectedState } = deviceListState;
 
@@ -260,13 +260,12 @@ export const DeviceGroups = ({
     if (pathname !== history.location.pathname || history.location.search !== `?${search}`) {
       history.replace({ pathname, search }); // lgtm [js/client-side-unvalidated-url-redirection]
     }
-    clearInterval(deviceTimer);
-    deviceTimer = setInterval(getAllDeviceCounts, refreshLength);
+    deviceTimer.current = setInterval(getAllDeviceCounts, refreshLength);
 
     setYesterday();
     setDeviceRefreshTrigger(!deviceRefreshTrigger);
     return () => {
-      clearInterval(deviceTimer);
+      clearInterval(deviceTimer.current);
     };
   }, []);
 
@@ -275,7 +274,7 @@ export const DeviceGroups = ({
   }, [groupCount]);
 
   useEffect(() => {
-    if (!deviceTimer) {
+    if (!deviceTimer.current) {
       return;
     }
     const { pathname, search } = generateBrowserLocation(selectedState, filters, selectedGroup, history.location);
@@ -285,7 +284,7 @@ export const DeviceGroups = ({
   }, [selectedState, filters, selectedGroup]);
 
   useEffect(() => {
-    if (!deviceTimer) {
+    if (!deviceTimer.current) {
       return;
     }
     const { filters: filterQuery = '', status = '' } = match.params;

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -38,7 +38,6 @@ import MonitorDetailsDialog from './device-details/monitordetailsdialog';
 import DeviceNotifications from './device-details/notifications';
 
 const refreshDeviceLength = 10000;
-let timer;
 
 export const ExpandedDevice = ({
   abortDeployment,
@@ -75,6 +74,7 @@ export const ExpandedDevice = ({
   const [troubleshootType, setTroubleshootType] = useState();
   const [monitorDetails, setMonitorDetails] = useState();
   const monitoring = useRef();
+  const timer = useRef();
 
   const { hasAuditlogs, hasDeviceConfig, hasDeviceConnect, hasMonitor } = tenantCapabilities;
 
@@ -82,11 +82,11 @@ export const ExpandedDevice = ({
     if (!device.id) {
       return;
     }
-    clearInterval(timer);
-    timer = setInterval(() => getDeviceInfo(device), refreshDeviceLength);
+    clearInterval(timer.current);
+    timer.current = setInterval(() => getDeviceInfo(device), refreshDeviceLength);
     getDeviceInfo(device);
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
     };
   }, [device.id, device.status]);
 

--- a/src/js/components/devices/troubleshootdialog.js
+++ b/src/js/components/devices/troubleshootdialog.js
@@ -95,6 +95,7 @@ export const TroubleshootDialog = ({
     }
     if (socketInitialized) {
       setStartTime(new Date());
+      clearInterval(timer.current);
       timer.current = setInterval(() => setElapsed(moment()), 500);
     } else {
       clearInterval(timer.current);


### PR DESCRIPTION
leaking timer setup was in `inprogressdeployments.js` as the timer lived on in the module scope and could be set multiple times due to the dynamic refresh setting... now the timers are component scopes and get torn down with the components
the remaining timer in artifacts will be addressed separately in the release filtering PR (#2163)