### PR TITLE
MEN-6383 - device check in time

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -971,11 +971,12 @@ const maybeUpdateDevicesByStatus = (deviceId, authId) => (dispatch, getState) =>
   return Promise.resolve();
 };
 
-export const updateDeviceAuth = (deviceId, authId, status) => dispatch =>
+export const updateDeviceAuth = (deviceId, authId, status) => (dispatch, getState) =>
   GeneralApi.put(`${deviceAuthV2}/devices/${deviceId}/auth/${authId}/status`, { status })
     .then(() => Promise.all([dispatch(getDeviceAuth(deviceId)), dispatch(setSnackbar('Device authorization status was updated successfully'))]))
     .catch(err => commonErrorHandler(err, 'There was a problem updating the device authorization status:', dispatch))
-    .then(() => Promise.resolve(dispatch(maybeUpdateDevicesByStatus(deviceId, authId))));
+    .then(() => Promise.resolve(dispatch(maybeUpdateDevicesByStatus(deviceId, authId))))
+    .finally(() => dispatch(setDeviceListState({ refreshTrigger: !getState().devices.deviceList.refreshTrigger })));
 
 export const updateDevicesAuth = (deviceIds, status) => (dispatch, getState) => {
   let devices = getState().devices.byId;
@@ -1013,11 +1014,12 @@ export const updateDevicesAuth = (deviceIds, status) => (dispatch, getState) => 
   });
 };
 
-export const deleteAuthset = (deviceId, authId) => dispatch =>
+export const deleteAuthset = (deviceId, authId) => (dispatch, getState) =>
   GeneralApi.delete(`${deviceAuthV2}/devices/${deviceId}/auth/${authId}`)
     .then(() => Promise.all([dispatch(setSnackbar('Device authorization status was updated successfully'))]))
     .catch(err => commonErrorHandler(err, 'There was a problem updating the device authorization status:', dispatch))
-    .then(() => Promise.resolve(dispatch(maybeUpdateDevicesByStatus(deviceId, authId))));
+    .then(() => Promise.resolve(dispatch(maybeUpdateDevicesByStatus(deviceId, authId))))
+    .finally(() => dispatch(setDeviceListState({ refreshTrigger: !getState().devices.deviceList.refreshTrigger })));
 
 export const preauthDevice = authset => dispatch =>
   GeneralApi.post(`${deviceAuthV2}/devices`, authset)
@@ -1030,11 +1032,13 @@ export const preauthDevice = authset => dispatch =>
     })
     .then(() => Promise.resolve(dispatch(setSnackbar('Device was successfully added to the preauthorization list', 5000))));
 
-export const decommissionDevice = (deviceId, authId) => dispatch =>
+export const decommissionDevice = (deviceId, authId) => (dispatch, getState) =>
   GeneralApi.delete(`${deviceAuthV2}/devices/${deviceId}`)
     .then(() => Promise.resolve(dispatch(setSnackbar('Device was decommissioned successfully'))))
     .catch(err => commonErrorHandler(err, 'There was a problem decommissioning the device:', dispatch))
-    .then(() => Promise.resolve(dispatch(maybeUpdateDevicesByStatus(deviceId, authId))));
+    .then(() => Promise.resolve(dispatch(maybeUpdateDevicesByStatus(deviceId, authId))))
+    // trigger reset of device list list!
+    .finally(() => dispatch(setDeviceListState({ refreshTrigger: !getState().devices.deviceList.refreshTrigger })));
 
 export const getDeviceConfig = deviceId => dispatch =>
   GeneralApi.get(`${deviceConfig}/${deviceId}`)

--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -50,6 +50,7 @@ const defaultAttributes = [
   { scope: 'monitor', attribute: 'alerts' },
   { scope: 'system', attribute: 'created_ts' },
   { scope: 'system', attribute: 'updated_ts' },
+  { scope: 'system', attribute: 'check_in_time' },
   { scope: 'system', attribute: 'group' },
   { scope: 'tags', attribute: 'name' }
 ];
@@ -329,7 +330,7 @@ const reduceReceivedDevices = (devices, ids, state, status) =>
       device.identity_data = { ...storedIdentity, ...identity, ...(device.identity_data ? device.identity_data : {}) };
       device.status = status ? status : device.status || identity.status;
       device.created_ts = getEarliestTs(getEarliestTs(system.created_ts, device.created_ts), stateDevice.created_ts);
-      device.updated_ts = getLatestTs(getLatestTs(system.updated_ts, device.updated_ts), stateDevice.updated_ts);
+      device.updated_ts = getLatestTs(getLatestTs(getLatestTs(device.check_in_time, device.updated_ts), system.updated_ts), stateDevice.updated_ts);
       device.isNew = new Date(device.created_ts) > new Date(state.app.newThreshold);
       device.isOffline = new Date(device.updated_ts) < new Date(state.app.offlineThreshold);
       accu.devicesById[device.id] = { ...stateDevice, ...device };

--- a/src/js/actions/deviceActions.test.js
+++ b/src/js/actions/deviceActions.test.js
@@ -67,6 +67,26 @@ const getGroupSuccessNotification = groupName => (
   </>
 );
 
+// eslint-disable-next-line no-unused-vars
+const { attributes, updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
+const receivedExpectedDevice = { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } };
+const defaultDeviceListState = {
+  type: DeviceConstants.SET_DEVICE_LIST_STATE,
+  state: {
+    ...defaultState.devices.deviceList,
+    perPage: 20,
+    deviceIds: [defaultState.devices.byId.a1.id, defaultState.devices.byId.a1.id],
+    isLoading: false,
+    total: 2
+  }
+};
+const acceptedDevices = {
+  type: DeviceConstants.SET_ACCEPTED_DEVICES,
+  deviceIds: [defaultState.devices.byId.a1.id, defaultState.devices.byId.a1.id],
+  status: DeviceConstants.DEVICE_STATES.accepted,
+  total: defaultState.devices.byStatus.accepted.total
+};
+
 const defaultResults = {
   receivedDynamicGroups: {
     type: DeviceConstants.RECEIVE_DYNAMIC_GROUPS,
@@ -82,7 +102,21 @@ const defaultResults = {
         total: 0
       }
     }
-  }
+  },
+  receiveDefaultDevice: { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: defaultState.devices.byId.a1 } },
+  acceptedDevices,
+  receivedExpectedDevice,
+  defaultDeviceListState,
+  postDeviceAuthActions: [
+    { type: DeviceConstants.SET_DEVICE_LIST_STATE, state: { deviceIds: [], isLoading: true, refreshTrigger: true } },
+    {
+      type: DeviceConstants.RECEIVE_DEVICES,
+      devicesById: { [defaultState.devices.byId.a1.id]: { ...defaultState.devices.byId.a1, updated_ts: inventoryDevice.updated_ts } }
+    },
+    acceptedDevices,
+    receivedExpectedDevice,
+    defaultDeviceListState
+  ]
 };
 
 /* eslint-disable sonarjs/no-identical-functions */
@@ -376,17 +410,15 @@ describe('device auth handling', () => {
   });
   it('should allow single device auth updates', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: SET_SNACKBAR, snackbar: { message: deviceUpdateSuccessMessage } },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [expectedDevice.id]: expectedDevice } },
+      defaultResults.receivedExpectedDevice,
       {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
+        ...defaultResults.acceptedDevices,
         deviceIds: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id),
-        status: DeviceConstants.DEVICE_STATES.accepted,
         total: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id).length
-      }
+      },
+      ...defaultResults.postDeviceAuthActions
     ];
     await store.dispatch(
       updateDeviceAuth(defaultState.devices.byId.a1.id, defaultState.devices.byId.a1.auth_sets[0].id, DeviceConstants.DEVICE_STATES.pending)
@@ -397,17 +429,15 @@ describe('device auth handling', () => {
   });
   it('should allow multiple device auth updates', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: SET_SNACKBAR, snackbar: { message: deviceUpdateSuccessMessage } },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [expectedDevice.id]: expectedDevice } },
+      defaultResults.receivedExpectedDevice,
       {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
+        ...defaultResults.acceptedDevices,
         deviceIds: [defaultState.devices.byId.b1.id],
-        status: DeviceConstants.DEVICE_STATES.accepted,
         total: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id).length
       },
+      ...defaultResults.postDeviceAuthActions,
       {
         type: SET_SNACKBAR,
         snackbar: {
@@ -444,16 +474,14 @@ describe('device auth handling', () => {
   });
   it('should allow single device auth set deletion', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: SET_SNACKBAR, snackbar: { message: deviceUpdateSuccessMessage } },
       {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
+        ...defaultResults.acceptedDevices,
         deviceIds: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id),
-        status: DeviceConstants.DEVICE_STATES.accepted,
         total: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id).length
-      }
+      },
+      ...defaultResults.postDeviceAuthActions
     ];
     await store.dispatch(deleteAuthset(defaultState.devices.byId.a1.id, defaultState.devices.byId.a1.auth_sets[0].id));
     const storeActions = store.getActions();
