### PR TITLE
MEN-5331 - fixed an issue that limited profile edits to passwords

### DIFF
--- a/src/js/actions/userActions.js
+++ b/src/js/actions/userActions.js
@@ -162,9 +162,14 @@ export const removeUser = userId => dispatch =>
     )
     .catch(err => userActionErrorHandler(err, 'remove', dispatch));
 
-export const editUser = (userId, userData) => dispatch =>
+export const editUser = (userId, userData) => (dispatch, getState) =>
   GeneralApi.put(`${useradmApiUrl}/users/${userId}`, userData)
-    .then(() => Promise.all([dispatch({ type: UserConstants.UPDATED_USER, userId, user: userData }), dispatch(setSnackbar(actions.edit.successMessage))]))
+    .then(() =>
+      Promise.all([
+        dispatch({ type: UserConstants.UPDATED_USER, userId: userId === UserConstants.OWN_USER_ID ? getState().users.currentUser : userId, user: userData }),
+        dispatch(setSnackbar(actions.edit.successMessage))
+      ])
+    )
     .catch(err => userActionErrorHandler(err, 'edit', dispatch));
 
 export const enableUser2fa =

--- a/src/js/components/user-management/selfusermanagement.js
+++ b/src/js/components/user-management/selfusermanagement.js
@@ -24,11 +24,7 @@ export const SelfUserManagement = ({ canHave2FA, currentUser, editUser, hasTrack
     if (userData.password != userData.password_confirmation) {
       setSnackbar(`The passwords don't match`);
     } else {
-      const data = {
-        current_password: userData.current_password,
-        password: userData.password
-      };
-      editUser(UserConstants.OWN_USER_ID, data).then(() => {
+      editUser(UserConstants.OWN_USER_ID, userData).then(() => {
         setEditEmail(false);
         setEditPass(false);
       });
@@ -73,14 +69,14 @@ export const SelfUserManagement = ({ canHave2FA, currentUser, editUser, hasTrack
           uniqueId={emailFormId}
         >
           <TextInput
-            hint="Email"
-            label="Email"
-            id="email"
             disabled={false}
-            value={email}
-            validations="isLength:1,isEmail"
-            focus={true}
+            focus
+            hint="Email"
+            id="email"
             InputLabelProps={{ shrink: !!email }}
+            label="Email"
+            validations="isLength:1,isEmail"
+            value={email}
           />
         </Form>
       )}


### PR DESCRIPTION
now editing the own email address is possible again

- also ensured the changed email is reflected in the UI right after editing
Changelog: title

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>