### PR TITLE
MEN-5107: Rework getDebConfigurationCode to support OS/Enterprise w/ demo/production

### DIFF
--- a/src/js/components/common/dialogs/__snapshots__/physicaldeviceonboarding.test.js.snap
+++ b/src/js/components/common/dialogs/__snapshots__/physicaldeviceonboarding.test.js.snap
@@ -1442,7 +1442,7 @@ exports[`PhysicalDeviceOnboarding Component tiny onboarding tips renders Install
           >
             JWT_TOKEN="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjZTNkMGY4Yy1hZWRlLTQwMzAtYjM5MS03ZDUwMjBlYjg3M2UiLCJzdWIiOiJhMzBhNzgwYi1iODQzLTUzNDQtODBlMy0wZmQ5NWE0ZjZmYzMiLCJleHAiOjE2MDY4MTUzNjksImlhdCI6MTYwNjIxMDU2OSwibWVuZGVyLnRlbmFudCI6IjVmODVjMTdiY2U2MmI3ZmE3ZjVmNzA0MCIsIm1lbmRlci51c2VyIjp0cnVlLCJpc3MiOiJNZW5kZXIgVXNlcnMiLCJzY3AiOiJtZW5kZXIuKiIsIm1lbmRlci5wbGFuIjoicHJvZmVzc2lvbmFsIiwibmJmIjoxNjA2MjEwNTY5fQ.qVgYdCzLTf8OdK9uUctqqaY_HWkIiwpekuGvuGQAXCEgOv4bRNDlZRN_ZRSbxQoARG3pquhScbQrjBV9tcF4irTUPlTn3yrsXNO17DpcbTVeKRkb88RDtIKiRw3orVZ_GlIb-ckTQ5dS-Nqlyyf3Fmrhca-gwt6m_xv2UrmJK6eYYTMfggdRRWb-4u7mEkBI_pHPMTQrT8kJ2BeX-vHgazH9AoH0k85LHtFZQXD7pXHlDZRnLxJXukncwMGDmF17374gavYAIyDIzcC8sEBMDnVXgpikeA1sauzirqix6mAVs6XmxdQO7aF0wfXO1_PTYUA3Nk1oQfMYNlEI3U9uLRJRZIq2L8fmrrBryhstKd4y0KlBbGAQrx8NtRkgajjd1ljMfPBUEZrb7uSerVjneiO-aIBO76CuH0zdklphIjpGJeogkBhe8pAYNggp1XsZHgpZfl7IE5faKaDkMGnutaea--Czor6bhqUNCuY4tR0cpQJbNwy6LS9o1CFy4Log"
 TENANT_TOKEN="testtoken"
-wget -q -O- https://get.mender.io | sudo bash -s -- --demo --commercial --jwt-token $JWT_TOKEN -- --quiet --device-type "raspberrypi7" --demo --hosted-mender --tenant-token $TENANT_TOKEN
+wget -q -O- https://get.mender.io | sudo bash -s -- --demo --commercial --jwt-token $JWT_TOKEN -- --quiet --device-type "raspberrypi7" --tenant-token $TENANT_TOKEN --demo --hosted-mender
           </span>
         </div>
         <p />

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.js
@@ -107,8 +107,8 @@ export const DeviceTypeSelectionStep = ({ docsVersion, hasConvertedImage, onboar
   );
 };
 
-export const InstallationStep = ({ advanceOnboarding, ipAddress, isHosted, isEnterprise, tenantToken, selection, isPreRelease }) => {
-  const codeToCopy = getDebConfigurationCode(ipAddress, isHosted, isEnterprise, tenantToken, selection, isPreRelease);
+export const InstallationStep = ({ advanceOnboarding, selection, ...remainingProps }) => {
+  const codeToCopy = getDebConfigurationCode({ ...remainingProps, deviceType: selection });
   return (
     <div>
       <b>2. Log into your device and install the Mender client</b>
@@ -135,6 +135,7 @@ export const PhysicalDeviceOnboarding = ({
   ipAddress,
   isHosted,
   isEnterprise,
+  isDemoMode,
   isPreRelease,
   onboardingState,
   progress,
@@ -166,6 +167,7 @@ export const PhysicalDeviceOnboarding = ({
       ipAddress={ipAddress}
       isEnterprise={isEnterprise}
       isHosted={isHosted}
+      isDemoMode={isDemoMode}
       isPreRelease={isPreRelease}
       onboardingState={onboardingState}
       onSelect={onSelect}
@@ -183,6 +185,7 @@ const mapStateToProps = state => {
     ipAddress: state.app.hostAddress,
     isEnterprise: getIsEnterprise(state),
     isHosted: state.app.features.isHosted,
+    isDemoMode: state.app.features.isDemoMode,
     isPreRelease: versionCompare(state.app.versionInformation.Integration, 'next') > -1,
     onboardingState: getOnboardingState(state),
     tenantToken: state.organization.organization.tenant_token

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.test.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.test.js
@@ -25,6 +25,7 @@ describe('PhysicalDeviceOnboarding Component', () => {
             ipAddress="test.address"
             isEnterprise={false}
             isHosted={true}
+            isDemoMode={false}
             onboardingState={{ complete: false, showTips: true, showHelptips: true }}
             onSelect={jest.fn}
             selection="raspberrypi7"

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -423,7 +423,7 @@ export const standardizePhases = phases =>
     return standardizedPhase;
   });
 
-export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, tenantToken, deviceType = 'generic-armv6', isPreRelease) => {
+export const getDebConfigurationCode = ({ ipAddress, isHosted, isEnterprise, isDemoMode, tenantToken, deviceType = 'generic-armv6', isPreRelease }) => {
   let envVars = ``;
   let installScriptArgs = `--demo`;
   if (isPreRelease) {
@@ -437,13 +437,16 @@ export const getDebConfigurationCode = (ipAddress, isHosted, isEnterprise, tenan
   let menderSetupArgs = `--quiet --device-type "${deviceType}"`;
   if (isHosted || isEnterprise) {
     envVars = `${envVars}TENANT_TOKEN="${tenantToken}"\n`;
-    if (isHosted) {
-      menderSetupArgs = `${menderSetupArgs} --demo --hosted-mender --tenant-token $TENANT_TOKEN`;
-    } else {
-      menderSetupArgs = `${menderSetupArgs} --retry-poll 30 --update-poll 5 --inventory-poll 5 --server-url https://${window.location.hostname} --server-cert="" --tenant-token $TENANT_TOKEN`;
-    }
-  } else {
+    menderSetupArgs = `${menderSetupArgs} --tenant-token $TENANT_TOKEN`;
+  }
+  if (isHosted) {
+    menderSetupArgs = `${menderSetupArgs} --demo --hosted-mender`;
+  } else if (isDemoMode) {
+    // Demo installation, either OS os Enterprise. Install demo cert and add IP to /etc/hosts
     menderSetupArgs = `${menderSetupArgs} --demo${ipAddress ? ` --server-ip ${ipAddress}` : ''}`;
+  } else {
+    // Production installation, either OS or Enterprise
+    menderSetupArgs = `${menderSetupArgs} --retry-poll 30 --update-poll 5 --inventory-poll 5 --server-url https://${window.location.hostname} --server-cert=""`;
   }
   let scriptUrl = `https://get.mender.io`;
   if (isPreRelease) {


### PR DESCRIPTION
    Fixes MEN-5107.
    
    Previous code basically assumed Enteprise=production and OS=demo. This
    commit reworks getDebConfigurationCode to use isDemoMode independently
    of isEnterprise, so that the four combinations are now possible.
    
    The unit tests should be self-explanatory of all the use cases
    considered.
    
    Changelog: Restore support for Open Source Production setups in bash
    snippets used during on-boarding and on "Connect a Device" dialog.