@@ -462,16 +490,14 @@ describe('device auth handling', () => {
   });
   it('should allow single device decomissioning', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: SET_SNACKBAR, snackbar: { message: 'Device was decommissioned successfully' } },
       {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
+        ...defaultResults.acceptedDevices,
         deviceIds: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id),
-        status: DeviceConstants.DEVICE_STATES.accepted,
         total: defaultState.devices.byStatus.accepted.deviceIds.filter(id => id !== defaultState.devices.byId.a1.id).length
-      }
+      },
+      ...defaultResults.postDeviceAuthActions
     ];
     await store.dispatch(decommissionDevice(defaultState.devices.byId.a1.id));
     const storeActions = store.getActions();

--- a/src/js/actions/deviceActions.test.js
+++ b/src/js/actions/deviceActions.test.js
@@ -123,22 +123,12 @@ const defaultResults = {
 describe('selecting things', () => {
   it('should allow device list selections', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: DeviceConstants.SET_DEVICE_LIST_STATE, state: { deviceIds: ['a1'], isLoading: true } },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
-      {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
-        deviceIds: [defaultState.devices.byId.a1.id, defaultState.devices.byId.a1.id],
-        status: DeviceConstants.DEVICE_STATES.accepted,
-        total: defaultState.devices.byStatus.accepted.total
-      },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
-      {
-        type: DeviceConstants.SET_DEVICE_LIST_STATE,
-        state: { ...defaultState.devices.deviceList, perPage: 20, deviceIds: ['a1', 'a1'], isLoading: false, total: 2 }
-      }
+      defaultResults.receivedExpectedDevice,
+      defaultResults.acceptedDevices,
+      defaultResults.receivedExpectedDevice,
+      defaultResults.defaultDeviceListState
     ];
     await store.dispatch(setDeviceListState({ deviceIds: ['a1'] }));
     const storeActions = store.getActions();
@@ -162,7 +152,7 @@ describe('selecting things', () => {
     const expectedActions = [
       { type: DeviceConstants.SELECT_GROUP, group: groupName },
       { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: { ...expectedDevice, attributes } } },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: { ...expectedDevice } } },
+      defaultResults.receivedExpectedDevice,
       {
         type: DeviceConstants.RECEIVE_GROUP_DEVICES,
         group: { filters: [], deviceIds: [defaultState.devices.byId.a1.id, defaultState.devices.byId.b1.id], total: 2 },
@@ -395,9 +385,7 @@ describe('device auth handling', () => {
   const deviceUpdateSuccessMessage = 'Device authorization status was updated successfully';
   it('should allow device auth information retrieval', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, ...expectedDevice } = defaultState.devices.byId.a1;
-    const expectedActions = [{ type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [expectedDevice.id]: expectedDevice } }];
+    const expectedActions = [defaultResults.receivedExpectedDevice];
     await store.dispatch(getDeviceAuth(defaultState.devices.byId.a1.id));
     const storeActions = store.getActions();
     expect(storeActions.length).toEqual(expectedActions.length);
@@ -515,7 +503,7 @@ describe('static grouping related actions', () => {
         type: DeviceConstants.RECEIVE_DEVICES,
         devicesById: { [defaultState.devices.byId.a1.id]: { ...defaultState.devices.byId.a1, updated_ts: inventoryDevice.updated_ts } }
       },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: defaultState.devices.byId.a1 } },
+      defaultResults.receiveDefaultDevice,
       {
         type: DeviceConstants.ADD_DYNAMIC_GROUP,
         groupName: DeviceConstants.UNGROUPED_GROUP.id,
@@ -541,7 +529,7 @@ describe('static grouping related actions', () => {
         type: DeviceConstants.RECEIVE_DEVICES,
         devicesById: { [defaultState.devices.byId.a1.id]: { ...defaultState.devices.byId.a1, updated_ts: inventoryDevice.updated_ts } }
       },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: defaultState.devices.byId.a1 } },
+      defaultResults.receiveDefaultDevice,
       {
         type: DeviceConstants.ADD_DYNAMIC_GROUP,
         groupName: DeviceConstants.UNGROUPED_GROUP.id,
@@ -559,7 +547,7 @@ describe('static grouping related actions', () => {
         type: DeviceConstants.RECEIVE_DEVICES,
         devicesById: { [defaultState.devices.byId.a1.id]: { ...defaultState.devices.byId.a1, updated_ts: inventoryDevice.updated_ts } }
       },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: defaultState.devices.byId.a1 } },
+      defaultResults.receiveDefaultDevice,
       {
         type: DeviceConstants.ADD_DYNAMIC_GROUP,
         groupName: DeviceConstants.UNGROUPED_GROUP.id,
@@ -607,7 +595,7 @@ describe('static grouping related actions', () => {
         type: DeviceConstants.RECEIVE_DEVICES,
         devicesById: { [defaultState.devices.byId.a1.id]: { ...defaultState.devices.byId.a1, updated_ts: inventoryDevice.updated_ts } }
       },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: defaultState.devices.byId.a1 } },
+      defaultResults.receiveDefaultDevice,
       {
         type: DeviceConstants.ADD_DYNAMIC_GROUP,
         groupName: DeviceConstants.UNGROUPED_GROUP.id,
@@ -657,10 +645,8 @@ describe('static grouping related actions', () => {
   it('should allow complete device retrieval for static groups', async () => {
     const store = mockStore({ ...defaultState });
     const groupName = 'testGroup';
-    // eslint-disable-next-line no-unused-vars
-    const { updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
+      defaultResults.receivedExpectedDevice,
       { type: DeviceConstants.RECEIVE_GROUP_DEVICES, group: { filters: [], deviceIds: [defaultState.devices.byId.a1.id], total: 1 }, groupName }
     ];
     await store.dispatch(getAllGroupDevices(groupName));
@@ -700,8 +686,6 @@ describe('dynamic grouping related actions', () => {
   it('should allow complete device retrieval for dynamic groups', async () => {
     const store = mockStore({ ...defaultState });
     const groupName = 'testGroupDynamic';
-    // eslint-disable-next-line no-unused-vars
-    const { updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: DeviceConstants.RECEIVE_DEVICES, devicesById: {} },
       { type: DeviceConstants.RECEIVE_GROUP_DEVICES, group: defaultState.devices.groups.byId.testGroupDynamic, groupName }
@@ -784,18 +768,7 @@ describe('device retrieval ', () => {
   });
   it('should allow retrieving multiple devices by status', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
-    const expectedActions = [
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
-      {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
-        deviceIds: Array.from({ length: defaultState.devices.byStatus.accepted.total }, () => defaultState.devices.byId.a1.id),
-        status: DeviceConstants.DEVICE_STATES.accepted,
-        total: defaultState.devices.byStatus.accepted.total
-      },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [expectedDevice.id]: expectedDevice } }
-    ];
+    const expectedActions = [defaultResults.receivedExpectedDevice, defaultResults.acceptedDevices, defaultResults.receivedExpectedDevice];
     await store.dispatch(getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted));
     const storeActions = store.getActions();
     expect(storeActions.length).toEqual(expectedActions.length);
@@ -803,17 +776,15 @@ describe('device retrieval ', () => {
   });
   it('should allow retrieving multiple devices by status and select if requested', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
+      defaultResults.receivedExpectedDevice,
       {
         type: DeviceConstants.SET_ACCEPTED_DEVICES,
         deviceIds: [defaultState.devices.byId.a1.id],
         status: DeviceConstants.DEVICE_STATES.accepted,
         total: defaultState.devices.byStatus.accepted.total
       },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } }
+      defaultResults.receivedExpectedDevice
     ];
     await store.dispatch(getDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted, { perPage: 1, shouldSelectDevices: true }));
     const storeActions = store.getActions();
@@ -822,23 +793,13 @@ describe('device retrieval ', () => {
   });
   it('should allow retrieving devices based on devicelist state', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { attributes, updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
       { type: DeviceConstants.SET_DEVICE_LIST_STATE, state: { ...defaultState.devices.deviceList, perPage: 2, deviceIds: [], isLoading: true } },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
-      {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
-        deviceIds: [defaultState.devices.byId.a1.id, defaultState.devices.byId.a1.id],
-        status: DeviceConstants.DEVICE_STATES.accepted,
-        total: defaultState.devices.byStatus.accepted.total
-      },
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
+      defaultResults.receivedExpectedDevice,
+      defaultResults.acceptedDevices,
+      defaultResults.receivedExpectedDevice,
       // the following perPage setting should be 2 as well, but the test backend seems to respond too fast for the state change to propagate
-      {
-        type: DeviceConstants.SET_DEVICE_LIST_STATE,
-        state: { ...defaultState.devices.deviceList, perPage: 20, deviceIds: ['a1', 'a1'], isLoading: false, total: 2 }
-      }
+      defaultResults.defaultDeviceListState
     ];
     await store.dispatch(setDeviceListState({ page: 1, perPage: 2, refreshTrigger: true }));
     const storeActions = store.getActions();
@@ -847,16 +808,9 @@ describe('device retrieval ', () => {
   });
   it('should allow retrieving all devices per status', async () => {
     const store = mockStore({ ...defaultState });
-    // eslint-disable-next-line no-unused-vars
-    const { updated_ts, ...expectedDevice } = defaultState.devices.byId.a1;
     const expectedActions = [
-      { type: DeviceConstants.RECEIVE_DEVICES, devicesById: { [defaultState.devices.byId.a1.id]: expectedDevice } },
-      {
-        type: DeviceConstants.SET_ACCEPTED_DEVICES,
-        deviceIds: Array.from({ length: defaultState.devices.byStatus.accepted.total }, () => defaultState.devices.byId.a1.id),
-        status: DeviceConstants.DEVICE_STATES.accepted,
-        total: defaultState.devices.byStatus.accepted.total
-      },
+      defaultResults.receivedExpectedDevice,
+      defaultResults.acceptedDevices,
       { type: DeviceConstants.SET_INACTIVE_DEVICES, activeDeviceTotal: 0, inactiveDeviceTotal: 2 }
     ];
     await store.dispatch(getAllDevicesByStatus(DeviceConstants.DEVICE_STATES.accepted));

--- a/src/js/components/__snapshots__/app.test.js.snap
+++ b/src/js/components/__snapshots__/app.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`App Component renders correctly 1`] = `
-.emotion-0 {
+<DocumentFragment>
+  .emotion-0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -869,7 +870,509 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-5:focus::-ms-input-p
   }
 }
 
-.emotion-55 {
+<div
+    id="app"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular emotion-0"
+      id="fixedHeader"
+    >
+      <div
+        class="flexbox space-between"
+      >
+        <div
+          class="flexbox center-aligned"
+        >
+          <a
+            href="/"
+          >
+            <img
+              id="logo"
+              src="headerlogo.png"
+            />
+          </a>
+        </div>
+        <div
+          class="MuiFormControl-root MuiTextField-root emotion-1"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart emotion-2"
+          >
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-standard MuiInputAdornment-sizeSmall emotion-3"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSize emotion-4"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </div>
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart emotion-5"
+              id="mui-1"
+              placeholder="Search devices"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="flexbox center-aligned"
+        >
+          <div
+            class="header-section"
+            data-mui-internal-clone-element="true"
+          >
+            <a
+              class=""
+              href="/devices"
+            >
+              <span>
+                2
+              </span>
+              <span
+                id="limit"
+              >
+                /500
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+                data-testid="DeveloperBoardIcon"
+                focusable="false"
+                style="margin: 0px 7px 0px 10px; font-size: 20px;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z"
+                />
+              </svg>
+            </a>
+            <a
+              href="/devices/pending"
+              style="margin-left: 7px;"
+            >
+              1 pending
+            </a>
+          </div>
+          <a
+            class="header-section"
+            href="/deployments/active"
+          >
+            <span>
+              0
+            </span>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium flip-horizontal emotion-7"
+              data-testid="RefreshIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+              />
+            </svg>
+          </a>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium header-dropdown emotion-8"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-9"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-10"
+                data-testid="AccountCircleIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 4c1.93 0 3.5 1.57 3.5 3.5S13.93 13 12 13s-3.5-1.57-3.5-3.5S10.07 6 12 6zm0 14c-2.03 0-4.43-.82-6.14-2.88C7.55 15.8 9.68 15 12 15s4.45.8 6.14 2.12C16.43 19.18 14.03 20 12 20z"
+                />
+              </svg>
+            </span>
+            a@b.com
+            <span
+              class="MuiButton-endIcon MuiButton-iconSizeMedium emotion-11"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root emotion-13"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="leftFixed leftNav emotion-14"
+    >
+      <ul
+        class="MuiList-root MuiList-padding emotion-15"
+        style="padding: 0px;"
+      >
+        <a
+          aria-current="page"
+          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16 active"
+          href="/"
+        >
+          <div
+            class="MuiListItemText-root emotion-17"
+            style="text-transform: uppercase;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
+            >
+              Dashboard
+            </span>
+          </div>
+        </a>
+        <a
+          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16"
+          href="/devices"
+        >
+          <div
+            class="MuiListItemText-root emotion-17"
+            style="text-transform: uppercase;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
+            >
+              Devices
+            </span>
+          </div>
+        </a>
+        <a
+          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16"
+          href="/releases"
+        >
+          <div
+            class="MuiListItemText-root emotion-17"
+            style="text-transform: uppercase;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
+            >
+              Releases
+            </span>
+          </div>
+        </a>
+        <a
+          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16"
+          href="/deployments"
+        >
+          <div
+            class="MuiListItemText-root emotion-17"
+            style="text-transform: uppercase;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
+            >
+              Deployments
+            </span>
+          </div>
+        </a>
+      </ul>
+      <ul
+        class="MuiList-root MuiList-padding emotion-28"
+      >
+        <a
+          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-29"
+          href="/help"
+        >
+          <div
+            class="MuiListItemText-root emotion-17"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
+            >
+              Help & support
+            </span>
+          </div>
+        </a>
+        <li
+          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding emotion-29"
+        >
+          <div
+            class="MuiListItemText-root MuiListItemText-multiline emotion-33"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
+            >
+              <div
+                class="clickable slightly-smaller"
+                data-mui-internal-clone-element="true"
+              >
+                Version: next
+              </div>
+            </span>
+            <p
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary emotion-35"
+            >
+              <a
+                class="emotion-36"
+                href="https://docs.mender.io/development/release-information/open-source-licenses"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                License information
+              </a>
+            </p>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="rightFluid container"
+    >
+      <h4
+        class="margin-left-small"
+      >
+        Dashboard
+      </h4>
+      <div
+        class="emotion-37"
+      >
+        <div
+          class="emotion-38"
+        >
+          <div
+            class="dashboard"
+          >
+            <div
+              class="widget "
+            >
+              <div
+                class="flexbox widgetHeader"
+              >
+                <div
+                  class="flexbox center-aligned"
+                >
+                  Accepted devices 
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium margin-left-small green emotion-6"
+                    data-testid="CheckCircleIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="flexbox column widgetMainContent"
+              >
+                <div
+                  class="counter"
+                >
+                  2
+                </div>
+              </div>
+            </div>
+            <div
+              class="widget emotion-40"
+            >
+              <div
+                class="flexbox widgetHeader"
+              >
+                Devices with issues
+              </div>
+              <div
+                class="widgetMainContent"
+              >
+                <a
+                  class="flexbox center-aligned column emotion-41 green"
+                  href="/devices?issues=offline"
+                >
+                  <div
+                    class="relative emotion-42"
+                  >
+                    <div
+                      class="emotion-43"
+                    >
+                      0
+                    </div>
+                    <div
+                      class="absolute emotion-44"
+                    >
+                      <div
+                        class="relative"
+                      >
+                        <div
+                          class="absolute"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall absolute emotion-45"
+                          data-testid="WifiOffIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M22.99 9C19.15 5.16 13.8 3.76 8.84 4.78l2.52 2.52c3.47-.17 6.99 1.05 9.63 3.7l2-2zm-4 4c-1.29-1.29-2.84-2.13-4.49-2.56l3.53 3.53.96-.97zM2 3.05 5.07 6.1C3.6 6.82 2.22 7.78 1 9l1.99 2c1.24-1.24 2.67-2.16 4.2-2.77l2.24 2.24C7.81 10.89 6.27 11.73 5 13v.01L6.99 15c1.36-1.36 3.14-2.04 4.92-2.06L18.98 20l1.27-1.26L3.29 1.79 2 3.05zM9 17l3 3 3-3c-1.65-1.66-4.34-1.66-6 0z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <p
+                    class="align-center slightly-smaller"
+                  >
+                    Offline
+                  </p>
+                </a>
+                <a
+                  class="flexbox center-aligned column emotion-41 green"
+                  href="/devices?issues=authRequests"
+                >
+                  <div
+                    class="relative emotion-42"
+                  >
+                    <div
+                      class="emotion-43"
+                    >
+                      0
+                    </div>
+                    <div
+                      class="absolute emotion-44"
+                    >
+                      <div
+                        class="relative"
+                      >
+                        <div
+                          class="absolute"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall absolute emotion-45"
+                          data-testid="VpnKeyOutlinedIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M22 19h-6v-4h-2.68c-1.14 2.42-3.6 4-6.32 4-3.86 0-7-3.14-7-7s3.14-7 7-7c2.72 0 5.17 1.58 6.32 4H24v6h-2v4zm-4-2h2v-4h2v-2H11.94l-.23-.67C11.01 8.34 9.11 7 7 7c-2.76 0-5 2.24-5 5s2.24 5 5 5c2.11 0 4.01-1.34 4.71-3.33l.23-.67H18v4zM7 15c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <p
+                    class="align-center slightly-smaller"
+                  >
+                    Authentication requests
+                  </p>
+                </a>
+              </div>
+            </div>
+            <div
+              class="widget flexbox centered"
+            >
+              <p
+                class="muted"
+                style="max-width: 200px;"
+              >
+                + connect more devices
+              </p>
+            </div>
+          </div>
+          <div
+            class="flexbox centered"
+          >
+            <p
+              class="emotion-51 icon flexbox center-aligned emotion-52 "
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-45"
+                data-testid="InfoOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                />
+              </svg>
+              <span>
+                With a more advanced commercial Mender plan you get access to actionable insights into the devices you are updating with Mender. Get an overview of the Mender plans on the 
+                <a
+                  href="https://mender.io/plans/features"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  features page
+                </a>
+                .
+              </span>
+            </p>
+          </div>
+        </div>
+        <div
+          class="emotion-54 deployments"
+        >
+          <div
+            class="dashboard flexbox column"
+            style="grid-template-columns: 1fr; row-gap: 10px;"
+          >
+            <h4
+              class="margin-bottom-none margin-left-small"
+            >
+              Recent deployments
+            </h4>
+            <h5
+              class="margin-bottom-none"
+            >
+              Pending
+            </h5>
+            <h5
+              class="margin-bottom-none"
+            >
+              In Progress
+            </h5>
+            <h5
+              class="margin-bottom-none"
+            >
+              Finished
+            </h5>
+            <a
+              class="margin-top"
+              href="/deployments"
+            >
+              See all deployments
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  .emotion-0 {
   position: fixed;
   display: grid;
   bottom: 0;
@@ -885,514 +1388,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-5:focus::-ms-input-p
   transition: all 0.2s ease-in-out;
 }
 
-<body>
-  <div>
-    <div
-      id="app"
-    >
-      <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular emotion-0"
-        id="fixedHeader"
-      >
-        <div
-          class="flexbox space-between"
-        >
-          <div
-            class="flexbox center-aligned"
-          >
-            <a
-              href="/"
-            >
-              <img
-                id="logo"
-                src="headerlogo.png"
-              />
-            </a>
-          </div>
-          <div
-            class="MuiFormControl-root MuiTextField-root emotion-1"
-          >
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart emotion-2"
-            >
-              <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-standard MuiInputAdornment-sizeSmall emotion-3"
-              >
-                <span
-                  class="notranslate"
-                >
-                  ​
-                </span>
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSize emotion-4"
-                  data-testid="SearchIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                  />
-                </svg>
-              </div>
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart emotion-5"
-                id="mui-1"
-                placeholder="Search devices"
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-          <div
-            class="flexbox center-aligned"
-          >
-            <div
-              class="header-section"
-              data-mui-internal-clone-element="true"
-            >
-              <a
-                class=""
-                href="/devices"
-              >
-                <span>
-                  2
-                </span>
-                <span
-                  id="limit"
-                >
-                  /
-                  500
-                </span>
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
-                  data-testid="DeveloperBoardIcon"
-                  focusable="false"
-                  style="margin: 0px 7px 0px 10px; font-size: 20px;"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z"
-                  />
-                </svg>
-              </a>
-              <a
-                href="/devices/pending"
-                style="margin-left: 7px;"
-              >
-                1
-                 pending
-              </a>
-            </div>
-            <a
-              class="header-section"
-              href="/deployments/active"
-            >
-              <span>
-                0
-              </span>
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium flip-horizontal emotion-7"
-                data-testid="RefreshIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                />
-              </svg>
-            </a>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium header-dropdown emotion-8"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-9"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-10"
-                  data-testid="AccountCircleIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 4c1.93 0 3.5 1.57 3.5 3.5S13.93 13 12 13s-3.5-1.57-3.5-3.5S10.07 6 12 6zm0 14c-2.03 0-4.43-.82-6.14-2.88C7.55 15.8 9.68 15 12 15s4.45.8 6.14 2.12C16.43 19.18 14.03 20 12 20z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiButton-endIcon MuiButton-iconSizeMedium emotion-11"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
-                  data-testid="ArrowDropDownIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m7 10 5 5 5-5z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root emotion-13"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        class="leftFixed leftNav emotion-14"
-      >
-        <ul
-          class="MuiList-root MuiList-padding emotion-15"
-          style="padding: 0px;"
-        >
-          <a
-            aria-current="page"
-            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16 active"
-            href="/"
-          >
-            <div
-              class="MuiListItemText-root emotion-17"
-              style="text-transform: uppercase;"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
-              >
-                Dashboard
-              </span>
-            </div>
-          </a>
-          <a
-            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16"
-            href="/devices"
-          >
-            <div
-              class="MuiListItemText-root emotion-17"
-              style="text-transform: uppercase;"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
-              >
-                Devices
-              </span>
-            </div>
-          </a>
-          <a
-            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16"
-            href="/releases"
-          >
-            <div
-              class="MuiListItemText-root emotion-17"
-              style="text-transform: uppercase;"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
-              >
-                Releases
-              </span>
-            </div>
-          </a>
-          <a
-            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-16"
-            href="/deployments"
-          >
-            <div
-              class="MuiListItemText-root emotion-17"
-              style="text-transform: uppercase;"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
-              >
-                Deployments
-              </span>
-            </div>
-          </a>
-        </ul>
-        <ul
-          class="MuiList-root MuiList-padding emotion-28"
-        >
-          <a
-            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding navLink leftNav emotion-29"
-            href="/help"
-          >
-            <div
-              class="MuiListItemText-root emotion-17"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
-              >
-                Help & support
-              </span>
-            </div>
-          </a>
-          <li
-            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding emotion-29"
-          >
-            <div
-              class="MuiListItemText-root MuiListItemText-multiline emotion-33"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-18"
-              >
-                <div
-                  class="clickable slightly-smaller"
-                  data-mui-internal-clone-element="true"
-                >
-                  Version: next
-                </div>
-              </span>
-              <p
-                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary emotion-35"
-              >
-                <a
-                  class="emotion-36"
-                  href="https://docs.mender.io/development/release-information/open-source-licenses"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  License information
-                </a>
-              </p>
-            </div>
-          </li>
-        </ul>
-      </div>
-      <div
-        class="rightFluid container"
-      >
-        <h4
-          class="margin-left-small"
-        >
-          Dashboard
-        </h4>
-        <div
-          class="emotion-37"
-        >
-          <div
-            class="emotion-38"
-          >
-            <div
-              class="dashboard"
-            >
-              <div
-                class="widget "
-              >
-                <div
-                  class="flexbox widgetHeader"
-                >
-                  <div
-                    class="flexbox center-aligned"
-                  >
-                    Accepted devices 
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium margin-left-small green emotion-6"
-                      data-testid="CheckCircleIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="flexbox column widgetMainContent"
-                >
-                  <div
-                    class="counter"
-                  >
-                    2
-                  </div>
-                </div>
-              </div>
-              <div
-                class="widget emotion-40"
-              >
-                <div
-                  class="flexbox widgetHeader"
-                >
-                  Devices with issues
-                </div>
-                <div
-                  class="widgetMainContent"
-                >
-                  <a
-                    class="flexbox center-aligned column emotion-41 green"
-                    href="/devices?issues=offline"
-                  >
-                    <div
-                      class="relative emotion-42"
-                    >
-                      <div
-                        class="emotion-43"
-                      >
-                        0
-                      </div>
-                      <div
-                        class="absolute emotion-44"
-                      >
-                        <div
-                          class="relative"
-                        >
-                          <div
-                            class="absolute"
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall absolute emotion-45"
-                            data-testid="WifiOffIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M22.99 9C19.15 5.16 13.8 3.76 8.84 4.78l2.52 2.52c3.47-.17 6.99 1.05 9.63 3.7l2-2zm-4 4c-1.29-1.29-2.84-2.13-4.49-2.56l3.53 3.53.96-.97zM2 3.05 5.07 6.1C3.6 6.82 2.22 7.78 1 9l1.99 2c1.24-1.24 2.67-2.16 4.2-2.77l2.24 2.24C7.81 10.89 6.27 11.73 5 13v.01L6.99 15c1.36-1.36 3.14-2.04 4.92-2.06L18.98 20l1.27-1.26L3.29 1.79 2 3.05zM9 17l3 3 3-3c-1.65-1.66-4.34-1.66-6 0z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                    <p
-                      class="align-center slightly-smaller"
-                    >
-                      Offline
-                    </p>
-                  </a>
-                  <a
-                    class="flexbox center-aligned column emotion-41 green"
-                    href="/devices?issues=authRequests"
-                  >
-                    <div
-                      class="relative emotion-42"
-                    >
-                      <div
-                        class="emotion-43"
-                      >
-                        0
-                      </div>
-                      <div
-                        class="absolute emotion-44"
-                      >
-                        <div
-                          class="relative"
-                        >
-                          <div
-                            class="absolute"
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall absolute emotion-45"
-                            data-testid="VpnKeyOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M22 19h-6v-4h-2.68c-1.14 2.42-3.6 4-6.32 4-3.86 0-7-3.14-7-7s3.14-7 7-7c2.72 0 5.17 1.58 6.32 4H24v6h-2v4zm-4-2h2v-4h2v-2H11.94l-.23-.67C11.01 8.34 9.11 7 7 7c-2.76 0-5 2.24-5 5s2.24 5 5 5c2.11 0 4.01-1.34 4.71-3.33l.23-.67H18v4zM7 15c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                    <p
-                      class="align-center slightly-smaller"
-                    >
-                      Authentication requests
-                    </p>
-                  </a>
-                </div>
-              </div>
-              <div
-                class="widget flexbox centered"
-              >
-                <p
-                  class="muted"
-                  style="max-width: 200px;"
-                >
-                  + connect more devices
-                </p>
-              </div>
-            </div>
-            <div
-              class="flexbox centered"
-            >
-              <p
-                class="emotion-51 icon flexbox center-aligned emotion-52 "
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-45"
-                  data-testid="InfoOutlinedIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                  />
-                </svg>
-                <span>
-                  With a more advanced commercial Mender plan you get access to actionable insights into the devices you are updating with Mender. Get an overview of the Mender plans on the 
-                  <a
-                    href="https://mender.io/plans/features"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    features page
-                  </a>
-                  .
-                </span>
-              </p>
-            </div>
-          </div>
-          <div
-            class="emotion-54 deployments"
-          >
-            <div
-              class="dashboard flexbox column"
-              style="grid-template-columns: 1fr; row-gap: 10px;"
-            >
-              <h4
-                class="margin-bottom-none margin-left-small"
-              >
-                Recent deployments
-              </h4>
-              <h5
-                class="margin-bottom-none"
-              >
-                Pending
-              </h5>
-              <h5
-                class="margin-bottom-none"
-              >
-                In Progress
-              </h5>
-              <h5
-                class="margin-bottom-none"
-              >
-                Finished
-              </h5>
-              <a
-                class="margin-top"
-                href="/deployments"
-              >
-                See all deployments
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="emotion-55"
-    />
-  </div>
-</body>
+<div
+    class="emotion-0"
+  />
+</DocumentFragment>
 `;

--- a/src/js/components/devices/__snapshots__/device-groups.test.js.snap
+++ b/src/js/components/devices/__snapshots__/device-groups.test.js.snap
@@ -501,7 +501,7 @@ exports[`DeviceGroups Component renders correctly 1`] = `
                 <div
                   class="flexbox center-aligned"
                 >
-                  Last check-in
+                  Latest activity
                   <svg
                     aria-hidden="true"
                     class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium sortIcon  true css-1lqc678-MuiSvgIcon-root"

--- a/src/js/components/devices/__snapshots__/expanded-device.test.js.snap
+++ b/src/js/components/devices/__snapshots__/expanded-device.test.js.snap
@@ -2059,7 +2059,9 @@ label+.emotion-62 {
             class="muted margin-left margin-right flexbox"
           >
             <div
+              aria-label="The last time the device communicated with the Mender server"
               class="margin-right-small"
+              data-mui-internal-clone-element="true"
             >
               Last check-in:
             </div>

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
@@ -61,7 +61,13 @@ import Filters from './widgets/filters';
 import DeviceIssuesSelection from './widgets/issueselection';
 import ListOptions from './widgets/listoptions';
 
-const refreshDeviceLength = TIMEOUTS.refreshDefault;
+const deviceRefreshTimes = {
+  [DEVICE_STATES.accepted]: TIMEOUTS.refreshLong,
+  [DEVICE_STATES.pending]: TIMEOUTS.refreshDefault,
+  [DEVICE_STATES.preauth]: TIMEOUTS.refreshLong,
+  [DEVICE_STATES.rejected]: TIMEOUTS.refreshLong,
+  default: TIMEOUTS.refreshDefault
+};
 
 const idAttributeTitleMap = {
   id: 'Device ID',
@@ -281,19 +287,21 @@ export const Authorized = ({
     setShowFilters(false);
   }, [selectedGroup]);
 
+  const refreshDevices = useCallback(() => {
+    const refreshLength = deviceRefreshTimes[selectedState] ?? deviceRefreshTimes.default;
+    return dispatch(setDeviceListState({ refreshTrigger: !refreshTrigger })).catch(err =>
+      setRetryTimer(err, 'devices', `Devices couldn't be loaded.`, refreshLength, dispatchedSetSnackbar)
+    );
+  }, [refreshTrigger, selectedState]);
+
   useEffect(() => {
     if (!devicesInitialized) {
       return;
     }
+    const refreshLength = deviceRefreshTimes[selectedState] ?? deviceRefreshTimes.default;
     clearInterval(timer.current);
-    timer.current = setInterval(
-      () =>
-        dispatch(setDeviceListState({ refreshTrigger: !refreshTrigger })).catch(err =>
-          setRetryTimer(err, 'devices', `Devices couldn't be loaded.`, refreshDeviceLength, dispatchedSetSnackbar)
-        ),
-      refreshDeviceLength
-    );
-  }, [devicesInitialized, refreshTrigger]);
+    timer.current = setInterval(() => refreshDevices(), refreshLength);
+  }, [devicesInitialized, selectedState]);
 
   useEffect(() => {
     Object.keys(availableIssueOptions).map(key => dispatch(getIssueCountsByType(key, { filters, group: selectedGroup, state: selectedState })));
@@ -340,8 +348,6 @@ export const Authorized = ({
   const handlePageChange = page => dispatch(setDeviceListState({ selectedId: undefined, page, refreshTrigger: !refreshTrigger }));
 
   const onPageLengthChange = perPage => dispatch(setDeviceListState({ perPage, page: 1, refreshTrigger: !refreshTrigger }));
-
-  const refreshDevices = () => dispatch(setDeviceListState({ refreshTrigger: !refreshTrigger }));
 
   const onSortChange = attribute => {
     let changedSortCol = attribute.name;

--- a/src/js/components/devices/authorized-devices.js
+++ b/src/js/components/devices/authorized-devices.js
@@ -516,7 +516,6 @@ export const Authorized = ({
         actionCallbacks={actionCallbacks}
         deviceId={openedDevice}
         onClose={() => dispatch(setDeviceListState({ selectedId: undefined }))}
-        refreshDevices={refreshDevices}
         setDetailsTab={setDetailsTab}
         tabSelection={tabSelection}
       />

--- a/src/js/components/devices/authorized-devices.test.js
+++ b/src/js/components/devices/authorized-devices.test.js
@@ -153,7 +153,7 @@ describe('AuthorizedDevices Component', () => {
       columnSelection: [
         { id: 'inventory-device_type', key: attributeNames.deviceType, name: attributeNames.deviceType, scope: 'inventory', title: 'Device type' },
         { id: 'inventory-rootfs-image.version', key: attributeNames.artifact, name: attributeNames.artifact, scope: 'inventory', title: 'Current software' },
-        { id: 'system-updated_ts', key: attributeNames.updateTime, name: attributeNames.updateTime, scope: 'system', title: 'Last check-in' },
+        { id: 'system-updated_ts', key: attributeNames.updateTime, name: attributeNames.updateTime, scope: 'system', title: 'Latest activity' },
         { id: 'inventory-testKey', key: testKey, name: testKey, scope: 'inventory', title: testKey }
       ]
     });

--- a/src/js/components/devices/base-devices.js
+++ b/src/js/components/devices/base-devices.js
@@ -175,7 +175,7 @@ export const defaultHeaders = {
     textRender: getDeviceTypeText
   },
   lastCheckIn: {
-    title: 'Last check-in',
+    title: 'Latest activity',
     attribute: { name: 'updated_ts', scope: 'system' },
     component: RelativeDeviceTime,
     sortable: true

--- a/src/js/components/devices/device-details/__snapshots__/deviceinventory.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/deviceinventory.test.js.snap
@@ -35,11 +35,27 @@ exports[`DeviceInventory Component renders correctly 1`] = `
     class="flexbox space-between"
     style="align-items: flex-start;"
   >
-    <h4
-      class="margin-bottom-small"
+    <div
+      class="flexbox"
+      style="align-items: baseline;"
     >
-      Device inventory
-    </h4>
+      <h4
+        class="margin-right"
+      >
+        Device Inventory
+      </h4>
+      <div
+        class="muted slightly-smaller"
+        style="margin-top: 2px;"
+      >
+        Last synced: 
+        <time
+          datetime="2019-01-13T13:00:00+00:00"
+        >
+          2019-01-13 13:00
+        </time>
+      </div>
+    </div>
     <div
       class="flexbox centered"
     />

--- a/src/js/components/devices/device-details/__snapshots__/devicetwin.test.js.snap
+++ b/src/js/components/devices/device-details/__snapshots__/devicetwin.test.js.snap
@@ -2,6 +2,17 @@
 
 exports[`DeviceTwin Component renders correctly 1`] = `
 .emotion-0 {
+  width: 100%;
+}
+
+.emotion-1 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -52,23 +63,23 @@ exports[`DeviceTwin Component renders correctly 1`] = `
   font-weight: bold;
 }
 
-.emotion-0::-moz-focus-inner {
+.emotion-2::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-0.Mui-disabled {
+.emotion-2.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-0 {
+  .emotion-2 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-0:hover {
+.emotion-2:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: rgb(65, 10, 46);
@@ -76,34 +87,34 @@ exports[`DeviceTwin Component renders correctly 1`] = `
 }
 
 @media (hover: none) {
-  .emotion-0:hover {
+  .emotion-2:hover {
     background-color: #5d0f43;
   }
 }
 
-.emotion-0:active {
+.emotion-2:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-0.Mui-focusVisible {
+.emotion-2.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-0.Mui-disabled {
+.emotion-2.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-0:hover {
+.emotion-2:hover {
   colors: #337a87;
 }
 
-.emotion-0.MuiButton-text {
+.emotion-2.MuiButton-text {
   color: rgba(10, 10, 11, 0.78);
 }
 
-.emotion-1 {
+.emotion-3 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -115,7 +126,7 @@ exports[`DeviceTwin Component renders correctly 1`] = `
   border-radius: inherit;
 }
 
-.emotion-2 {
+.emotion-4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -165,57 +176,57 @@ exports[`DeviceTwin Component renders correctly 1`] = `
   padding: 10px 15px;
 }
 
-.emotion-2::-moz-focus-inner {
+.emotion-4::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-2.Mui-disabled {
+.emotion-4.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-2 {
+  .emotion-4 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-2:hover {
+.emotion-4:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: rgba(51, 122, 135, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-2:hover {
+  .emotion-4:hover {
     background-color: transparent;
   }
 }
 
-.emotion-2.Mui-disabled {
+.emotion-4.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-2:hover {
+.emotion-4:hover {
   colors: #337a87;
 }
 
-.emotion-2.MuiButton-text {
+.emotion-4.MuiButton-text {
   color: rgba(10, 10, 11, 0.78);
 }
 
-.emotion-3 {
+.emotion-5 {
   display: inherit;
   margin-right: 8px;
   margin-left: -4px;
 }
 
-.emotion-3>*:nth-of-type(1) {
+.emotion-5>*:nth-of-type(1) {
   font-size: 20px;
 }
 
-.emotion-4 {
+.emotion-6 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -232,7 +243,7 @@ exports[`DeviceTwin Component renders correctly 1`] = `
   font-size: 1.3929rem;
 }
 
-.emotion-4 iconButton {
+.emotion-6 iconButton {
   margin-right: 8px;
 }
 
@@ -244,15 +255,30 @@ exports[`DeviceTwin Component renders correctly 1`] = `
     style="align-items: flex-start;"
   >
     <div
-      class="flexbox center-aligned"
+      class="flexbox center-aligned space-between emotion-0"
     >
-      <h4
-        class="margin-right"
+      <div
+        class="flexbox emotion-1"
       >
-        Azure IoT Hub
-         
-        Device Twin
-      </h4>
+        <h4
+          class="margin-right"
+        >
+          Azure IoT Hub
+           
+          Device Twin
+        </h4>
+        <div
+          class="muted slightly-smaller"
+          style="margin-top: 2px;"
+        >
+          Last synced: 
+          <time
+            datetime="2019-01-13T06:25:00+00:00"
+          >
+            2019-01-13 06:25
+          </time>
+        </div>
+      </div>
       <a
         href="/settings/integrations"
       >
@@ -346,13 +372,13 @@ exports[`DeviceTwin Component renders correctly 1`] = `
         style="align-items: flex-start; justify-content: flex-end;"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-0"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-2"
           tabindex="0"
           type="button"
         >
           Edit desired configuration
           <span
-            class="MuiTouchRipple-root emotion-1"
+            class="MuiTouchRipple-root emotion-3"
           />
         </button>
       </div>
@@ -381,16 +407,16 @@ exports[`DeviceTwin Component renders correctly 1`] = `
           </div>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium emotion-2"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium emotion-4"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-3"
+            class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-5"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-4"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
               data-testid="RefreshIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -402,7 +428,7 @@ exports[`DeviceTwin Component renders correctly 1`] = `
           </span>
           Refresh
           <span
-            class="MuiTouchRipple-root emotion-1"
+            class="MuiTouchRipple-root emotion-3"
           />
         </button>
       </div>
@@ -412,16 +438,42 @@ exports[`DeviceTwin Component renders correctly 1`] = `
 `;
 
 exports[`DeviceTwin Component renders sub component Title correctly 1`] = `
+.emotion-0 {
+  width: 100%;
+}
+
+.emotion-1 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
 <div
-  class="flexbox center-aligned"
+  class="flexbox center-aligned space-between emotion-0"
 >
-  <h4
-    class="margin-right"
+  <div
+    class="flexbox emotion-1"
   >
-    Test
-     
-    Device Twin
-  </h4>
+    <h4
+      class="margin-right"
+    >
+      Test
+       
+      Device Twin
+    </h4>
+    <div
+      class="muted slightly-smaller"
+      style="margin-top: 2px;"
+    >
+      Last synced: 
+      <time
+        datetime="2019-01-01T09:25:00+00:00"
+      >
+        2019-01-01 09:25
+      </time>
+    </div>
+  </div>
   <a
     href="/settings/integrations"
   >
@@ -512,7 +564,7 @@ exports[`DeviceTwin Component renders sub component TwinSyncStatus correctly 1`]
 }
 
 <div
-  class="padding,css-8wzxjs-root"
+  class="padding,css-1hs2uht-diffStatus"
 >
   <svg
     aria-hidden="true"
@@ -527,17 +579,6 @@ exports[`DeviceTwin Component renders sub component TwinSyncStatus correctly 1`]
   </svg>
   <div>
     No difference between desired and reported configuration
-  </div>
-  <div
-    class="muted slightly-smaller"
-    style="align-content: flex-end; margin-bottom: -10px;"
-  >
-    Last synced: 
-    <time
-      datetime="2019-01-01T09:25:00+00:00"
-    >
-      2019-01-01 09:25
-    </time>
   </div>
 </div>
 `;
@@ -590,7 +631,7 @@ exports[`DeviceTwin Component renders sub component TwinSyncStatus correctly 2`]
   </div>
   <div
     class="muted slightly-smaller"
-    style="align-content: flex-end; margin-bottom: -10px;"
+    style="margin-top: 2px;"
   >
     Last synced: 
     <time

--- a/src/js/components/devices/device-details/authsets/authsets.js
+++ b/src/js/components/devices/device-details/authsets/authsets.js
@@ -40,7 +40,7 @@ const useStyles = makeStyles()(theme => ({
   }
 }));
 
-export const Authsets = ({ decommission, device, deviceListRefresh, showHelptips }) => {
+export const Authsets = ({ decommission, device, showHelptips }) => {
   const [confirmDecommission, setConfirmDecomission] = useState(false);
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
@@ -53,25 +53,10 @@ export const Authsets = ({ decommission, device, deviceListRefresh, showHelptips
 
   const updateDeviceAuthStatus = (device_id, auth_id, status) => {
     setLoading(auth_id);
-    const postUpdateSteps = () => {
-      deviceListRefresh();
-      setLoading(null);
-    };
-
-    if (status === DEVICE_DISMISSAL_STATE) {
-      return (
-        dispatch(deleteAuthset(device_id, auth_id))
-          // on finish, change "loading" back to null
-          .finally(postUpdateSteps)
-      );
-    } else {
-      // call API to update authset
-      return (
-        dispatch(updateDeviceAuth(device_id, auth_id, status))
-          // on finish, change "loading" back to null
-          .finally(postUpdateSteps)
-      );
-    }
+    // call API to update authset
+    const request = status === DEVICE_DISMISSAL_STATE ? dispatch(deleteAuthset(device_id, auth_id)) : dispatch(updateDeviceAuth(device_id, auth_id, status));
+    // on finish, change "loading" back to null
+    return request.finally(() => setLoading(null));
   };
 
   const { canManageDevices } = userCapabilities;

--- a/src/js/components/devices/device-details/authstatus.js
+++ b/src/js/components/devices/device-details/authstatus.js
@@ -32,7 +32,7 @@ const states = {
   preauthorized: <CheckIcon style={iconStyle} />
 };
 
-export const AuthStatus = ({ decommission, device, deviceListRefresh, showHelptips }) => {
+export const AuthStatus = ({ decommission, device, showHelptips }) => {
   const { auth_sets = [], status = DEVICE_STATES.accepted } = device;
 
   let hasPending = '';
@@ -61,7 +61,7 @@ export const AuthStatus = ({ decommission, device, deviceListRefresh, showHelpti
         </div>
       }
     >
-      <Authsets decommission={decommission} device={device} deviceListRefresh={deviceListRefresh} showHelptips={showHelptips} />
+      <Authsets decommission={decommission} device={device} showHelptips={showHelptips} />
     </DeviceDataCollapse>
   );
 };

--- a/src/js/components/devices/device-details/deviceinventory.js
+++ b/src/js/components/devices/device-details/deviceinventory.js
@@ -17,9 +17,19 @@ import { extractSoftware } from '../../../helpers';
 import { TwoColumnDataMultiple } from '../../common/configurationobject';
 import DeviceDataCollapse from './devicedatacollapse';
 import DeviceInventoryLoader from './deviceinventoryloader';
+import { LastSyncNote } from './devicetwin';
+
+export const Title = ({ updateTime }) => {
+  return (
+    <div className="flexbox" style={{ alignItems: 'baseline' }}>
+      <h4 className="margin-right">Device Inventory</h4>
+      <LastSyncNote updateTime={updateTime} />
+    </div>
+  );
+};
 
 export const DeviceInventory = ({ device, docsVersion, setSnackbar }) => {
-  const { attributes = {} } = device;
+  const { attributes = {}, updated_ts: updateTime } = device;
 
   const { device_type, ...remainingAttributes } = attributes;
 
@@ -53,7 +63,7 @@ export const DeviceInventory = ({ device, docsVersion, setSnackbar }) => {
           <TwoColumnDataMultiple config={keyContent} setSnackbar={setSnackbar} style={{ marginBottom: 5 }} />
         )
       }
-      title="Device inventory"
+      title={<Title updateTime={updateTime} />}
     >
       <TwoColumnDataMultiple config={deviceInventory} setSnackbar={setSnackbar} />
     </DeviceDataCollapse>

--- a/src/js/components/devices/device-details/devicetwin.js
+++ b/src/js/components/devices/device-details/devicetwin.js
@@ -16,7 +16,6 @@ import { Link } from 'react-router-dom';
 
 import { CheckCircleOutlined, CloudUploadOutlined as CloudUpload, Refresh as RefreshIcon } from '@mui/icons-material';
 import { Button } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
 import Editor, { DiffEditor, loader } from '@monaco-editor/react';
@@ -32,8 +31,11 @@ import DeviceDataCollapse from './devicedatacollapse';
 
 loader.config({ paths: { vs: '/ui/vs' } });
 
-const diffStatusStyle = makeStyles()(theme => ({
-  root: {
+const useStyles = makeStyles()(theme => ({
+  buttonSpacer: { marginLeft: theme.spacing(2) },
+  title: { alignItems: 'baseline' },
+  titleContainer: { width: '100%' },
+  diffStatus: {
     minHeight: 75,
     display: 'grid',
     gridTemplateColumns: 'min-content 300px max-content',
@@ -44,19 +46,18 @@ const diffStatusStyle = makeStyles()(theme => ({
   }
 }));
 
-const LastSyncNote = ({ updateTime }) => (
-  <div className="muted slightly-smaller" style={{ alignContent: 'flex-end', marginBottom: -10 }}>
+export const LastSyncNote = ({ updateTime }) => (
+  <div className="muted slightly-smaller" style={{ marginTop: 2 }}>
     Last synced: <Time value={updateTime} />
   </div>
 );
 
-const NoDiffStatus = ({ updateTime }) => {
-  const { classes } = diffStatusStyle();
+const NoDiffStatus = () => {
+  const { classes } = useStyles();
   return (
-    <div className={['padding', classes.root]}>
+    <div className={['padding', classes.diffStatus]}>
       <CheckCircleOutlined className="green" />
       <div>No difference between desired and reported configuration</div>
-      <LastSyncNote updateTime={updateTime} />
     </div>
   );
 };
@@ -75,14 +76,14 @@ export const TwinError = ({ providerTitle, twinError }) => (
 );
 
 export const TwinSyncStatus = ({ diffCount, providerTitle, twinError, updateTime }) => {
-  const classes = diffStatusStyle();
+  const classes = useStyles();
   if (twinError) {
     return <TwinError providerTitle={providerTitle} twinError={twinError} />;
   }
   return !diffCount ? (
-    <NoDiffStatus updateTime={updateTime} />
+    <NoDiffStatus />
   ) : (
-    <div className={['padding', classes.root]}>
+    <div className={['padding', classes.diffStatus]}>
       <CloudUpload />
       <div>
         <b>
@@ -95,14 +96,20 @@ export const TwinSyncStatus = ({ diffCount, providerTitle, twinError, updateTime
   );
 };
 
-export const Title = ({ providerTitle, twinTitle }) => (
-  <div className="flexbox center-aligned">
-    <h4 className="margin-right">
-      {providerTitle} {twinTitle}
-    </h4>
-    <Link to="/settings/integrations">Integration settings</Link>
-  </div>
-);
+export const Title = ({ providerTitle, twinTitle, updateTime }) => {
+  const { classes } = useStyles();
+  return (
+    <div className={`flexbox center-aligned space-between ${classes.titleContainer}`}>
+      <div className={`flexbox ${classes.title}`}>
+        <h4 className="margin-right">
+          {providerTitle} {twinTitle}
+        </h4>
+        <LastSyncNote updateTime={updateTime} />
+      </div>
+      <Link to="/settings/integrations">Integration settings</Link>
+    </div>
+  );
+};
 
 const editorProps = {
   height: 500,
@@ -131,7 +138,6 @@ const indentation = 4; // number of spaces, tab based indentation won't show in 
 const stringifyTwin = twin => JSON.stringify(twin, undefined, indentation) ?? '';
 
 export const DeviceTwin = ({ device, getDeviceTwin, integration, setDeviceTwin }) => {
-  const theme = useTheme();
   const [configured, setConfigured] = useState('');
   const [diffCount, setDiffCount] = useState(0);
   const [isEditing, setIsEditing] = useState(false);
@@ -142,6 +148,7 @@ export const DeviceTwin = ({ device, getDeviceTwin, integration, setDeviceTwin }
   const [updated, setUpdated] = useState('');
   const [isSync, setIsSync] = useState(true);
   const editorRef = useRef(null);
+  const { classes } = useStyles();
 
   const externalProvider = EXTERNAL_PROVIDER[integration.provider];
   const { [integration.id]: deviceTwin = {} } = device.twinsByIntegration ?? {};
@@ -226,7 +233,7 @@ export const DeviceTwin = ({ device, getDeviceTwin, integration, setDeviceTwin }
           )}
         </div>
       }
-      title={<Title providerTitle={externalProvider.title} twinTitle={externalProvider.twinTitle} />}
+      title={<Title providerTitle={externalProvider.title} twinTitle={externalProvider.twinTitle} updateTime={updateTime} />}
     >
       <div className={`flexbox column ${isEditing ? 'twin-editing' : ''}`}>
         <div style={widthStyle}>
@@ -270,7 +277,7 @@ export const DeviceTwin = ({ device, getDeviceTwin, integration, setDeviceTwin }
             {isEditing ? (
               <>
                 <Button onClick={onCancelClick}>Cancel</Button>
-                <Button color="secondary" onClick={onApplyClick} style={{ marginLeft: theme.spacing(2) }} variant="contained">
+                <Button className={classes.buttonSpacer} color="secondary" onClick={onApplyClick} variant="contained">
                   Save
                 </Button>
               </>

--- a/src/js/components/devices/device-details/identity.js
+++ b/src/js/components/devices/device-details/identity.js
@@ -61,10 +61,10 @@ export const DeviceIdentity = ({ device, setSnackbar }) => {
 
 export default DeviceIdentity;
 
-export const IdentityTab = ({ device, setDeviceTags, setSnackbar, showHelptips, userCapabilities, refreshDevices, onDecommissionDevice }) => (
+export const IdentityTab = ({ device, setDeviceTags, setSnackbar, showHelptips, userCapabilities, onDecommissionDevice }) => (
   <>
     <DeviceIdentity device={device} setSnackbar={setSnackbar} />
-    <AuthStatus device={device} decommission={onDecommissionDevice} deviceListRefresh={refreshDevices} showHelptips={showHelptips} />
+    <AuthStatus device={device} decommission={onDecommissionDevice} showHelptips={showHelptips} />
     <DeviceTags device={device} setSnackbar={setSnackbar} setDeviceTags={setDeviceTags} showHelptips={showHelptips} userCapabilities={userCapabilities} />
   </>
 );

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -24,7 +24,6 @@ import { setOfflineThreshold, setSnackbar } from '../../actions/appActions';
 import {
   addDynamicGroup,
   addStaticGroup,
-  getAllDeviceCounts,
   preauthDevice,
   removeDevicesFromGroup,
   removeDynamicGroup,
@@ -35,7 +34,7 @@ import {
   updateDynamicGroup
 } from '../../actions/deviceActions';
 import { setShowConnectingDialog } from '../../actions/userActions';
-import { SORTING_OPTIONS, TIMEOUTS } from '../../constants/appConstants';
+import { SORTING_OPTIONS } from '../../constants/appConstants';
 import { DEVICE_FILTERING_OPTIONS, DEVICE_ISSUE_OPTIONS, DEVICE_STATES, emptyFilter } from '../../constants/deviceConstants';
 import { toggle } from '../../helpers';
 import {
@@ -65,8 +64,6 @@ import CreateGroupExplainer from './group-management/create-group-explainer';
 import RemoveGroup from './group-management/remove-group';
 import Groups from './groups';
 import DeviceAdditionWidget from './widgets/deviceadditionwidget';
-
-const refreshLength = TIMEOUTS.refreshDefault;
 
 export const DeviceGroups = () => {
   const [createGroupExplanation, setCreateGroupExplanation] = useState(false);
@@ -160,12 +157,7 @@ export const DeviceGroups = () => {
       dispatch(setDeviceFilters([...filters, { ...emptyFilter, key: 'id', operator: DEVICE_FILTERING_OPTIONS.$in.key, value: id }]));
     }
     dispatch(setDeviceListState(listState));
-    clearInterval(deviceTimer.current);
-    deviceTimer.current = setInterval(() => dispatch(getAllDeviceCounts()), refreshLength);
     dispatch(setOfflineThreshold());
-    return () => {
-      clearInterval(deviceTimer.current);
-    };
   }, []);
 
   /*

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -205,7 +205,7 @@ const tabs = [
   }
 ];
 
-export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, refreshDevices, setDetailsTab, tabSelection }) => {
+export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, setDetailsTab, tabSelection }) => {
   const [socketClosed, setSocketClosed] = useState(true);
   const [troubleshootType, setTroubleshootType] = useState();
   const timer = useRef();
@@ -258,15 +258,8 @@ export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, refreshDevi
     dispatch(getGatewayDevices(device.id));
   }, [device.id, mender_gateway_system_id]);
 
-  const onDecommissionDevice = device_id => {
-    // close dialog!
-    // close expanded device
-    // trigger reset of list!
-    return dispatch(decommissionDevice(device_id)).finally(() => {
-      refreshDevices();
-      onClose();
-    });
-  };
+  // close expanded device
+  const onDecommissionDevice = device_id => dispatch(decommissionDevice(device_id)).finally(onClose);
 
   const launchTroubleshoot = type => {
     Tracking.event({ category: 'devices', action: 'open_terminal' });
@@ -323,7 +316,6 @@ export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, refreshDevi
     latestAlerts,
     launchTroubleshoot,
     onDecommissionDevice,
-    refreshDevices,
     resetDeviceDeployments: id => dispatch(resetDeviceDeployments(id)),
     saveGlobalSettings: settings => dispatch(saveGlobalSettings(settings)),
     setDetailsTab,

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -16,7 +16,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { Close as CloseIcon, Link as LinkIcon } from '@mui/icons-material';
-import { Chip, Divider, Drawer, IconButton, Tab, Tabs, chipClasses } from '@mui/material';
+import { Chip, Divider, Drawer, IconButton, Tab, Tabs, Tooltip, chipClasses } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 import copy from 'copy-to-clipboard';
@@ -353,7 +353,9 @@ export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, setDetailsT
             />
           )}
           <div className={`${isOffline ? 'red' : 'muted'} margin-left margin-right flexbox`}>
-            <div className="margin-right-small">Last check-in:</div>
+            <Tooltip title="The last time the device communicated with the Mender server" placement="bottom">
+              <div className="margin-right-small">Last check-in:</div>
+            </Tooltip>
             <RelativeTime updateTime={device.updated_ts} />
           </div>
           <IconButton style={{ marginLeft: 'auto' }} onClick={onCloseClick} aria-label="close" size="large">

--- a/src/js/components/header/header.js
+++ b/src/js/components/header/header.js
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
@@ -32,6 +32,7 @@ import logo from '../../../assets/img/headerlogo.png';
 import whiteEnterpriseLogo from '../../../assets/img/whiteheaderlogo-enterprise.png';
 import whiteLogo from '../../../assets/img/whiteheaderlogo.png';
 import { setFirstLoginAfterSignup, setSearchState } from '../../actions/appActions';
+import { getAllDeviceCounts } from '../../actions/deviceActions';
 import { initializeSelf, logoutUser, setHideAnnouncement, toggleHelptips } from '../../actions/userActions';
 import { getToken } from '../../auth';
 import { TIMEOUTS } from '../../constants/appConstants';
@@ -127,6 +128,7 @@ export const Header = ({ mode }) => {
   const { pending: pendingDevices } = useSelector(getDeviceCountsByStatus);
   const user = useSelector(getCurrentUser);
   const dispatch = useDispatch();
+  const deviceTimer = useRef();
 
   useEffect(() => {
     if ((!sessionId || !user?.id || !user.email.length) && !gettingUser && !loggingOut) {
@@ -144,9 +146,13 @@ export const Header = ({ mode }) => {
   }, [sessionId, user.id, user.email, gettingUser, loggingOut]);
 
   useEffect(() => {
-    // updateUsername();
     const showOfferCookie = cookies.get('offer') === currentOffer.name;
     setHasOfferCookie(showOfferCookie);
+    clearInterval(deviceTimer.current);
+    deviceTimer.current = setInterval(() => dispatch(getAllDeviceCounts()), TIMEOUTS.refreshDefault);
+    return () => {
+      clearInterval(deviceTimer.current);
+    };
   }, []);
 
   const updateUsername = () => {

--- a/src/js/constants/appConstants.js
+++ b/src/js/constants/appConstants.js
@@ -52,7 +52,8 @@ export const TIMEOUTS = {
   twoSeconds: 2 * oneSecond,
   threeSeconds: 3 * oneSecond,
   fiveSeconds: 5 * oneSecond,
-  refreshDefault: 10 * oneSecond
+  refreshDefault: 10 * oneSecond,
+  refreshLong: 60 * oneSecond
 };
 export const locations = {
   eu: { key: 'eu', title: 'EU', location: 'eu.hosted.mender.io', icon: FlagEU },

--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -121,7 +121,8 @@ export const getFilterAttributes = createSelector(
   ({ previousFilters }, { identityAttributes, inventoryAttributes, systemAttributes, tagAttributes }) => {
     const deviceNameAttribute = { key: 'name', value: 'Name', scope: ATTRIBUTE_SCOPES.tags, category: ATTRIBUTE_SCOPES.tags, priority: 1 };
     const deviceIdAttribute = { key: 'id', value: 'Device ID', scope: ATTRIBUTE_SCOPES.identity, category: ATTRIBUTE_SCOPES.identity, priority: 1 };
-    const checkInAttribute = { key: 'updated_ts', value: 'Last check-in', scope: ATTRIBUTE_SCOPES.system, category: ATTRIBUTE_SCOPES.system, priority: 4 };
+    const checkInAttribute = { key: 'check_in_time', value: 'Latest activity', scope: ATTRIBUTE_SCOPES.system, category: ATTRIBUTE_SCOPES.system, priority: 4 };
+    const updateAttribute = { ...checkInAttribute, key: 'updated_ts', value: 'Last inventory update' };
     const firstRequestAttribute = { key: 'created_ts', value: 'First request', scope: ATTRIBUTE_SCOPES.system, category: ATTRIBUTE_SCOPES.system, priority: 4 };
     const attributes = [
       ...previousFilters.map(item => ({
@@ -136,6 +137,7 @@ export const getFilterAttributes = createSelector(
       ...inventoryAttributes.map(item => ({ key: item, value: item, scope: ATTRIBUTE_SCOPES.inventory, category: ATTRIBUTE_SCOPES.inventory, priority: 2 })),
       ...tagAttributes.map(item => ({ key: item, value: item, scope: ATTRIBUTE_SCOPES.tags, category: ATTRIBUTE_SCOPES.tags, priority: 3 })),
       checkInAttribute,
+      updateAttribute,
       firstRequestAttribute,
       ...systemAttributes.map(item => ({ key: item, value: item, scope: ATTRIBUTE_SCOPES.system, category: ATTRIBUTE_SCOPES.system, priority: 4 }))
     ];


### PR DESCRIPTION
Reviewer notes:
This makes the UI ready for the introduction of the device check in time, so a less fine-grained check in value for the device list and a more accurate value in the device details.
Since the device list is less accurate now, the refresh times of the device list for all status' except for `pending` are now longer. The device count in the header of the UI should now also be updated when not on the device list.
Also the refresh of the device list in a change to a device auth set is now handled in the "backend" of the frontend, which is for a looser coupling and better testability, but shouldn't be noticeable.

Also note: the check in time only really works with reporting, so an inventory only setup will still rely on the `updated_ts`, but this should not be noticeable by a user...