### PR TITLE
Offline container startup support 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,12 @@ if [ -n "$GATEWAY_PORT" ]; then
     HOSTNAME=$HOSTNAME':'$GATEWAY_PORT
 fi
 
-wget -O /var/www/mender-gui/dist/tags.json https://api.github.com/repos/mendersoftware/gui/tags?per_page=10
+if [ -n "$MENDER_HOSTED" ]; then
+  wget -O /var/www/mender-gui/dist/tags.json https://api.github.com/repos/mendersoftware/gui/tags?per_page=10
+else
+  echo "[]" >> /var/www/mender-gui/dist/tags.json
+fi
+
 cat >/var/www/mender-gui/dist/env.js <<EOF
   mender_environment = {
     hostAddress: "$HOSTNAME",


### PR DESCRIPTION
chore: made tags retrieval optional to ease image startup without connectivity or in non-hosted environments