### PR TITLE
feat: added possibility to add extra confirmation step on deployment creation

### DIFF
--- a/src/js/components/common/confirm.js
+++ b/src/js/components/common/confirm.js
@@ -41,7 +41,7 @@ const confirmationType = {
   }
 };
 
-export const Confirm = ({ action, cancel, classes = '', style = {}, type }) => {
+export const Confirm = ({ action, cancel, classes = '', message = '', style = {}, type }) => {
   const [className, setClassName] = useState('fadeIn');
   const [loading, setLoading] = useState(false);
 
@@ -54,9 +54,13 @@ export const Confirm = ({ action, cancel, classes = '', style = {}, type }) => {
     action();
   };
 
+  let notification = message;
+  if (confirmationType[type]) {
+    notification = loading ? confirmationType[type].loading : confirmationType[type].message;
+  }
   return (
     <div className={`flexbox center-aligned ${className} ${classes}`} style={{ marginRight: '12px', justifyContent: 'flex-end', ...style }}>
-      <span className="bold">{loading ? confirmationType[type].loading : confirmationType[type].message}</span>
+      <span className="bold">{notification}</span>
       <IconButton id="confirmAbort" onClick={handleConfirm} size="large">
         <CheckCircleIcon className="green" />
       </IconButton>

--- a/src/js/components/settings/__snapshots__/global.test.js.snap
+++ b/src/js/components/settings/__snapshots__/global.test.js.snap
@@ -398,6 +398,191 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
 }
 
 .emotion-10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: 58px;
+  height: 38px;
+  overflow: hidden;
+  padding: 12px;
+  box-sizing: border-box;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  z-index: 0;
+  vertical-align: middle;
+}
+
+@media print {
+  .emotion-10 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  padding: 9px;
+  border-radius: 50%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  color: #fff;
+  -webkit-transition: left 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,-webkit-transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: left 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-11::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-11.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-11 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-11.Mui-checked {
+  -webkit-transform: translateX(20px);
+  -moz-transform: translateX(20px);
+  -ms-transform: translateX(20px);
+  transform: translateX(20px);
+}
+
+.emotion-11.Mui-disabled {
+  color: #d8ebe9;
+}
+
+.emotion-11.Mui-checked+.MuiSwitch-track {
+  opacity: 0.5;
+}
+
+.emotion-11.Mui-disabled+.MuiSwitch-track {
+  opacity: 0.12;
+}
+
+.emotion-11 .MuiSwitch-input {
+  left: -100%;
+  width: 300%;
+}
+
+.emotion-11:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-11:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-11.Mui-checked {
+  color: #337a87;
+}
+
+.emotion-11.Mui-checked:hover {
+  background-color: rgba(51, 122, 135, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-11.Mui-checked:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-11.Mui-checked.Mui-disabled {
+  color: rgb(177, 204, 209);
+}
+
+.emotion-11.Mui-checked+.MuiSwitch-track {
+  background-color: #337a87;
+}
+
+.emotion-12 {
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+}
+
+.emotion-13 {
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);
+  background-color: currentColor;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.emotion-14 {
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: inherit;
+}
+
+.emotion-15 {
+  height: 100%;
+  width: 100%;
+  border-radius: 7px;
+  z-index: -1;
+  -webkit-transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  background-color: #000;
+  opacity: 0.38;
+}
+
+.emotion-16 {
   color: rgba(0, 0, 0, 0.54);
   line-height: 1.4375em;
   font-family: Lato,sans-serif;
@@ -420,30 +605,30 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.emotion-10.Mui-focused {
+.emotion-16.Mui-focused {
   color: #337a87;
 }
 
-.emotion-10.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-10.Mui-error {
+.emotion-16.Mui-error {
   color: #ab1000;
 }
 
-.emotion-10.Mui-focused {
+.emotion-16.Mui-focused {
   color: #337a87;
 }
 
-.emotion-11 {
+.emotion-17 {
   display: grid;
   grid-template-columns: 100px 100px;
   -webkit-column-gap: 16px;
   column-gap: 16px;
 }
 
-.emotion-12 {
+.emotion-18 {
   line-height: 1.4375em;
   font-family: Lato,sans-serif;
   font-weight: 400;
@@ -463,12 +648,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   position: relative;
 }
 
-.emotion-12.Mui-disabled {
+.emotion-18.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-12:after {
+.emotion-18:after {
   border-bottom: 2px solid #337a87;
   left: 0;
   bottom: 0;
@@ -484,14 +669,14 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   pointer-events: none;
 }
 
-.emotion-12.Mui-focused:after {
+.emotion-18.Mui-focused:after {
   -webkit-transform: scaleX(1) translateX(0);
   -moz-transform: scaleX(1) translateX(0);
   -ms-transform: scaleX(1) translateX(0);
   transform: scaleX(1) translateX(0);
 }
 
-.emotion-12.Mui-error:after {
+.emotion-18.Mui-error:after {
   border-bottom-color: #ab1000;
   -webkit-transform: scaleX(1);
   -moz-transform: scaleX(1);
@@ -499,7 +684,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   transform: scaleX(1);
 }
 
-.emotion-12:before {
+.emotion-18:before {
   border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   left: 0;
   bottom: 0;
@@ -511,33 +696,33 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   pointer-events: none;
 }
 
-.emotion-12:hover:not(.Mui-disabled):before {
+.emotion-18:hover:not(.Mui-disabled):before {
   border-bottom: 2px solid rgba(10, 10, 11, 0.78);
 }
 
 @media (hover: none) {
-  .emotion-12:hover:not(.Mui-disabled):before {
+  .emotion-18:hover:not(.Mui-disabled):before {
     border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   }
 }
 
-.emotion-12.Mui-disabled:before {
+.emotion-18.Mui-disabled:before {
   border-bottom-style: dotted;
 }
 
-.emotion-12:before {
+.emotion-18:before {
   border-bottom: 1px solid rgb(224, 224, 224);
 }
 
-.emotion-12:hover:not($disabled):before {
+.emotion-18:hover:not($disabled):before {
   border-bottom: 2px solid #337a87!important;
 }
 
-.emotion-12:after {
+.emotion-18:after {
   border-bottom: 2px solid #337a87;
 }
 
-.emotion-16 {
+.emotion-22 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -557,7 +742,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   min-width: initial;
 }
 
-.emotion-17 {
+.emotion-23 {
   line-height: 1.4375em;
   font-family: Lato,sans-serif;
   font-weight: 400;
@@ -577,16 +762,16 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   position: relative;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-23.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-label+.emotion-17 {
+label+.emotion-23 {
   margin-top: 16px;
 }
 
-.emotion-17:after {
+.emotion-23:after {
   border-bottom: 2px solid #337a87;
   left: 0;
   bottom: 0;
@@ -602,14 +787,14 @@ label+.emotion-17 {
   pointer-events: none;
 }
 
-.emotion-17.Mui-focused:after {
+.emotion-23.Mui-focused:after {
   -webkit-transform: scaleX(1) translateX(0);
   -moz-transform: scaleX(1) translateX(0);
   -ms-transform: scaleX(1) translateX(0);
   transform: scaleX(1) translateX(0);
 }
 
-.emotion-17.Mui-error:after {
+.emotion-23.Mui-error:after {
   border-bottom-color: #ab1000;
   -webkit-transform: scaleX(1);
   -moz-transform: scaleX(1);
@@ -617,7 +802,7 @@ label+.emotion-17 {
   transform: scaleX(1);
 }
 
-.emotion-17:before {
+.emotion-23:before {
   border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   left: 0;
   bottom: 0;
@@ -629,33 +814,33 @@ label+.emotion-17 {
   pointer-events: none;
 }
 
-.emotion-17:hover:not(.Mui-disabled):before {
+.emotion-23:hover:not(.Mui-disabled):before {
   border-bottom: 2px solid rgba(10, 10, 11, 0.78);
 }
 
 @media (hover: none) {
-  .emotion-17:hover:not(.Mui-disabled):before {
+  .emotion-23:hover:not(.Mui-disabled):before {
     border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   }
 }
 
-.emotion-17.Mui-disabled:before {
+.emotion-23.Mui-disabled:before {
   border-bottom-style: dotted;
 }
 
-.emotion-17:before {
+.emotion-23:before {
   border-bottom: 1px solid rgb(224, 224, 224);
 }
 
-.emotion-17:hover:not($disabled):before {
+.emotion-23:hover:not($disabled):before {
   border-bottom: 2px solid #337a87!important;
 }
 
-.emotion-17:after {
+.emotion-23:after {
   border-bottom: 2px solid #337a87;
 }
 
-.emotion-18 {
+.emotion-24 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -675,84 +860,84 @@ label+.emotion-17 {
   animation-duration: 10ms;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-24::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-24::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-24:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-24::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-24:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-24:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-24::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-24:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-24.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-24:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
@@ -853,18 +1038,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
       </div>
     </div>
   </div>
+  <div
+    class="clickable flexbox center-aligned space-between"
+  >
+    <p
+      class="help-content"
+    >
+      Require confirmation on deployment creation
+    </p>
+    <span
+      class="MuiSwitch-root MuiSwitch-sizeMedium emotion-10"
+    >
+      <span
+        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary emotion-11"
+      >
+        <input
+          class="PrivateSwitchBase-input MuiSwitch-input emotion-12"
+          type="checkbox"
+        />
+        <span
+          class="MuiSwitch-thumb emotion-13"
+        />
+        <span
+          class="MuiTouchRipple-root emotion-14"
+        />
+      </span>
+      <span
+        class="MuiSwitch-track emotion-15"
+      />
+    </span>
+  </div>
   <label
-    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink margin-top emotion-10"
+    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink margin-top emotion-16"
     data-shrink="true"
     id="offline-theshold"
   >
     Offline threshold
   </label>
   <div
-    class="emotion-11"
+    class="emotion-17"
   >
     <div
-      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary  emotion-12"
+      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary  emotion-18"
     >
       <div
         aria-expanded="false"
@@ -898,14 +1113,14 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
       </svg>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root emotion-16"
+      class="MuiFormControl-root MuiTextField-root emotion-22"
     >
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiInput-input emotion-18"
+          class="MuiInputBase-input MuiInput-input emotion-24"
           id="mui-1"
           max="1000"
           min="1"

--- a/src/js/components/settings/global.js
+++ b/src/js/components/settings/global.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 
-import { Button, Checkbox, FormControl, FormControlLabel, FormHelperText, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import { Button, Checkbox, FormControl, FormControlLabel, FormHelperText, InputLabel, MenuItem, Select, Switch, TextField } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 import { getDeviceAttributes } from '../../actions/deviceActions';
@@ -102,7 +102,8 @@ export const GlobalSettingsDialog = ({
   onCloseClick,
   onSaveClick,
   saveGlobalSettings,
-  selectedAttribute
+  selectedAttribute,
+  settings
 }) => {
   const [channelSettings, setChannelSettings] = useState(notificationChannelSettings);
   const [currentInterval, setCurrentInterval] = useState(offlineThresholdSettings.interval);
@@ -111,8 +112,8 @@ export const GlobalSettingsDialog = ({
   const debouncedInterval = useDebounce(currentInterval, 300);
   const debouncedIntervalUnit = useDebounce(currentIntervalUnit, 300);
   const timer = useRef(false);
-
   const { classes } = useStyles();
+  const { needsDeploymentConfirmation = false } = settings;
 
   useEffect(() => {
     setChannelSettings(notificationChannelSettings);
@@ -151,6 +152,10 @@ export const GlobalSettingsDialog = ({
     setIntervalErrorText('Please enter a valid number.');
   };
 
+  const toggleDeploymentConfirmation = () => {
+    saveGlobalSettings({ needsDeploymentConfirmation: !needsDeploymentConfirmation });
+  };
+
   return (
     <div style={{ maxWidth }} className="margin-top-small">
       <h2 className="margin-top-small">Global settings</h2>
@@ -162,6 +167,10 @@ export const GlobalSettingsDialog = ({
         onSaveClick={onSaveClick}
         selectedAttribute={selectedAttribute}
       />
+      <div className="clickable flexbox center-aligned space-between" onClick={toggleDeploymentConfirmation}>
+        <p className="help-content">Require confirmation on deployment creation</p>
+        <Switch checked={needsDeploymentConfirmation} />
+      </div>
       {isAdmin &&
         hasMonitor &&
         Object.keys(alertChannels).map(channel => (
@@ -278,6 +287,7 @@ export const GlobalSettingsContainer = ({
       onCloseClick={onCloseClick}
       onSaveClick={saveAttributeSetting}
       saveGlobalSettings={saveGlobalSettings}
+      settings={settings}
       selectedAttribute={selectedAttribute}
     />
   );


### PR DESCRIPTION
for now this uses a 10 device threshold + an organization wide setting to determine if the request should be shown - the threshold could be replaced with a percentage or we could just rely on the organization setting...

@michaelatmender I changed the dialog approach to the confirmation overlay we use in other parts of the UI to try to avoid the dialog nested in the slide out, but would also be happy to change it to the dialog 👌
<img width="919" alt="Screenshot 2022-08-31 at 10 27 15" src="https://user-images.githubusercontent.com/482243/187633864-808bc8fa-e6c4-4700-8873-a1d700e7ca87.png">
