### PR TITLE
Gateway adjustments

### DIFF
--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -51,6 +51,7 @@ import DeviceAdditionWidget from './widgets/deviceadditionwidget';
 import QuickFilter from './widgets/quickfilter';
 import Groups from './groups';
 import DeviceStatusNotification from './devicestatusnotification';
+import { versionCompare } from '../../helpers';
 
 export const defaultHeaders = {
   currentSoftware: {
@@ -203,6 +204,7 @@ export const DeviceGroups = ({
   addDynamicGroup,
   addStaticGroup,
   authRequestCount,
+  canPreview,
   deviceLimit,
   deviceListState,
   docsVersion,
@@ -497,7 +499,7 @@ export const DeviceGroups = ({
             setSnackbar={setSnackbar}
           />
         )}
-        {showMakeGateway && <MakeGatewayDialog docsVersion={docsVersion} onCancel={toggleMakeGatewayClick} />}
+        {showMakeGateway && <MakeGatewayDialog docsVersion={docsVersion} isPreRelease={canPreview} onCancel={toggleMakeGatewayClick} />}
       </div>
     </>
   );
@@ -540,6 +542,7 @@ const mapStateToProps = state => {
   return {
     acceptedCount: state.devices.byStatus.accepted.total || 0,
     authRequestCount: state.monitor.issueCounts.byType[DEVICE_ISSUE_OPTIONS.authRequests.key].total,
+    canPreview: versionCompare(state.app.versionInformation.Integration, 'next') > -1,
     deviceLimit: state.devices.limit,
     deviceListState: state.devices.deviceList,
     docsVersion: getDocsVersion(state),

--- a/src/js/components/devices/dialogs/__snapshots__/make-gateway-dialog.test.js.snap
+++ b/src/js/components/devices/dialogs/__snapshots__/make-gateway-dialog.test.js.snap
@@ -445,7 +445,7 @@ wget -O- https://get.mender.io | sudo bash -s -- --jwt-token $JWT_TOKEN mender-g
           Note: this is only intended for demo or testing purposes. For production installation please refer to the
            
           <a
-            href="https://docs.mender.io/server-integration/mender-gateway"
+            href="https://docs.mender.io/get-started/mender-gateway"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/js/components/devices/dialogs/make-gateway-dialog.js
+++ b/src/js/components/devices/dialogs/make-gateway-dialog.js
@@ -30,7 +30,7 @@ export const MakeGatewayDialog = ({ docsVersion, isPreRelease, onCancel }) => (
       <CopyCode code={getCode(isPreRelease)} withDescription />
       <p>
         Note: this is only intended for demo or testing purposes. For production installation please refer to the{' '}
-        <a href={`https://docs.mender.io/${docsVersion}server-integration/mender-gateway`} target="_blank" rel="noopener noreferrer">
+        <a href={`https://docs.mender.io/${docsVersion}get-started/mender-gateway`} target="_blank" rel="noopener noreferrer">
           full Mender Gateway documentation
         </a>
       </p>

--- a/src/js/components/devices/dialogs/make-gateway-dialog.js
+++ b/src/js/components/devices/dialogs/make-gateway-dialog.js
@@ -6,11 +6,16 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/
 import { getToken } from '../../../auth';
 import CopyCode from '../../common/copy-code';
 
-export const getCode = () => `JWT_TOKEN='${getToken()}'
+export const getCode = isPreRelease => {
+  const { target, flags } = isPreRelease
+    ? { target: 'https://get.mender.io/staging', flags: ' -c --experimental' }
+    : { target: 'https://get.mender.io', flags: '' };
+  return `JWT_TOKEN='${getToken()}'
 
-wget -O- https://get.mender.io | sudo bash -s -- --jwt-token $JWT_TOKEN mender-gateway --demo`;
+wget -O- ${target} | sudo bash -s -- --jwt-token $JWT_TOKEN mender-gateway --demo${flags}`;
+};
 
-export const MakeGatewayDialog = ({ docsVersion, onCancel }) => (
+export const MakeGatewayDialog = ({ docsVersion, isPreRelease, onCancel }) => (
   <Dialog open fullWidth maxWidth="md">
     <DialogTitle>Promoting a device to a gateway</DialogTitle>
     <DialogContent className="onboard-dialog dialog-content">
@@ -22,7 +27,7 @@ export const MakeGatewayDialog = ({ docsVersion, onCancel }) => (
         </a>{' '}
         if mender-connect is enabled on the device.
       </p>
-      <CopyCode code={getCode()} withDescription />
+      <CopyCode code={getCode(isPreRelease)} withDescription />
       <p>
         Note: this is only intended for demo or testing purposes. For production installation please refer to the{' '}
         <a href={`https://docs.mender.io/${docsVersion}server-integration/mender-gateway`} target="_blank" rel="noopener noreferrer">

--- a/src/js/components/devices/dialogs/troubleshootdialog.js
+++ b/src/js/components/devices/dialogs/troubleshootdialog.js
@@ -22,9 +22,10 @@ import Time from '../../common/time';
 import Terminal from '../troubleshoot/terminal';
 import FileTransfer from '../troubleshoot/filetransfer';
 import { apiUrl } from '../../../api/general-api';
-import { createDownload } from '../../../helpers';
+import { createDownload, versionCompare } from '../../../helpers';
 import ListOptions from '../widgets/listoptions';
 import { getCode } from './make-gateway-dialog';
+import { getIsEnterprise, getUserRoles } from '../../../selectors';
 
 momentDurationFormatSetup(moment);
 const MessagePack = msgpack5();
@@ -46,6 +47,7 @@ const tabs = {
 };
 
 export const TroubleshootDialog = ({
+  canPreview,
   deviceId,
   deviceFileUpload,
   getDeviceFileDownloadLink,
@@ -161,7 +163,7 @@ export const TroubleshootDialog = ({
   };
 
   const onMakeGatewayClick = () => {
-    const code = getCode();
+    const code = getCode(canPreview);
     setTerminalInput(code);
   };
 
@@ -263,4 +265,12 @@ export const TroubleshootDialog = ({
 
 const actionCreators = { getDeviceFileDownloadLink, deviceFileUpload, setSnackbar };
 
-export default connect(undefined, actionCreators)(TroubleshootDialog);
+const mapStateToProps = state => {
+  return {
+    canPreview: versionCompare(state.app.versionInformation.Integration, 'next') > -1,
+    isEnterprise: getIsEnterprise(state),
+    userRoles: getUserRoles(state)
+  };
+};
+
+export default connect(mapStateToProps, actionCreators)(TroubleshootDialog);

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -64,7 +64,7 @@ const GatewayNotification = ({ device, docsVersion }) => {
       title={
         <div style={{ maxWidth: 350 }}>
           For information about connecting other devices to this gateway, please refer to the{' '}
-          <a href={`https://docs.mender.io/${docsVersion}server-integration/mender-gateway`} target="_blank" rel="noopener noreferrer">
+          <a href={`https://docs.mender.io/${docsVersion}get-started/mender-gateway`} target="_blank" rel="noopener noreferrer">
             Mender Gateway documentation
           </a>
           . This device is reachable via <i>{ipAddress}</i>.

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -92,7 +92,6 @@ export const ExpandedDevice = ({
   getDeviceTwin,
   getSingleDeployment,
   integrations,
-  isEnterprise,
   latestAlerts,
   onClose,
   onMakeGatewayClick,
@@ -249,13 +248,11 @@ export const ExpandedDevice = ({
 
       <TroubleshootDialog
         deviceId={device.id}
-        isEnterprise={isEnterprise}
         open={Boolean(troubleshootType)}
         onCancel={() => setTroubleshootType()}
         onSocketClose={() => setTimeout(() => setSocketClosed(true), 5000)}
         setSocketClosed={setSocketClosed}
         type={troubleshootType}
-        userRoles={userRoles}
       />
       {monitorDetails && <MonitorDetailsDialog alert={monitorDetails} onClose={() => setMonitorDetails()} />}
     </Drawer>


### PR DESCRIPTION
this adjusts the location of the gateway docs (depends on mendersoftware/mender-docs#1730)
+ makes the gateway setup instructions refer to `get.mender.io/staging` and add `-c experimental` when running on a `next` integration version (e.g. during release testing)
