### PR TITLE
fix: allow filter chip labels to wrap text

### DIFF
--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -67,6 +67,9 @@ const useStyles = makeStyles()(theme => ({
     [`.filter-list > .MuiChip-root`]: {
       marginBottom: theme.spacing()
     },
+    [`.filter-list > .MuiChip-root > .MuiChip-label`]: {
+      whiteSpace: 'normal'
+    },
     ['&.filter-header']: {
       overflow: 'hidden',
       zIndex: 2


### PR DESCRIPTION
Prevents this from occurring with long "in" filter values:
![device filter nowrap](https://user-images.githubusercontent.com/15045782/224265910-5a47a721-80e3-4799-a779-9e5ea1931000.png)
