### PR TITLE
ci: Move all workloads to GCP

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,8 @@ test:lint:
     - npm ci --cache .npm --prefer-offline
     - cd tests/e2e_tests && npm ci && cd ../..
     - npm run lint
+  tags:
+    - mender-qa-worker-generic-light
 
 .template:test:acceptance:
   stage: e2e-test
@@ -61,6 +63,8 @@ test:lint:
       junit:
         - junit/results.xml
     when: always
+  tags:
+    - mender-qa-worker-generic-light
 
 test:acceptance:
   extends: .template:test:acceptance
@@ -135,6 +139,8 @@ test:docs-links:
     - if [ $error -gt 0 ]; then
     - exit 1
     - fi
+  tags:
+    - mender-qa-worker-generic-light
 
 test:docs-links:hosted:
   extends: test:docs-links
@@ -157,6 +163,8 @@ test:prep:
     paths:
       - mender-stress-test-client
     expire_in: 30 days
+  tags:
+    - mender-qa-worker-generic-light
 
 build:docker:
   after_script:
@@ -207,6 +215,8 @@ build:docker:
       - tests/e2e_tests/test-results
       - logs
     when: always
+  tags:
+    - mender-qa-worker-generic-light
 
 test:staging-deployment:chrome:
   extends: .template:test:staging-deployment
@@ -234,6 +244,8 @@ test:staging-deployment:webkit:
     - export COVERALLS_SERVICE_NUMBER=${CI_PIPELINE_ID}
     - apk add --no-cache git
     - npm i -g coveralls
+  tags:
+    - mender-qa-worker-generic-light
 
 publish:tests:
   extends: .template:publish:tests
@@ -279,9 +291,13 @@ publish:disclaimer:
       - disclaimer.txt
   only:
     - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
+  tags:
+    - mender-qa-worker-generic-light
 
 coveralls:done:
   image: curlimages/curl
   stage: .post
   script:
     - curl "https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN" -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"
+  tags:
+    - mender-qa-worker-generic-light


### PR DESCRIPTION
By using existing tag `mender-qa-worker-generic-light`.