### PR TITLE
Cherry-pick ME-46 to 3.4.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,8 @@ test:lint:
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
     - export SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}
     - apk add --no-cache bash git jq wget
+    - git clone --no-tags --depth=1 --single-branch https://github.com/mendersoftware/integration.git
+    - docker load -i image.tar
   artifacts:
     expire_in: 2w
     paths:
@@ -65,9 +67,7 @@ test:acceptance:
   except:
     - /^(staging|saas-[a-zA-Z0-9.]+)$/
   script:
-    - docker load -i image.tar
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:pr
-    - git clone --no-tags --depth=1 --single-branch https://github.com/mendersoftware/integration.git
     - GUI_REPOSITORY=$(pwd) INTEGRATION_PATH=$(pwd)/integration ./tests/e2e_tests/run
     - docker rmi $DOCKER_REPOSITORY:pr
 
@@ -81,9 +81,7 @@ test:acceptance:enterprise:
     - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
     - docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io
     - fi
-    - docker load -i image.tar
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:pr
-    - git clone --no-tags --depth=1 --single-branch https://github.com/mendersoftware/integration.git
     - GUI_REPOSITORY=$(pwd) INTEGRATION_PATH=$(pwd)/integration ./tests/e2e_tests/run --enterprise
     - docker rmi $DOCKER_REPOSITORY:pr
 

--- a/httpd.conf
+++ b/httpd.conf
@@ -41,10 +41,7 @@ http {
         set $docs_location https://docs.mender.io/releases/versions.json;
         proxy_pass $docs_location;
     }
