### PR TITLE
MEN-5781 - fix: fixed an issue that prevented direct device links from working

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -456,7 +456,6 @@ export const getDeviceById = id => (dispatch, getState) =>
     .then(res => {
       const device = reduceReceivedDevices([res.data], [], getState()).devicesById[id];
       device.etag = res.headers.etag;
-      delete device.updated_ts;
       dispatch({ type: DeviceConstants.RECEIVE_DEVICE, device });
       return Promise.resolve(device);
     })
@@ -482,7 +481,7 @@ export const getDeviceById = id => (dispatch, getState) =>
     });
 
 export const getDeviceInfo = deviceId => (dispatch, getState) => {
-  const device = getState().devices.byId[deviceId];
+  const device = getState().devices.byId[deviceId] || {};
   const { hasDeviceConfig, hasMonitor } = getTenantCapabilities(getState());
   let tasks = [dispatch(getDeviceAuth(deviceId)), dispatch(getDeviceTwin(deviceId))];
   if (hasDeviceConfig && [DEVICE_STATES.accepted, DEVICE_STATES.preauth].includes(device.status)) {

--- a/src/js/components/devices/__snapshots__/expanded-device.test.js.snap
+++ b/src/js/components/devices/__snapshots__/expanded-device.test.js.snap
@@ -989,9 +989,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
           />
         </button>
         <div
-          class="muted margin-left margin-right"
+          class="muted margin-left margin-right flexbox"
         >
-          Last check-in: 
+          <div
+            class="margin-right-small"
+          >
+            Last check-in:
+          </div>
           <span
             aria-label="Tue Jan 01 2019 09:25:00 GMT+0000"
             class=""

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -101,22 +101,6 @@ export const DeviceGroups = ({
   const { refreshTrigger, selectedId, state: selectedState } = deviceListState;
 
   useEffect(() => {
-    maybeSetGroupAndFilters(locationParams);
-    clearInterval(deviceTimer.current);
-    deviceTimer.current = setInterval(getAllDeviceCounts, refreshLength);
-    setYesterday();
-    const state = statusParam && Object.values(DEVICE_STATES).some(state => state === statusParam) ? statusParam : selectedState;
-    let listState = { state, refreshTrigger: !refreshTrigger };
-    if (locationParams.id && Boolean(locationParams.open)) {
-      listState.selectedId = locationParams.id;
-    }
-    setDeviceListState(listState);
-    return () => {
-      clearInterval(deviceTimer.current);
-    };
-  }, []);
-
-  useEffect(() => {
     refreshGroups();
   }, [groupCount]);
 
@@ -142,13 +126,26 @@ export const DeviceGroups = ({
     }
   }, [locationParams.groupName]);
 
-  const maybeSetGroupAndFilters = ({ filters, groupName }) => {
+  useEffect(() => {
+    const { groupName, filters, ...remainder } = locationParams;
     if (groupName) {
       selectGroup(groupName, filters);
     } else if (filters?.length) {
       setDeviceFilters(filters);
     }
-  };
+    const state = statusParam && Object.values(DEVICE_STATES).some(state => state === statusParam) ? statusParam : selectedState;
+    let listState = { ...remainder, state, refreshTrigger: !refreshTrigger };
+    if (locationParams.id && Boolean(locationParams.open)) {
+      listState.selectedId = locationParams.id;
+    }
+    setDeviceListState(listState);
+    clearInterval(deviceTimer.current);
+    deviceTimer.current = setInterval(getAllDeviceCounts, refreshLength);
+    setYesterday();
+    return () => {
+      clearInterval(deviceTimer.current);
+    };
+  }, []);
 
   /*
    * Groups

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -135,16 +135,16 @@ export const ExpandedDevice = ({
   const { hasAuditlogs, hasDeviceConfig, hasDeviceConnect, hasMonitor } = tenantCapabilities;
 
   useEffect(() => {
-    if (!device.id) {
+    if (!deviceId) {
       return;
     }
     clearInterval(timer.current);
-    timer.current = setInterval(() => getDeviceInfo(device.id), refreshDeviceLength);
-    getDeviceInfo(device.id);
+    timer.current = setInterval(() => getDeviceInfo(deviceId), refreshDeviceLength);
+    getDeviceInfo(deviceId);
     return () => {
       clearInterval(timer.current);
     };
-  }, [device.id, device.status]);
+  }, [deviceId, device.status]);
 
   const onDecommissionDevice = device_id => {
     // close dialog!
@@ -164,15 +164,15 @@ export const ExpandedDevice = ({
 
   const copyLinkToClipboard = () => {
     const location = window.location.href.substring(0, window.location.href.indexOf('/devices') + '/devices'.length);
-    copy(`${location}?id=${device.id}`);
+    copy(`${location}?id=${deviceId}`);
     setSnackbar('Link copied to clipboard');
   };
 
   const scrollToMonitor = () => monitoring.current?.scrollIntoView({ behavior: 'smooth' });
 
-  const onCreateDeploymentClick = () => navigate(`/deployments?open=true&deviceId=${device.id}`);
+  const onCreateDeploymentClick = () => navigate(`/deployments?open=true&deviceId=${deviceId}`);
 
-  const deviceIdentifier = attributes.name ?? device.id ?? '-';
+  const deviceIdentifier = attributes.name ?? deviceId ?? '-';
   const isAcceptedDevice = status === DEVICE_STATES.accepted;
   const isGateway = stringToBoolean(attributes.mender_is_gateway);
   const actionCallbacks = {
@@ -192,14 +192,15 @@ export const ExpandedDevice = ({
   }, [deviceId, onClose]);
 
   return (
-    <Drawer anchor="right" className="expandedDevice" open={!!device.id} onClose={onCloseClick} PaperProps={{ style: { minWidth: '67vw' } }}>
+    <Drawer anchor="right" className="expandedDevice" open={!!deviceId} onClose={onCloseClick} PaperProps={{ style: { minWidth: '67vw' } }}>
       <div className="flexbox center-aligned">
         <h3>Device information for {deviceIdentifier}</h3>
         <IconButton onClick={copyLinkToClipboard} size="large">
           <LinkIcon />
         </IconButton>
-        <div className={`${isOffline ? 'red' : 'muted'} margin-left margin-right`}>
-          Last check-in: <RelativeTime updateTime={device.updated_ts} />
+        <div className={`${isOffline ? 'red' : 'muted'} margin-left margin-right flexbox`}>
+          <div className="margin-right-small">Last check-in:</div>
+          <RelativeTime updateTime={device.updated_ts} />
         </div>
         {isGateway && <GatewayNotification device={device} docsVersion={docsVersion} />}
         <IconButton style={{ marginLeft: 'auto' }} onClick={onCloseClick} aria-label="close" size="large">


### PR DESCRIPTION
- the device object might not be initialized at the time of rendering the expanded device, causing it to stay closed => use the deviceId prop as indicator where possible instead
- also fixed an issue where single device info retrieval would fail without prior device init
- parsed device list data from links was not fully taken into account, ignoring e.g. page & perPage settings

Ticket: MEN-5781
Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>