### PR TITLE
chore: prevented errors from showing up for non-enterprise saml requests

### DIFF
--- a/src/js/components/settings/organization/organization.js
+++ b/src/js/components/settings/organization/organization.js
@@ -70,8 +70,13 @@ export const Organization = ({
 
   useEffect(() => {
     getUserOrganization();
-    getSamlConfigs();
   }, []);
+
+  useEffect(() => {
+    if (isEnterprise) {
+      getSamlConfigs();
+    }
+  }, [isEnterprise]);
 
   useEffect(() => {
     setHasSingleSignOn(!!samlConfigs.length);


### PR DESCRIPTION
hmpf.