-    location / {
-      try_files $uri @index;
-    }
-    location @index {
+    location /ui/ {
       add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
       add_header Content-Security-Policy "default-src 'none'; child-src 'self' blob:; worker-src 'self' blob:; connect-src 'self' wss://$host https://api.stripe.com https://www.google-analytics.com https://stats.g.doubleclick.net; script-src 'self' https://www.google-analytics.com https://js.stripe.com https://cdn.jsdelivr.net/npm/cookieconsent@3 https://www.google.com www.gstatic.com 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com; font-src 'self'; frame-src https://js.stripe.com https://hooks.stripe.com https://www.google.com; style-src 'self' https://cdn.jsdelivr.net/npm/cookieconsent@3 'unsafe-inline'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';";
       add_header Last-Modified $date_gmt;
@@ -54,7 +51,14 @@ http {
       if_modified_since off;
       expires off;
       etag off;
-      try_files $uri/index.html /index.html =404;
+      rewrite ^/ui(.*)$ $1 break;
+      try_files $uri $uri/index.html /index.html =404;
+    }
+    location /ui {
+      return 301 https://$host/ui/;
+    }
+    location / {
+      return 301 https://$host/ui/$1;
     }
   }
 

--- a/httpd.conf
+++ b/httpd.conf
@@ -54,10 +54,13 @@ http {
       rewrite ^/ui(.*)$ $1 break;
       try_files $uri $uri/index.html /index.html =404;
     }
-    location /ui {
+    location = /ui {
       return 301 https://$host/ui/;
     }
-    location / {
+    location ~ ^/([a-zA-Z0-9]+)$ {
+      return 301 https://$host/ui/$1;
+    }
+    location = / {
       return 301 https://$host/ui/$1;
     }
   }

--- a/src/js/actions/userActions.js
+++ b/src/js/actions/userActions.js
@@ -200,21 +200,12 @@ export const removeUser = userId => dispatch =>
     .catch(err => userActionErrorHandler(err, 'remove', dispatch));
 
 export const editUser = (userId, userData) => (dispatch, getState) => {
-  const currentUser = getCurrentUser(getState());
-  let sanityCheck = Promise.resolve();
-  if ((userId === UserConstants.OWN_USER_ID || userId === currentUser.id) && currentUser.email !== userData.email) {
-    sanityCheck = UsersApi.postLogin(`${useradmApiUrl}/auth/login`, { email: currentUser.email, password: userData.current_password });
-  }
-  return sanityCheck
-    .then(() =>
-      GeneralApi.put(`${useradmApiUrl}/users/${userId}`, userData).then(() =>
-        Promise.all([
-          dispatch({ type: UserConstants.UPDATED_USER, userId: userId === UserConstants.OWN_USER_ID ? getState().users.currentUser : userId, user: userData }),
-          dispatch(setSnackbar(actions.edit.successMessage))
-        ])
-      )
-    )
-    .catch(err => userActionErrorHandler(err, 'edit', dispatch));
+  return GeneralApi.put(`${useradmApiUrl}/users/${userId}`, userData).then(() =>
+    Promise.all([
+      dispatch({ type: UserConstants.UPDATED_USER, userId: userId === UserConstants.OWN_USER_ID ? getState().users.currentUser : userId, user: userData }),
+      dispatch(setSnackbar(actions.edit.successMessage))
+    ])
+  );
 };
 
 export const enableUser2fa =

--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -14,6 +14,7 @@ services:
       - mender-gui
       - mender-client
       - mender-deployments
+      - mender-reporting
       - mender-device-auth
       - mender-inventory
       - mender-useradm

--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -38,8 +38,6 @@ services:
   mender-client:
     image: mendersoftware/mender-client-docker-addons:master
     volumes:
-      - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/artifact_info:/etc/mender/artifact_info
-      - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/device_type:/var/lib/mender/device_type
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender.json:/etc/mender/mender.conf
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf
 

--- a/tests/e2e_tests/dockerClient/artifact_info
+++ b/tests/e2e_tests/dockerClient/artifact_info
@@ -1,1 +1,0 @@
-artifact_name=release-v1

--- a/tests/e2e_tests/dockerClient/device_type
+++ b/tests/e2e_tests/dockerClient/device_type
@@ -1,1 +1,0 @@
-device_type=qemux86-64

--- a/tests/e2e_tests/fixtures/fixtures.ts
+++ b/tests/e2e_tests/fixtures/fixtures.ts
@@ -22,7 +22,7 @@ const defaultConfig = {
   baseUrl: urls.localhost,
   username: 'mender-demo@example.com',
   password: 'mysecretpassword!123',
-  demoDeviceName: 'release-v1'
+  demoDeviceName: 'original'
 };
 
 const test = (process.env.TEST_ENVIRONMENT === 'staging' ? nonCoveredTest : coveredTest).extend<TestFixtures>({

--- a/tests/e2e_tests/integration/02-layoutAssertions.spec.ts
+++ b/tests/e2e_tests/integration/02-layoutAssertions.spec.ts
@@ -41,9 +41,9 @@ test.describe('Layout assertions', () => {
     }
     await page.locator(`input:near(:text("Status:"))`).first().click({ force: true });
     await page.click(`css=.MuiPaper-root >> text=/Accepted/i`);
-    await page.waitForSelector(`css=.deviceListItem >> text=/release/`, { timeout: 60000 });
+    await page.waitForSelector(`css=.deviceListItem >> text=/original/`, { timeout: 60000 });
     const element = await page.textContent('.deviceListItem');
-    expect(element.includes('release')).toBeTruthy();
+    expect(element.includes('original')).toBeTruthy();
     await page.click(`.deviceListItem div:last-child`);
     await page.waitForSelector(`text=/Device information for/i`);
     expect(await page.isVisible('text=Authentication status')).toBeTruthy();
@@ -61,6 +61,6 @@ test.describe('Layout assertions', () => {
     await page.click(`.grouplist:has-text('All devices')`);
     await page.click(selectors.deviceListCheckbox);
     await page.click(`.grouplist:has-text('testgroup')`);
-    expect(await page.locator(`css=.deviceListItem >> text=/release/`)).toBeVisible();
+    expect(await page.locator(`css=.deviceListItem >> text=/original/`)).toBeVisible();
   });
 });

--- a/tests/e2e_tests/integration/05-deviceDetails.spec.ts
+++ b/tests/e2e_tests/integration/05-deviceDetails.spec.ts
@@ -17,7 +17,6 @@ test.describe('Device details', () => {
     await page.click(`text=/show 1\\d+ more/i`);
     expect(await page.isVisible(`css=.expandedDevice >> text=Linux`)).toBeTruthy();
     expect(await page.isVisible(`css=.expandedDevice >> text=mac`)).toBeTruthy();
-    expect(await page.isVisible(`css=.expandedDevice >> text=qemux86-64`)).toBeTruthy();
     expect(await page.isVisible(`css=.expandedDevice >> text=${demoDeviceName}`)).toBeTruthy();
   });
 

--- a/tests/e2e_tests/run
+++ b/tests/e2e_tests/run
@@ -69,6 +69,8 @@ run_tests() {
     declare retries=5
 
     if [[ $ENTERPRISE -eq 1 ]]; then
+        # remove the client, since it won't be able to connect as it lacks a proper tenant token config
+        $COMPOSE_CMD rm -fsv mender-client
         while [[ $retries -gt 0 && -z $containerid ]]; do
             containerid=$(get_container_id mender-tenantadm)
             sleep 1
@@ -82,9 +84,7 @@ run_tests() {
         tenant=$(docker exec $containerid /usr/bin/tenantadm create-org --name=test --username=$USER --password=$PASSWORD)
         token=$(docker exec $containerid /usr/bin/tenantadm get-tenant --id $tenant | jq -r .tenant_token)
         jq --arg tenantToken "$token" '. + { "TenantToken": $tenantToken }' ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender.json > ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-test.json
-        # remove the client, since it won't be able to connect without a proper tenant token config
-        # starting it is easier when done in the test suite
-        $COMPOSE_CMD rm -fsv mender-client
+        # start a new client, using the obtained tenant token - starting it later (in the test suite) would require docker access in the test runner
         docker run --name connect-client -d --network=gui-tests_mender \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-test.json:/etc/mender/mender.conf \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf \

--- a/tests/e2e_tests/run
+++ b/tests/e2e_tests/run
@@ -88,8 +88,6 @@ run_tests() {
         docker run --name connect-client -d --network=gui-tests_mender \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-test.json:/etc/mender/mender.conf \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf \
-            -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/artifact_info:/etc/mender/artifact_info \
-            -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/device_type:/var/lib/mender/device_type \
             mendersoftware/mender-client-docker-addons:master
     else
         while [[ $retries -gt 0 && -z $containerid ]]; do

--- a/tests/e2e_tests/utils/commands.ts
+++ b/tests/e2e_tests/utils/commands.ts
@@ -34,29 +34,28 @@ const updateConfigFileWithUrl = (fileName, serverUrl = 'https://docker.mender.io
   fs.writeFileSync(`${projectRoot}/dockerClient/${fileName}-test.json`, JSON.stringify(connectConfig));
 };
 
+const deviceType = 'qemux86-64';
+const artifactName = 'original';
+const updateInterval = 5;
+const attributes = {
+  device_type: deviceType,
+  client_version: 'mender-2.2.0',
+  artifact_name: artifactName,
+  kernel: 'test Linux version',
+  mac_enp0: '12.34'
+};
+const clientArgs = [
+  'run',
+  ...Object.entries(attributes).map(([key, value]) => `--inventory-attribute="${key}:${value}"`),
+  `--device-type=${deviceType}`,
+  `--artifact-name=${artifactName}`,
+  `--auth-interval=${updateInterval}`,
+  `--inventory-interval=${updateInterval}`,
+  `--update-interval=${updateInterval}`
+];
 export const startClient = async (baseUrl, token, count) => {
   const srippedBaseUrl = baseUrl.replace(/\/$/, '');
-  const deviceType = 'qemux86-64';
-  const artifactName = 'release-v1';
-  const attributes = {
-    device_type: deviceType,
-    client_version: 'mender-2.2.0',
-    artifact_name: artifactName,
-    kernel: 'test Linux version',
-    mac_enp0: '12.34'
-  };
-  const updateInterval = 5;
-  const args = [
-    'run',
-    ...Object.entries(attributes).map(([key, value]) => `--inventory-attribute="${key}:${value}"`),
-    `--device-type=${deviceType}`,
-    `--artifact-name=${artifactName}`,
-    `--auth-interval=${updateInterval}`,
-    `--inventory-interval=${updateInterval}`,
-    `--update-interval=${updateInterval}`,
-    `--count=${count}`,
-    `--server-url=${srippedBaseUrl}`
-  ];
+  const args = [...clientArgs, `--count=${count}`, `--server-url=${srippedBaseUrl}`];
   if (token) {
     args.push(`--tenant-token=${token}`);
   }
@@ -90,10 +89,6 @@ export const startDockerClient = async (baseUrl, token) => {
     '--name',
     'connect-client',
     ...localNetwork,
-    '-v',
-    `${projectRoot}/dockerClient/artifact_info:/etc/mender/artifact_info`,
-    '-v',
-    `${projectRoot}/dockerClient/device_type:/var/lib/mender/device_type`,
     '-v',
     `${projectRoot}/dockerClient/mender-test.json:/etc/mender/mender.conf`,
     '-v',

--- a/tests/e2e_tests/utils/commands.ts
+++ b/tests/e2e_tests/utils/commands.ts
@@ -24,14 +24,14 @@ export const getPeristentLoginInfo = () => {
   return loginInfo;
 };
 
-const updateConfigFileWithUrl = (fileName, serverUrl = 'https://docker.mender.io', token = '', projectRoot) => {
+const updateConfigFileWithUrl = (fileName, serverUrl = 'https://docker.mender.io', token = '') => {
   const connectConfigFile = fs.readFileSync(`dockerClient/${fileName}.json`, 'utf8');
   const connectConfig = JSON.parse(connectConfigFile);
   connectConfig.ServerURL = serverUrl;
   if (token) {
     connectConfig.TenantToken = token;
   }
-  fs.writeFileSync(`${projectRoot}/dockerClient/${fileName}-test.json`, JSON.stringify(connectConfig));
+  fs.writeFileSync(`dockerClient/${fileName}-test.json`, JSON.stringify(connectConfig));
 };
 
 const deviceType = 'qemux86-64';
@@ -78,8 +78,8 @@ export const startClient = async (baseUrl, token, count) => {
 export const startDockerClient = async (baseUrl, token) => {
   const projectRoot = process.cwd();
   const srippedBaseUrl = baseUrl.replace(/\/$/, '');
-  updateConfigFileWithUrl('mender', srippedBaseUrl, token, projectRoot);
-  updateConfigFileWithUrl('mender-connect', srippedBaseUrl, token, projectRoot);
+  updateConfigFileWithUrl('mender', srippedBaseUrl, token);
+  updateConfigFileWithUrl('mender-connect', srippedBaseUrl, token);
   // NB! to run the tests against a running local Mender backend, uncomment & adjust the following
   // const localNetwork = ['--network', 'menderintegration_mender'];
   const localNetwork = baseUrl.includes('docker.mender.io') ? ['--network', 'gui-tests_mender'] : [];


### PR DESCRIPTION
fix: User not being able to change email with two-factor authentication

The operation was blocked by an obsolescent sanity check in the frontend which is now resolved in the backend.

Changelog: Title
Ticket: ME-46
(cherry picked from commit 5888d3e3ee47b764b256e89da9419f903936e4f3)