### PR TITLE
chore: fixed image build stage platform to ensure tolerable build speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.2.0-alpine AS build
+FROM --platform=amd64 node:18.2.0-alpine AS build
 WORKDIR /usr/src/app
 COPY package-lock.json package.json ./
 RUN npm ci


### PR DESCRIPTION
- since the final stage will only serve static files, independent of their build architecture, the build step does not have to match the target platform


@alfrunes the current `Dockerfile` seems to build locally for me also for `arm/v6`, but in an awfully long time, with this the final image is still `arm/v6`, but build time is in line with the "classic" build