### PR TITLE
MEN-5899 - feat: added way to retrieve license information about on prem deployments

### DIFF
--- a/src/js/actions/organizationActions.js
+++ b/src/js/actions/organizationActions.js
@@ -10,7 +10,7 @@ import { deepCompare } from '../helpers';
 import { getTenantCapabilities } from '../selectors';
 import { getToken } from '../auth';
 import { commonErrorFallback, commonErrorHandler, setSnackbar } from './appActions';
-import { iotManagerBaseURL } from './deviceActions';
+import { deviceAuthV2, iotManagerBaseURL } from './deviceActions';
 
 const cookies = new Cookies();
 export const auditLogsApiUrl = `${apiUrl.v1}/auditlogs`;
@@ -171,6 +171,11 @@ export const requestPlanChange = (tenantId, content) => dispatch =>
   Api.post(`${tenantadmApiUrlv2}/tenants/${tenantId}/plan`, content)
     .catch(err => commonErrorHandler(err, 'There was an error sending your request', dispatch, commonErrorFallback))
     .then(() => Promise.resolve(dispatch(setSnackbar('Your request was sent successfully', 5000, ''))));
+
+export const downloadLicenseReport = () => dispatch =>
+  Api.get(`${deviceAuthV2}/reports/devices`)
+    .catch(err => commonErrorHandler(err, 'There was an error downloading the report', dispatch, commonErrorFallback))
+    .then(res => res.data);
 
 export const createIntegration = integration => dispatch => {
   // eslint-disable-next-line no-unused-vars

--- a/src/js/actions/organizationActions.test.js
+++ b/src/js/actions/organizationActions.test.js
@@ -16,6 +16,7 @@ import {
   createOrganizationTrial,
   deleteIntegration,
   deleteSamlConfig,
+  downloadLicenseReport,
   getAuditLogs,
   getAuditLogsCsvLink,
   getCurrentCard,
@@ -162,6 +163,15 @@ describe('organization actions', () => {
         expect(storeActions).toHaveLength(expectedActions.length);
         expectedActions.map((action, index) => expect(storeActions[index]).toMatchObject(action));
       });
+  });
+
+  it('should handle license report downloads', async () => {
+    const store = mockStore({ ...defaultState });
+    expect(store.getActions()).toHaveLength(0);
+    const result = await store.dispatch(downloadLicenseReport());
+    const storeActions = store.getActions();
+    expect(storeActions).toHaveLength(0);
+    expect(result).toEqual('test,report');
   });
 
   it('should handle account upgrade init', async () => {

--- a/src/js/components/settings/organization/organization.test.js
+++ b/src/js/components/settings/organization/organization.test.js
@@ -24,7 +24,8 @@ describe('MyOrganization Component', () => {
         features: {
           ...defaultState.app.features,
           isHosted: true
-        }
+        },
+        versionInformation: { Integration: '1.2.3' }
       },
       devices: {
         ...defaultState.devices,

--- a/tests/__mocks__/deviceHandlers.js
+++ b/tests/__mocks__/deviceHandlers.js
@@ -264,5 +264,6 @@ export const deviceHandlers = [
       return res(ctx.status(200));
     }
     return res(ctx.status(517));
-  })
+  }),
+  rest.get(`${deviceAuthV2}/reports/devices`, (req, res, ctx) => res(ctx.text('test,report')))
 ];


### PR DESCRIPTION

![Screenshot 2022-11-01 at 16 45 18](https://user-images.githubusercontent.com/482243/199275910-661b9697-d721-4042-9742-00649c06ab29.png)

Ticket: MEN-5899
Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>