### PR TITLE
MEN-5652 + MEN-5665

### DIFF
--- a/src/js/components/devices/devicelist.js
+++ b/src/js/components/devices/devicelist.js
@@ -146,8 +146,7 @@ export const DeviceList = props => {
     onSelect,
     onSort,
     pageLoading,
-    pageTotal,
-    setSnackbar
+    pageTotal
   } = props;
 
   const {
@@ -182,14 +181,6 @@ export const DeviceList = props => {
     }
     deviceListRef.current.style.gridTemplateColumns = getColumnsStyle(customColumnSizes, undefined, selectable);
   }, [deviceListRef.current, customColumnSizes, selectable]);
-
-  const expandRow = (event, rowNumber) => {
-    if (event && event.target.closest('input')?.hasOwnProperty('checked')) {
-      return;
-    }
-    setSnackbar('');
-    onExpandClick(devices[rowNumber]);
-  };
 
   const onRowSelection = selectedRow => {
     let updatedSelection = [...selectedRowsRef.current];
@@ -252,10 +243,11 @@ export const DeviceList = props => {
           <DeviceListItem
             columnHeaders={columnHeaders}
             device={device}
+            deviceListState={deviceListState}
             idAttribute={idAttribute.attribute}
             index={index}
             key={device.id}
-            onClick={expandRow}
+            onClick={onExpandClick}
             onRowSelect={onRowSelection}
             selectable={selectable}
             selected={selectedRows.indexOf(index) !== -1}

--- a/src/js/components/devices/devicelistitem.js
+++ b/src/js/components/devices/devicelistitem.js
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 
 // material ui
 import { Checkbox } from '@mui/material';
@@ -16,14 +16,23 @@ const useStyles = makeStyles()(theme => ({
   }
 }));
 
-const DeviceListItem = ({ columnHeaders, device, idAttribute, index, onClick, onRowSelect, selectable, selected }) => {
+const DeviceListItem = ({ columnHeaders, device, deviceListState, idAttribute, index, onClick, onRowSelect, selectable, selected }) => {
   const [isHovering, setIsHovering] = useState(false);
   const { classes } = useStyles();
 
   const onMouseOut = () => setIsHovering(false);
   const onMouseOver = () => setIsHovering(true);
 
-  const handleOnClick = e => onClick(e, index);
+  const handleOnClick = useCallback(
+    event => {
+      if (event && event.target.closest('input')?.hasOwnProperty('checked')) {
+        return;
+      }
+      onClick(device);
+    },
+    [device.id, onClick, deviceListState.expandedDeviceId]
+  );
+
   const handleRowSelect = () => onRowSelect(index);
 
   return (

--- a/src/js/components/devices/devicelistitem.test.js
+++ b/src/js/components/devices/devicelistitem.test.js
@@ -6,7 +6,9 @@ import DeviceListItem from './devicelistitem';
 
 describe('DeviceListItem Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(<DeviceListItem device={{ id: 1 }} columnHeaders={[{ render: item => item }]} idAttribute="id" selectable />);
+    const { baseElement } = render(
+      <DeviceListItem columnHeaders={[{ render: item => item }]} device={{ id: 1 }} deviceListState={{}} idAttribute="id" selectable />
+    );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/tests/e2e_tests/integration/02-layoutAssertions.spec.ts
+++ b/tests/e2e_tests/integration/02-layoutAssertions.spec.ts
@@ -43,6 +43,7 @@ test.describe('Layout assertions', () => {
     const element = await page.textContent('.deviceListItem');
     expect(element.includes('release')).toBeTruthy();
     await page.click(`.deviceListItem div:last-child`);
+    await page.waitForSelector(`text=/Device information for/i`, { timeout: 2000 });
     expect(await page.isVisible('text=Authentication status')).toBeTruthy();
   });
 


### PR DESCRIPTION
fix: fixed an issue that allowed device expansion only once
- improved device list click handler invalidation as the list item memoization lead to stale expansion state being considered
- also prevented device expansion from flickering when expanding/ selecting in quick succession

Ticket: MEN-5665
Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>