### PR TITLE
MEN-5203: tests: Do not inject server certificate(s)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,7 +178,6 @@ test:staging-deployment:
     - curl -fsSL https://get.docker.com | sh
     - mv mender-stress-test-client tests/e2e_tests/ && cd tests/e2e_tests
     - curl -o fixtures/mender-demo-artifact.mender "https://dgsbl4vditpls.cloudfront.net/mender-demo-artifact.mender"
-    - touch hosted.pem && true | openssl s_client -connect staging.hosted.mender.io:443 2>/dev/null | openssl x509 > hosted.pem
     - docker pull mendersoftware/mender-client-docker-addons:master
   script:
     - npm ci --cache .npm --prefer-offline

--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -33,7 +33,6 @@ services:
   mender-client:
     image: mendersoftware/mender-client-docker-addons:master
     volumes:
-      - ${INTEGRATION_PATH}/cert/cert.crt:/certs/hosted.pem
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/artifact_info:/etc/mender/artifact_info
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/device_type:/var/lib/mender/device_type
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender.json:/etc/mender/mender.conf

--- a/tests/e2e_tests/dockerClient/mender-connect.json
+++ b/tests/e2e_tests/dockerClient/mender-connect.json
@@ -1,6 +1,5 @@
 {
   "ShellCommand": "/bin/bash",
   "User": "root",
-  "ServerCertificate": "/certs/hosted.pem",
   "Terminal": { "Height": 24, "Width": 128 }
 }

--- a/tests/e2e_tests/dockerClient/mender.json
+++ b/tests/e2e_tests/dockerClient/mender.json
@@ -2,6 +2,5 @@
   "InventoryPollIntervalSeconds": 5,
   "RetryPollIntervalSeconds": 30,
   "ServerURL": "https://docker.mender.io/",
-  "UpdatePollIntervalSeconds": 5,
-  "ServerCertificate": "/certs/hosted.pem"
+  "UpdatePollIntervalSeconds": 5
 }

--- a/tests/e2e_tests/run
+++ b/tests/e2e_tests/run
@@ -87,7 +87,6 @@ run_tests() {
         # starting it is easier when done in the test suite
         $COMPOSE_CMD rm -fsv mender-client
         docker run --name connect-client -d --network=gui-tests_mender \
-            -v ${INTEGRATION_PATH}/cert/cert.crt:/certs/hosted.pem \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-test.json:/etc/mender/mender.conf \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/artifact_info:/etc/mender/artifact_info \

--- a/tests/e2e_tests/utils/commands.ts
+++ b/tests/e2e_tests/utils/commands.ts
@@ -70,8 +70,7 @@ export const startDockerClient = async (baseUrl, token) => {
   // NB! to run the tests against a running local Mender backend, uncomment & adjust the following
   // const localNetwork = ['--network', 'menderintegration_mender'];
   const localNetwork = baseUrl.includes('docker.mender.io')
-    ? ['--network', 'gui-tests_mender', '-v', `${process.env.INTEGRATION_PATH}/cert/cert.crt:/certs/hosted.pem`]
-    : ['-v', `${projectRoot}/hosted.pem:/certs/hosted.pem`];
+    ? ['--network', 'gui-tests_mender'] : [];
   let args = [
     'run',
     '--name',


### PR DESCRIPTION
For `mender-connect` the setting is deprecated. The Docker image
mender-client-docker-addons has now the demo certificate installed in
the root, so it should be necessary.

Remove also the code for getting/injecting the staging.mender.io cert as
the server is CA-backed and shouldn't be necessary.