### PR TITLE
chore: increased chances of failing early on incompatible build hosts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
unfortunately that seems to only work with somewhat newer node/ npm versions (v14/v8 worked, v12/v6 didn't), but it might be better than not having it...