### PR TITLE
fix: made it possible to rely on backend tokens only for session expiration

### DIFF
--- a/src/js/api/users-api.js
+++ b/src/js/api/users-api.js
@@ -5,13 +5,12 @@ import { commonRequestConfig } from './general-api';
 
 const Api = {
   postLogin: (url, userData) => {
-    let body = {};
-    if (userData.hasOwnProperty('token2fa')) {
-      body = { token2fa: userData.token2fa };
+    const { email: username, password, stayLoggedIn, ...remainder } = userData;
+    let body = { stayLoggedIn };
+    if (remainder.hasOwnProperty('token2fa')) {
+      body = { stayLoggedIn, token2fa: remainder.token2fa };
     }
-    return axios
-      .post(url, body, { ...commonRequestConfig, auth: { username: userData.email, password: userData.password } })
-      .then(res => ({ text: res.data, code: res.status }));
+    return axios.post(url, body, { ...commonRequestConfig, auth: { username, password } }).then(res => ({ text: res.data, code: res.status }));
   },
   putVerifyTFA: (url, userData) => {
     let body = {};

--- a/src/js/components/login/login.js
+++ b/src/js/components/login/login.js
@@ -99,7 +99,7 @@ export const Login = ({ currentUser, isHosted, loginUser, logoutUser, setSnackba
   }, [noExpiry]);
 
   const onLoginClick = loginData =>
-    loginUser(loginData).catch(err => {
+    loginUser({ stayLoggedIn: noExpiry, ...loginData }).catch(err => {
       // don't reset the state once it was set - thus not setting `has2FA` solely based on the existence of 2fa in the error
       if (err?.error?.includes('2fa')) {
         setHas2FA(true);


### PR DESCRIPTION
this needs:
- https://github.com/mendersoftware/useradm/pull/339

Ticket: None
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>