### PR TITLE
Chore/simplify test setup

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -18,6 +18,7 @@ import * as DeviceConstants from '../constants/deviceConstants';
 import { rootfsImageVersion } from '../constants/releaseConstants';
 import { attributeDuplicateFilter, deepCompare, extractErrorMessage, getSnackbarMessage, mapDeviceAttributes } from '../helpers';
 import {
+  getDeviceById as getDeviceByIdSelector,
   getDeviceFilters,
   getDeviceTwinIntegrations,
   getGroups as getGroupsSelector,
@@ -312,7 +313,7 @@ const getLatestTs = (dateA = '', dateB = '') => (!dateA || !dateB ? dateA || dat
 const reduceReceivedDevices = (devices, ids, state, status) =>
   devices.reduce(
     (accu, device) => {
-      const stateDevice = state.devices.byId[device.id] || {};
+      const stateDevice = getDeviceByIdSelector(state, device.id);
       const {
         attributes: storedAttributes = {},
         identity_data: storedIdentity = {},
@@ -1161,7 +1162,7 @@ export const getSystemDevices =
   (dispatch, getState) => {
     const { page = defaultPage, perPage = defaultPerPage, sortOptions = [] } = options;
     const state = getState();
-    let device = state.devices.byId[id];
+    let device = getDeviceByIdSelector(state, id);
     const { attributes: deviceAttributes = {} } = device;
     const { mender_gateway_system_id = '' } = deviceAttributes;
     const { hasFullFiltering } = getTenantCapabilities(state);
@@ -1204,7 +1205,7 @@ export const getSystemDevices =
 
 export const getGatewayDevices = deviceId => (dispatch, getState) => {
   const state = getState();
-  let device = state.devices.byId[deviceId];
+  let device = getDeviceByIdSelector(state, deviceId);
   const { attributes = {} } = device;
   const { mender_gateway_system_id = '' } = attributes;
   const filters = [

--- a/src/js/components/__snapshots__/app.test.js.snap
+++ b/src/js/components/__snapshots__/app.test.js.snap
@@ -870,6 +870,151 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-5:focus::-ms-input-p
   }
 }
 
+.emotion-55 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #f7f7f7;
+  border-radius: 8px;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  max-width: 500px;
+  padding: 8px;
+}
+
+.emotion-55>div:last-child {
+  width: 100%;
+}
+
+.emotion-56 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: inherit;
+}
+
+.emotion-56 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-60 {
+  background-color: #f7f7f7;
+  padding: 10px 20px;
+  border-radius: 4px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  min-height: 70px;
+}
+
+.emotion-60 .chart-container {
+  min-height: 70px;
+}
+
+.emotion-60 .progress-chart {
+  min-height: 45px;
+}
+
+.emotion-60 .compact .progress-step,
+.emotion-60 .detailed .progress-step {
+  min-height: 45px;
+}
+
+.emotion-60 .progress-step,
+.emotion-60 .detailed .progress-step-total {
+  position: absolute;
+  border-right-style: none;
+}
+
+.emotion-60 .progress-step-total .progress-bar {
+  background-color: #d4e9e7;
+}
+
+.emotion-60 .progress-step-number {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+}
+
+.emotion-60.minimal {
+  padding: initial;
+}
+
+.emotion-60.no-background {
+  background: none;
+}
+
+.emotion-60.stepped-progress .progress-step-total {
+  margin-left: -0.25%;
+  width: 100.5%;
+}
+
+.emotion-60.stepped-progress .progress-step-total .progress-bar {
+  background-color: #fff;
+  border: 1px solid #a9a9a9;
+  border-radius: 2px;
+  height: 12px;
+}
+
+.emotion-60.stepped-progress .detailed .progress-step {
+  min-height: 20px;
+}
+
+.emotion-63 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 500px;
+}
+
+.emotion-63>time {
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: flex-end;
+  align-self: flex-end;
+  margin-right: 6px;
+}
+
+.emotion-65 {
+  background: #fff;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.emotion-66 {
+  -webkit-column-gap: 8px;
+  column-gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 32px);
+}
+
+.emotion-66>div {
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+}
+
+.emotion-66 .disabled {
+  opacity: 0.1;
+}
+
 <div
     id="app"
   >
@@ -972,7 +1117,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-5:focus::-ms-input-p
             href="/deployments/active"
           >
             <span>
-              0
+              2
             </span>
             <svg
               aria-hidden="true"
@@ -1351,16 +1496,379 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-5:focus::-ms-input-p
             >
               Pending
             </h5>
+            <div
+              class="clickable emotion-55"
+            >
+              <div>
+                <div>
+                  r1
+                </div>
+                <div
+                  class=""
+                  title="test deployment"
+                >
+                  test deployment
+                </div>
+              </div>
+              <div
+                class="flexbox center-aligned"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-56"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+                  />
+                </svg>
+                <span
+                  class="margin-left-small"
+                >
+                  Queued to start
+                </span>
+              </div>
+            </div>
+            <div
+              class="clickable emotion-55"
+            >
+              <div>
+                <div>
+                  r1
+                </div>
+                <div
+                  class=""
+                  title="test deployment 2"
+                >
+                  test deployment 2
+                </div>
+              </div>
+              <div
+                class="flexbox center-aligned"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-56"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+                  />
+                </svg>
+                <span
+                  class="margin-left-small"
+                >
+                  Queued to start
+                </span>
+              </div>
+            </div>
             <h5
               class="margin-bottom-none"
             >
               In Progress
             </h5>
+            <div
+              class="clickable emotion-55"
+            >
+              <div>
+                <div>
+                  r1
+                </div>
+                <div
+                  class=""
+                  title="test deployment"
+                >
+                  test deployment
+                </div>
+              </div>
+              <div
+                class="relative emotion-60 minimal "
+              >
+                <div
+                  class="chart-container"
+                >
+                  <div
+                    class="progress-chart relative detailed"
+                  >
+                    <div
+                      class="progress-step"
+                      style="left: 0%; width: 100%;"
+                    >
+                      <div
+                        class="progress-bar"
+                        style="width: 100%; background-color: rgb(170, 170, 170);"
+                      />
+                      <div
+                        style="display: contents;"
+                      >
+                        <div
+                          class="progress-bar green"
+                          style="width: 0%;"
+                        />
+                        <div
+                          class="progress-bar warning"
+                          style="left: 0%; width: 0%;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="progress-step relative flexbox progress-step-total"
+                    >
+                      <div
+                        class="progress-bar"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="clickable emotion-55"
+            >
+              <div>
+                <div>
+                  r1
+                </div>
+                <div
+                  class=""
+                  title="test deployment 2"
+                >
+                  test deployment 2
+                </div>
+              </div>
+              <div
+                class="flexbox center-aligned"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-56"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+                  />
+                </svg>
+                <span
+                  class="margin-left-small"
+                >
+                  Queued to start
+                </span>
+              </div>
+            </div>
             <h5
               class="margin-bottom-none"
             >
               Finished
             </h5>
+            <div
+              class="emotion-63"
+            >
+              <time
+                class="muted slightly-smaller"
+                datetime="2019-01-13T13:15:00+00:00"
+              >
+                2019-01-13 13:15
+              </time>
+              <div
+                class="clickable emotion-55"
+              >
+                <div>
+                  <div>
+                    r1
+                  </div>
+                  <div
+                    class=""
+                    title="test deployment"
+                  >
+                    test deployment
+                  </div>
+                </div>
+                <div
+                  class="emotion-65"
+                >
+                  <div
+                    class="flexbox emotion-66 "
+                  >
+                    <div
+                      aria-label="Skipped"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="skipped_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Pending"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="pending_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                    <div
+                      aria-label="In progress"
+                      class="flexbox centered "
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="progress_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        1
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Successful"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="success_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Failed"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="error_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="emotion-63"
+            >
+              <time
+                class="muted slightly-smaller"
+                datetime="2019-01-13T13:15:00+00:00"
+              >
+                2019-01-13 13:15
+              </time>
+              <div
+                class="clickable emotion-55"
+              >
+                <div>
+                  <div>
+                    r1
+                  </div>
+                  <div
+                    class=""
+                    title="test deployment 2"
+                  >
+                    test deployment 2
+                  </div>
+                </div>
+                <div
+                  class="emotion-65"
+                >
+                  <div
+                    class="flexbox emotion-66 "
+                  >
+                    <div
+                      aria-label="Skipped"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="skipped_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Pending"
+                      class="flexbox centered "
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="pending_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        1
+                      </div>
+                    </div>
+                    <div
+                      aria-label="In progress"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="progress_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Successful"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="success_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Failed"
+                      class="flexbox centered disabled"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <img
+                        src="error_status.png"
+                      />
+                      <div
+                        class="status"
+                      >
+                        0
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
             <a
               class="margin-top"
               href="/deployments"

--- a/src/js/components/app.test.js
+++ b/src/js/components/app.test.js
@@ -12,25 +12,20 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import 'jsdom-worker';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import Cookies from 'universal-cookie';
 
 import { defaultState, mockDate, token, undefineds } from '../../../tests/mockData';
 import { render } from '../../../tests/setupTests';
+import * as DeviceActions from '../actions/deviceActions';
 import { TIMEOUTS } from '../constants/appConstants';
-import { getConfiguredStore } from '../reducers';
 import App, { timeout } from './app';
 
 jest.mock('../tracking');
 
-const mockStore = configureStore([thunk]);
-
-const state = {
+const preloadedState = {
   ...defaultState,
   app: {
     ...defaultState.app,
@@ -53,71 +48,73 @@ const state = {
   }
 };
 
+const reportsSpy = jest.spyOn(DeviceActions, 'deriveReportsData');
+
 describe('App Component', () => {
   let cookies;
   beforeEach(() => {
     cookies = new Cookies();
     cookies.get.mockReturnValue('omnomnom');
   });
-  it('renders correctly', async () => {
-    const store = mockStore(state);
+  it(
+    'renders correctly',
+    async () => {
+      window.localStorage.getItem.mockReturnValueOnce('false');
+      jest.replaceProperty(window.mender_environment, 'integrationVersion', 'next');
 
-    window.localStorage.getItem.mockReturnValueOnce('false');
-    const ui = (
-      <Provider store={store}>
-        <App />
-      </Provider>
-    );
-    const { asFragment, rerender } = render(ui);
-    await waitFor(() => expect(screen.queryByText(/see all deployments/i)).toBeInTheDocument(), { timeout: TIMEOUTS.fiveSeconds });
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-      jest.runAllTicks();
-      return new Promise(resolve => resolve(), TIMEOUTS.threeSeconds);
-    });
-    await waitFor(() => rerender(ui));
-    const view = asFragment();
-    expect(view).toMatchSnapshot();
-    expect(view).toEqual(expect.not.stringMatching(undefineds));
-  });
+      const ui = <App />;
+      const { asFragment, rerender } = render(ui, { preloadedState });
+      await waitFor(() => expect(screen.queryByText(/see all deployments/i)).toBeInTheDocument(), { timeout: TIMEOUTS.fiveSeconds });
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+        jest.runAllTicks();
+        return new Promise(resolve => resolve(), TIMEOUTS.threeSeconds);
+      });
+      await waitFor(() => expect(reportsSpy).toHaveBeenCalled(), { timeout: TIMEOUTS.fiveSeconds });
+      await waitFor(() => rerender(ui));
+      const view = asFragment();
+      expect(view).toMatchSnapshot();
+      expect(view).toEqual(expect.not.stringMatching(undefineds));
+      reportsSpy.mockClear();
+    },
+    10 * TIMEOUTS.oneSecond
+  );
 
-  it('works as intended', async () => {
-    const store = getConfiguredStore({
-      preloadedState: {
-        ...state,
+  it(
+    'works as intended',
+    async () => {
+      const state = {
+        ...preloadedState,
         users: {
-          ...state.users,
+          ...preloadedState.users,
           currentUser: 'notNull'
         }
-      }
-    });
-    window.localStorage.getItem.mockReturnValueOnce('false');
-    const ui = (
-      <Provider store={store}>
-        <App />
-      </Provider>
-    );
-    const { rerender } = render(ui);
-    cookies.get.mockReturnValue(token);
-    act(() => {
-      jest.advanceTimersByTime(timeout + 500);
-      jest.runAllTicks();
-    });
-    cookies.get.mockReturnValue('');
-    await waitFor(() => rerender(ui));
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-      jest.runAllTicks();
-      return new Promise(resolve => resolve(), TIMEOUTS.threeSeconds);
-    });
-    await waitFor(() => rerender(ui));
-    await waitFor(() => expect(screen.queryByText(/Version:/i)).not.toBeInTheDocument(), { timeout: TIMEOUTS.fiveSeconds });
-    expect(screen.queryByText(/Northern.tech/i)).toBeInTheDocument();
-    expect(screen.queryByText(`© ${mockDate.getFullYear()} Northern.tech`)).toBeInTheDocument();
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-      jest.runAllTicks();
-      return new Promise(resolve => resolve(), TIMEOUTS.fiveSeconds);
-    });
-  }, 10000);
+      };
+      window.localStorage.getItem.mockReturnValueOnce('false');
+      const ui = <App />;
+      const { rerender } = render(ui, { preloadedState: state });
+      cookies.get.mockReturnValue(token);
+      act(() => {
+        jest.advanceTimersByTime(timeout + 500);
+        jest.runAllTicks();
+      });
+      cookies.get.mockReturnValue('');
+      await waitFor(() => expect(reportsSpy).toHaveBeenCalled(), { timeout: TIMEOUTS.threeSeconds });
+      await waitFor(() => rerender(ui));
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+        jest.runAllTicks();
+      });
+      await waitFor(() => rerender(ui));
+      await waitFor(() => expect(screen.queryByText(/Version:/i)).not.toBeInTheDocument(), { timeout: TIMEOUTS.fiveSeconds });
+      expect(screen.queryByText(/Northern.tech/i)).toBeInTheDocument();
+      expect(screen.queryByText(`© ${mockDate.getFullYear()} Northern.tech`)).toBeInTheDocument();
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+        jest.runAllTicks();
+      });
+      reportsSpy.mockClear();
+    },
+    10 * TIMEOUTS.oneSecond
+  );
 });

--- a/src/js/components/auditlogs/__snapshots__/auditlogs.test.js.snap
+++ b/src/js/components/auditlogs/__snapshots__/auditlogs.test.js.snap
@@ -282,12 +282,6 @@ exports[`Auditlogs Component renders correctly 1`] = `
           </div>
         </div>
       </div>
-      <span
-        class="link margin-bottom-small"
-        style="align-self: flex-end;"
-      >
-        clear filter
-      </span>
     </div>
     <div
       class="flexbox center-aligned"
@@ -626,7 +620,7 @@ exports[`Auditlogs Component renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="loaderContainer shrunk"
+          class="loaderContainer"
         >
           <div
             class="small  loader"

--- a/src/js/components/auditlogs/auditlogs.test.js
+++ b/src/js/components/auditlogs/auditlogs.test.js
@@ -21,28 +21,21 @@ import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { prettyDOM } from '@testing-library/dom';
 import { screen, render as testingLibRender, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
+import { getConfiguredStore } from '../../reducers';
 import AuditLogs from './auditlogs';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = { ...defaultState, app: { ...defaultState.app, features: { ...defaultState.app.features, hasAuditlogs: true } } };
 
 describe('Auditlogs Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState, app: { ...defaultState.app, features: { ...defaultState.app.features, hasAuditlogs: true } } });
-  });
-
   it('renders correctly', async () => {
     const { baseElement } = render(
       <LocalizationProvider dateAdapter={AdapterMoment}>
-        <Provider store={store}>
-          <AuditLogs />
-        </Provider>
-      </LocalizationProvider>
+        <AuditLogs />
+      </LocalizationProvider>,
+      { preloadedState }
     );
     const view = prettyDOM(baseElement.firstChild, 100000, { highlight: false })
       .replace(/id="mui-[0-9]*"/g, '')
@@ -56,10 +49,9 @@ describe('Auditlogs Component', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(
       <LocalizationProvider dateAdapter={AdapterMoment}>
-        <Provider store={store}>
-          <AuditLogs />
-        </Provider>
-      </LocalizationProvider>
+        <AuditLogs />
+      </LocalizationProvider>,
+      { preloadedState }
     );
     await user.click(screen.getByText(/last 7 days/i));
     await user.click(screen.getByText(/clear filter/i));
@@ -68,6 +60,7 @@ describe('Auditlogs Component', () => {
   });
 
   it('allows navigating by url as expected', async () => {
+    let store = getConfiguredStore({ preloadedState });
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const ui = (
       <LocalizationProvider dateAdapter={AdapterMoment}>

--- a/src/js/components/auditlogs/auditlogslist.test.js
+++ b/src/js/components/auditlogs/auditlogslist.test.js
@@ -12,38 +12,28 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { prettyDOM } from '@testing-library/dom';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { adminUserCapabilities, defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import AuditLogsList from './auditlogslist';
 
-const mockStore = configureStore([thunk]);
-
 describe('Auditlogs Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
+    const state = { ...defaultState };
     const { baseElement } = render(
-      <Provider store={store}>
-        <AuditLogsList
-          items={defaultState.organization.auditlog.events}
-          loading={false}
-          onChangeRowsPerPage={jest.fn}
-          onChangePage={jest.fn}
-          onChangeSorting={jest.fn}
-          selectionState={defaultState.organization.auditlog.selectionState}
-          setAuditlogsState={jest.fn}
-          userCapabilities={adminUserCapabilities}
-        />
-      </Provider>
+      <AuditLogsList
+        items={defaultState.organization.auditlog.events}
+        loading={false}
+        onChangeRowsPerPage={jest.fn}
+        onChangePage={jest.fn}
+        onChangeSorting={jest.fn}
+        selectionState={defaultState.organization.auditlog.selectionState}
+        setAuditlogsState={jest.fn}
+        userCapabilities={adminUserCapabilities}
+      />,
+      { state }
     );
 
     const view = prettyDOM(baseElement.firstChild, 100000, { highlight: false })

--- a/src/js/components/auditlogs/eventdetails/deviceconfiguration.js
+++ b/src/js/components/auditlogs/eventdetails/deviceconfiguration.js
@@ -17,14 +17,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from '@mui/material/styles';
 
 import { getDeviceById } from '../../../actions/deviceActions';
-import { getIdAttribute, getUserCapabilities } from '../../../selectors';
+import { getDeviceById as getDeviceByIdSelector, getIdAttribute, getUserCapabilities } from '../../../selectors';
 import Loader from '../../common/loader';
 import DeviceDetails, { DetailInformation } from './devicedetails';
 
 export const DeviceConfiguration = ({ item, onClose }) => {
   const { object = {} } = item;
   const { canReadDevices } = useSelector(getUserCapabilities);
-  const device = useSelector(state => state.devices.byId[object.id]);
+  const device = useSelector(state => getDeviceByIdSelector(state, object.id));
   const { attribute: idAttribute } = useSelector(getIdAttribute);
   const dispatch = useDispatch();
 

--- a/src/js/components/auditlogs/eventdetails/deviceconfiguration.test.js
+++ b/src/js/components/auditlogs/eventdetails/deviceconfiguration.test.js
@@ -12,27 +12,18 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceConfiguration from './deviceconfiguration';
 
-const mockStore = configureStore([thunk]);
-const store = mockStore({ ...defaultState });
-
 describe('DeviceConfiguration Component', () => {
   it('renders correctly', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceConfiguration
-          item={{ ...defaultState.organization.auditlog.events[2], object: { id: defaultState.devices.byId.a1.id }, change: '{"something":"here"}' }}
-          onClose={jest.fn}
-        />
-      </Provider>
+      <DeviceConfiguration
+        item={{ ...defaultState.organization.auditlog.events[2], object: { id: defaultState.devices.byId.a1.id }, change: '{"something":"here"}' }}
+        onClose={jest.fn}
+      />
     );
 
     const view = baseElement.firstChild.firstChild;

--- a/src/js/components/auditlogs/eventdetails/devicedetails.test.js
+++ b/src/js/components/auditlogs/eventdetails/devicedetails.test.js
@@ -12,24 +12,15 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceDetails from './devicedetails';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceDetails Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceDetails device={defaultState.devices.byId.a1} item={defaultState.organization.auditlog.events[2]} onClose={jest.fn} />
-      </Provider>
+      <DeviceDetails device={defaultState.devices.byId.a1} item={defaultState.organization.auditlog.events[2]} onClose={jest.fn} />
     );
 
     const view = baseElement.firstChild.firstChild;

--- a/src/js/components/auditlogs/eventdetails/filetransfer.js
+++ b/src/js/components/auditlogs/eventdetails/filetransfer.js
@@ -17,7 +17,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from '@mui/material/styles';
 
 import { getDeviceById } from '../../../actions/deviceActions';
-import { getIdAttribute, getUserCapabilities } from '../../../selectors';
+import { getDeviceById as getDeviceByIdSelector, getIdAttribute, getUserCapabilities } from '../../../selectors';
 import Loader from '../../common/loader';
 import DeviceDetails, { DetailInformation } from './devicedetails';
 
@@ -28,7 +28,7 @@ export const FileTransfer = ({ item, onClose }) => {
     meta: { path = [] },
     object = {}
   } = item;
-  const device = useSelector(state => state.devices.byId[object.id]);
+  const device = useSelector(state => getDeviceByIdSelector(state, object.id));
   const { canReadDevices } = useSelector(getUserCapabilities);
   const { attribute: idAttribute } = useSelector(getIdAttribute);
   const theme = useTheme();

--- a/src/js/components/auditlogs/eventdetails/filetransfer.test.js
+++ b/src/js/components/auditlogs/eventdetails/filetransfer.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import FileTransfer from './filetransfer';
 
-const mockStore = configureStore([thunk]);
-
 describe('FileTransfer Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <FileTransfer item={{ ...defaultState.organization.auditlog.events[2], meta: { path: ['/dev/null'] } }} />
-      </Provider>
-    );
+    const { baseElement } = render(<FileTransfer item={{ ...defaultState.organization.auditlog.events[2], meta: { path: ['/dev/null'] } }} />);
 
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/auditlogs/eventdetails/portforward.js
+++ b/src/js/components/auditlogs/eventdetails/portforward.js
@@ -20,7 +20,7 @@ import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
 
 import { getDeviceById, getSessionDetails } from '../../../actions/deviceActions';
-import { getIdAttribute, getUserCapabilities } from '../../../selectors';
+import { getDeviceById as getDeviceByIdSelector, getIdAttribute, getUserCapabilities } from '../../../selectors';
 import Loader from '../../common/loader';
 import Time from '../../common/time';
 import DeviceDetails, { DetailInformation } from './devicedetails';
@@ -33,7 +33,7 @@ export const PortForward = ({ item, onClose }) => {
   const dispatch = useDispatch();
   const { object = {} } = item;
   const { canReadDevices } = useSelector(getUserCapabilities);
-  const device = useSelector(state => state.devices.byId[object.id]);
+  const device = useSelector(state => getDeviceByIdSelector(state, object.id));
   const { attribute: idAttribute } = useSelector(getIdAttribute);
 
   useEffect(() => {

--- a/src/js/components/auditlogs/eventdetails/portforward.test.js
+++ b/src/js/components/auditlogs/eventdetails/portforward.test.js
@@ -12,27 +12,18 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import * as DeviceActions from '../../../actions/deviceActions';
 import PortForward from './portforward';
 
-const mockStore = configureStore([thunk]);
-const store = mockStore({ ...defaultState });
 describe('PortForward Component', () => {
   it('renders correctly', async () => {
     const sessionSpy = jest.spyOn(DeviceActions, 'getSessionDetails');
-    const ui = (
-      <Provider store={store}>
-        <PortForward item={defaultState.organization.auditlog.events[2]} />
-      </Provider>
-    );
+    const ui = <PortForward item={defaultState.organization.auditlog.events[2]} />;
     const { baseElement, rerender } = render(ui);
     await waitFor(() => rerender(ui));
     await act(async () => {

--- a/src/js/components/auditlogs/eventdetails/terminalsession.js
+++ b/src/js/components/auditlogs/eventdetails/terminalsession.js
@@ -20,7 +20,7 @@ import moment from 'moment';
 import momentDurationFormatSetup from 'moment-duration-format';
 
 import { getDeviceById, getSessionDetails } from '../../../actions/deviceActions';
-import { getIdAttribute, getUserCapabilities } from '../../../selectors';
+import { getDeviceById as getDeviceByIdSelector, getIdAttribute, getUserCapabilities } from '../../../selectors';
 import Loader from '../../common/loader';
 import Time from '../../common/time';
 import DeviceDetails, { DetailInformation } from './devicedetails';
@@ -34,7 +34,7 @@ export const TerminalSession = ({ item, onClose }) => {
   const dispatch = useDispatch();
   const { object = {} } = item;
   const { canReadDevices } = useSelector(getUserCapabilities);
-  const device = useSelector(state => state.devices.byId[object.id]);
+  const device = useSelector(state => getDeviceByIdSelector(state, object.id));
   const { attribute: idAttribute } = useSelector(getIdAttribute);
 
   useEffect(() => {

--- a/src/js/components/auditlogs/eventdetails/terminalsession.test.js
+++ b/src/js/components/auditlogs/eventdetails/terminalsession.test.js
@@ -12,19 +12,13 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import * as DeviceActions from '../../../actions/deviceActions';
 import TerminalSession from './terminalsession';
-
-const mockStore = configureStore([thunk]);
-const store = mockStore({ ...defaultState });
 
 describe('TerminalSession Component', () => {
   let socketSpyFactory;
@@ -62,11 +56,7 @@ describe('TerminalSession Component', () => {
 
   it('renders correctly', async () => {
     const sessionSpy = jest.spyOn(DeviceActions, 'getSessionDetails');
-    const ui = (
-      <Provider store={store}>
-        <TerminalSession item={defaultState.organization.auditlog.events[2]} />
-      </Provider>
-    );
+    const ui = <TerminalSession item={defaultState.organization.auditlog.events[2]} />;
     const { baseElement, rerender } = render(ui);
     await waitFor(() => rerender(ui));
     await act(async () => {

--- a/src/js/components/common/deviceidentity.test.js
+++ b/src/js/components/common/deviceidentity.test.js
@@ -12,32 +12,22 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import { ATTRIBUTE_SCOPES } from '../../constants/deviceConstants';
 import DeviceIdentityDisplay from './deviceidentity';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceIdentityDisplay Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({
+    const preloadedState = {
       ...defaultState,
       users: {
         ...defaultState.users,
         globalSettings: { ...defaultState.users.globalSettings, id_attribute: { attribute: 'mac', scope: ATTRIBUTE_SCOPES.identity } }
       }
-    });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceIdentityDisplay device={defaultState.devices.byId.a1} isEditable={false} />
-      </Provider>
-    );
+    };
+    const { baseElement } = render(<DeviceIdentityDisplay device={defaultState.devices.byId.a1} isEditable={false} />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/common/devicenameinput.test.js
+++ b/src/js/components/common/devicenameinput.test.js
@@ -12,12 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -25,19 +22,9 @@ import * as AppActions from '../../actions/appActions';
 import * as DeviceActions from '../../actions/deviceActions';
 import DeviceNameInput from './devicenameinput';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceNameInput Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceNameInput device={defaultState.devices.byId.a1} isHovered />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceNameInput device={defaultState.devices.byId.a1} isHovered />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -47,11 +34,7 @@ describe('DeviceNameInput Component', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const deviceTagsSpy = jest.spyOn(DeviceActions, 'setDeviceTags');
     const snackbarSpy = jest.spyOn(AppActions, 'setSnackbar');
-    const ui = (
-      <Provider store={store}>
-        <DeviceNameInput device={{ ...defaultState.devices.byId.a1, tags: { name: 'testname' } }} isHovered />
-      </Provider>
-    );
+    const ui = <DeviceNameInput device={{ ...defaultState.devices.byId.a1, tags: { name: 'testname' } }} isHovered />;
     const { rerender } = render(ui);
     expect(screen.queryByDisplayValue(/testname/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button'));

--- a/src/js/components/common/dialogs/confirmdismisshelptips.test.js
+++ b/src/js/components/common/dialogs/confirmdismisshelptips.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import ConfirmDismissHelptips from './confirmdismisshelptips';
 
-const mockStore = configureStore([thunk]);
-
 describe('ConfirmDismissHelptips Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({});
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <ConfirmDismissHelptips open={true} />
-      </Provider>
-    );
+    const { baseElement } = render(<ConfirmDismissHelptips open={true} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/common/dialogs/createartifactdialog.test.js
+++ b/src/js/components/common/dialogs/createartifactdialog.test.js
@@ -12,35 +12,21 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import CreateArtifactDialog from './createartifactdialog';
 
-const mockStore = configureStore([thunk]);
-
 describe('CreateArtifactDialog Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
+  it('renders correctly', async () => {
+    const preloadedState = {
       ...defaultState,
       onboarding: {
         ...defaultState.onboarding,
         showCreateArtifactDialog: true
       }
-    });
-  });
-
-  it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <CreateArtifactDialog />
-      </Provider>
-    );
+    };
+    const { baseElement } = render(<CreateArtifactDialog />, { preloadedState });
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/common/dialogs/deviceconnectiondialog.test.js
+++ b/src/js/components/common/dialogs/deviceconnectiondialog.test.js
@@ -12,31 +12,17 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceConnectionDialog from './deviceconnectiondialog';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceConnectionDialog Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceConnectionDialog onCancel={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceConnectionDialog onCancel={jest.fn} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -44,11 +30,7 @@ describe('DeviceConnectionDialog Component', () => {
 
   it('works as intended', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    render(
-      <Provider store={store}>
-        <DeviceConnectionDialog onCancel={jest.fn} />
-      </Provider>
-    );
+    render(<DeviceConnectionDialog onCancel={jest.fn} />);
     await user.click(screen.getByText(/get started/i));
     expect(screen.getByText(/Enter your device type/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /back/i }));

--- a/src/js/components/common/dialogs/physicaldeviceonboarding.test.js
+++ b/src/js/components/common/dialogs/physicaldeviceonboarding.test.js
@@ -12,13 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import { EXTERNAL_PROVIDER } from '../../../constants/deviceConstants';
 import PhysicalDeviceOnboarding, {
@@ -29,14 +26,10 @@ import PhysicalDeviceOnboarding, {
   InstallationStep
 } from './physicaldeviceonboarding';
 
-const mockStore = configureStore([thunk]);
-
 const oldHostname = window.location.hostname;
 
 describe('PhysicalDeviceOnboarding Component', () => {
-  let store;
   beforeEach(() => {
-    store = mockStore({ ...defaultState });
     window.location = {
       ...window.location,
       hostname: 'hosted.mender.io'
@@ -54,23 +47,22 @@ describe('PhysicalDeviceOnboarding Component', () => {
       async (Component, index) => {
         it(`renders ${Component.displayName || Component.name} correctly`, () => {
           const { baseElement } = render(
-            <Provider store={store}>
-              <Component
-                advanceOnboarding={jest.fn}
-                connectionString="test"
-                hasConvertedImage={true}
-                integrationProvider={EXTERNAL_PROVIDER['iot-hub'].provider}
-                hasExternalIntegration={index % 2}
-                ipAddress="test.address"
-                isEnterprise={false}
-                isHosted={true}
-                isDemoMode={false}
-                onboardingState={{ complete: false, showTips: true, showHelptips: true }}
-                onSelect={jest.fn}
-                selection="raspberrypi7"
-                tenantToken="testtoken"
-              />
-            </Provider>
+            <Component
+              advanceOnboarding={jest.fn}
+              connectionString="test"
+              docsVersion={''}
+              hasConvertedImage={true}
+              integrationProvider={EXTERNAL_PROVIDER['iot-hub'].provider}
+              hasExternalIntegration={index % 2}
+              ipAddress="test.address"
+              isEnterprise={false}
+              isHosted={true}
+              isDemoMode={false}
+              onboardingState={{ complete: false, showTips: true, showHelptips: true }}
+              onSelect={jest.fn}
+              selection="raspberrypi7"
+              tenantToken="testtoken"
+            />
           );
           const view = baseElement.firstChild;
           expect(view).toMatchSnapshot();
@@ -81,14 +73,10 @@ describe('PhysicalDeviceOnboarding Component', () => {
   });
 
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <PhysicalDeviceOnboarding progress={1} />
-      </Provider>
-    );
+    const { baseElement, store } = render(<PhysicalDeviceOnboarding progress={1} />);
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
-    await waitFor(() => expect(store.getActions().some(({ type, value }) => type === 'SET_ONBOARDING_APPROACH' && value === 'physical')).toBeTruthy());
+    await waitFor(() => expect(store.getState().onboarding.approach === 'physical').toBeTruthy());
   });
 });

--- a/src/js/components/common/dialogs/virtualdeviceonboarding.test.js
+++ b/src/js/components/common/dialogs/virtualdeviceonboarding.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import VirtualDeviceOnboarding, { getDemoDeviceCreationCommand } from './virtualdeviceonboarding';
 
-const mockStore = configureStore([thunk]);
-
 describe('VirtualDeviceOnboarding Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <VirtualDeviceOnboarding />
-      </Provider>
-    );
+    const { baseElement } = render(<VirtualDeviceOnboarding />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/common/sharedsnackbar.test.js
+++ b/src/js/components/common/sharedsnackbar.test.js
@@ -12,32 +12,18 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import { yes } from '../../constants/appConstants';
 import SharedSnackbar from './sharedsnackbar';
 
-const mockStore = configureStore([thunk]);
-
 describe('SharedSnackbar Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <SharedSnackbar snackbar={{ maxWidth: 200, open: true, message: 'test' }} setSnackbar={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<SharedSnackbar snackbar={{ maxWidth: 200, open: true, message: 'test' }} setSnackbar={jest.fn} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/dashboard/__snapshots__/dashboard.test.js.snap
+++ b/src/js/components/dashboard/__snapshots__/dashboard.test.js.snap
@@ -1,9 +1,927 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dashboard Component renders correctly 1`] = `
-<h4
-  class="margin-left-small"
->
-  Dashboard
-</h4>
+.emotion-0 {
+  -webkit-column-gap: 48px;
+  column-gap: 48px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-height: 80vh;
+}
+
+.emotion-1 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  min-width: 60vw;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  row-gap: 48px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+@media (min-width:1536px) {
+  .emotion-1 {
+    min-width: 50vw;
+  }
+}
+
+.emotion-2 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.3929rem;
+}
+
+.emotion-2 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-3.widget {
+  max-width: initial!important;
+}
+
+.emotion-3 .widgetMainContent {
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-evenly;
+  -ms-flex-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  justify-content: space-evenly;
+}
+
+.emotion-4 {
+  max-width: 6vh;
+}
+
+.emotion-4.red {
+  color: #5d0f43;
+}
+
+.emotion-4.green {
+  color: #337a87;
+}
+
+.emotion-5 {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 2rem;
+  height: 5vh;
+  width: 5vh;
+  max-width: 3em;
+  max-height: 3em;
+}
+
+.emotion-6 {
+  display: grid;
+  place-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-7 {
+  bottom: -8px;
+  height: 20px;
+  width: 100%;
+}
+
+.emotion-7>div {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  width: 100%;
+}
+
+.emotion-7>div>div {
+  background: currentColor;
+  border-radius: 6px;
+  height: 100%;
+  width: 24px;
+}
+
+.emotion-7 svg {
+  fill: #fff;
+}
+
+.emotion-8 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.1607rem;
+}
+
+.emotion-8 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-14 {
+  color: rgba(0, 0, 0, 0.38);
+  margin: 15px 0;
+}
+
+.emotion-15 {
+  gap: 8px;
+}
+
+.emotion-17 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 400px;
+  border: none;
+  padding-left: 0;
+  padding-top: 0;
+}
+
+.emotion-17 .deployments .dashboard>h4 {
+  margin-top: 48px;
+}
+
+.emotion-17 .deployments .dashboard>h4.margin-top-none {
+  margin-top: 0;
+}
+
+@media (min-width:1536px) {
+  .emotion-17 {
+    border-left: 1px solid #e9e9e9;
+    margin-top: -16px;
+    padding-left: 48px;
+    padding-top: 16px;
+  }
+
+  .emotion-17 .deployments .dashboard>h4 {
+    margin-top: 0;
+  }
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #f7f7f7;
+  border-radius: 8px;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  max-width: 500px;
+  padding: 8px;
+}
+
+.emotion-18>div:last-child {
+  width: 100%;
+}
+
+.emotion-19 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: inherit;
+}
+
+.emotion-19 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-23 {
+  background-color: #f7f7f7;
+  padding: 10px 20px;
+  border-radius: 4px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  min-height: 70px;
+}
+
+.emotion-23 .chart-container {
+  min-height: 70px;
+}
+
+.emotion-23 .progress-chart {
+  min-height: 45px;
+}
+
+.emotion-23 .compact .progress-step,
+.emotion-23 .detailed .progress-step {
+  min-height: 45px;
+}
+
+.emotion-23 .progress-step,
+.emotion-23 .detailed .progress-step-total {
+  position: absolute;
+  border-right-style: none;
+}
+
+.emotion-23 .progress-step-total .progress-bar {
+  background-color: #d4e9e7;
+}
+
+.emotion-23 .progress-step-number {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+}
+
+.emotion-23.minimal {
+  padding: initial;
+}
+
+.emotion-23.no-background {
+  background: none;
+}
+
+.emotion-23.stepped-progress .progress-step-total {
+  margin-left: -0.25%;
+  width: 100.5%;
+}
+
+.emotion-23.stepped-progress .progress-step-total .progress-bar {
+  background-color: #fff;
+  border: 1px solid #a9a9a9;
+  border-radius: 2px;
+  height: 12px;
+}
+
+.emotion-23.stepped-progress .detailed .progress-step {
+  min-height: 20px;
+}
+
+.emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 500px;
+}
+
+.emotion-26>time {
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: flex-end;
+  align-self: flex-end;
+  margin-right: 6px;
+}
+
+.emotion-28 {
+  background: #fff;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.emotion-29 {
+  -webkit-column-gap: 8px;
+  column-gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 32px);
+}
+
+.emotion-29>div {
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+}
+
+.emotion-29 .disabled {
+  opacity: 0.1;
+}
+
+<div>
+  <h4
+    class="margin-left-small"
+  >
+    Dashboard
+  </h4>
+  <div
+    class="emotion-0"
+  >
+    <div
+      class="emotion-1"
+    >
+      <div
+        class="dashboard"
+      >
+        <div
+          class="widget "
+        >
+          <div
+            class="flexbox widgetHeader"
+          >
+            <div
+              class="flexbox center-aligned"
+            >
+              Accepted devices 
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium margin-left-small green emotion-2"
+                data-testid="CheckCircleIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="flexbox column widgetMainContent"
+          >
+            <div
+              class="counter"
+            >
+              2
+            </div>
+          </div>
+        </div>
+        <div
+          class="widget emotion-3"
+        >
+          <div
+            class="flexbox widgetHeader"
+          >
+            Devices with issues
+          </div>
+          <div
+            class="widgetMainContent"
+          >
+            <a
+              class="flexbox center-aligned column emotion-4 green"
+              href="/devices?issues=offline"
+            >
+              <div
+                class="relative emotion-5"
+              >
+                <div
+                  class="emotion-6"
+                >
+                  0
+                </div>
+                <div
+                  class="absolute emotion-7"
+                >
+                  <div
+                    class="relative"
+                  >
+                    <div
+                      class="absolute"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall absolute emotion-8"
+                      data-testid="WifiOffIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M22.99 9C19.15 5.16 13.8 3.76 8.84 4.78l2.52 2.52c3.47-.17 6.99 1.05 9.63 3.7l2-2zm-4 4c-1.29-1.29-2.84-2.13-4.49-2.56l3.53 3.53.96-.97zM2 3.05 5.07 6.1C3.6 6.82 2.22 7.78 1 9l1.99 2c1.24-1.24 2.67-2.16 4.2-2.77l2.24 2.24C7.81 10.89 6.27 11.73 5 13v.01L6.99 15c1.36-1.36 3.14-2.04 4.92-2.06L18.98 20l1.27-1.26L3.29 1.79 2 3.05zM9 17l3 3 3-3c-1.65-1.66-4.34-1.66-6 0z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <p
+                class="align-center slightly-smaller"
+              >
+                Offline
+              </p>
+            </a>
+            <a
+              class="flexbox center-aligned column emotion-4 green"
+              href="/devices?issues=authRequests"
+            >
+              <div
+                class="relative emotion-5"
+              >
+                <div
+                  class="emotion-6"
+                >
+                  0
+                </div>
+                <div
+                  class="absolute emotion-7"
+                >
+                  <div
+                    class="relative"
+                  >
+                    <div
+                      class="absolute"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall absolute emotion-8"
+                      data-testid="VpnKeyOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M22 19h-6v-4h-2.68c-1.14 2.42-3.6 4-6.32 4-3.86 0-7-3.14-7-7s3.14-7 7-7c2.72 0 5.17 1.58 6.32 4H24v6h-2v4zm-4-2h2v-4h2v-2H11.94l-.23-.67C11.01 8.34 9.11 7 7 7c-2.76 0-5 2.24-5 5s2.24 5 5 5c2.11 0 4.01-1.34 4.71-3.33l.23-.67H18v4zM7 15c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <p
+                class="align-center slightly-smaller"
+              >
+                Authentication requests
+              </p>
+            </a>
+          </div>
+        </div>
+        <div
+          class="widget flexbox centered"
+        >
+          <p
+            class="muted"
+            style="max-width: 200px;"
+          >
+            + connect more devices
+          </p>
+        </div>
+      </div>
+      <div
+        class="flexbox centered"
+      >
+        <p
+          class="emotion-14 icon flexbox center-aligned emotion-15 "
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-8"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+          <span>
+            With a more advanced commercial Mender plan you get access to actionable insights into the devices you are updating with Mender. Get an overview of the Mender plans on the 
+            <a
+              href="https://mender.io/plans/features"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              features page
+            </a>
+            .
+          </span>
+        </p>
+      </div>
+    </div>
+    <div
+      class="emotion-17 deployments"
+    >
+      <div
+        class="dashboard flexbox column"
+        style="grid-template-columns: 1fr; row-gap: 10px;"
+      >
+        <h4
+          class="margin-bottom-none margin-left-small"
+        >
+          Recent deployments
+        </h4>
+        <h5
+          class="margin-bottom-none"
+        >
+          Pending
+        </h5>
+        <div
+          class="clickable emotion-18"
+        >
+          <div>
+            <div>
+              r1
+            </div>
+            <div
+              class=""
+              title="test deployment"
+            >
+              test deployment
+            </div>
+          </div>
+          <div
+            class="flexbox center-aligned"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-19"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+              />
+            </svg>
+            <span
+              class="margin-left-small"
+            >
+              Queued to start
+            </span>
+          </div>
+        </div>
+        <div
+          class="clickable emotion-18"
+        >
+          <div>
+            <div>
+              r1
+            </div>
+            <div
+              class=""
+              title="test deployment 2"
+            >
+              test deployment 2
+            </div>
+          </div>
+          <div
+            class="flexbox center-aligned"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-19"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+              />
+            </svg>
+            <span
+              class="margin-left-small"
+            >
+              Queued to start
+            </span>
+          </div>
+        </div>
+        <h5
+          class="margin-bottom-none"
+        >
+          In Progress
+        </h5>
+        <div
+          class="clickable emotion-18"
+        >
+          <div>
+            <div>
+              r1
+            </div>
+            <div
+              class=""
+              title="test deployment"
+            >
+              test deployment
+            </div>
+          </div>
+          <div
+            class="relative emotion-23 minimal "
+          >
+            <div
+              class="chart-container"
+            >
+              <div
+                class="progress-chart relative detailed"
+              >
+                <div
+                  class="progress-step"
+                  style="left: 0%; width: 100%;"
+                >
+                  <div
+                    class="progress-bar"
+                    style="width: 100%; background-color: rgb(170, 170, 170);"
+                  />
+                  <div
+                    style="display: contents;"
+                  >
+                    <div
+                      class="progress-bar green"
+                      style="width: 0%;"
+                    />
+                    <div
+                      class="progress-bar warning"
+                      style="left: 0%; width: 0%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="progress-step relative flexbox progress-step-total"
+                >
+                  <div
+                    class="progress-bar"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="clickable emotion-18"
+        >
+          <div>
+            <div>
+              r1
+            </div>
+            <div
+              class=""
+              title="test deployment 2"
+            >
+              test deployment 2
+            </div>
+          </div>
+          <div
+            class="flexbox center-aligned"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-19"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+              />
+            </svg>
+            <span
+              class="margin-left-small"
+            >
+              Queued to start
+            </span>
+          </div>
+        </div>
+        <h5
+          class="margin-bottom-none"
+        >
+          Finished
+        </h5>
+        <div
+          class="emotion-26"
+        >
+          <time
+            class="muted slightly-smaller"
+            datetime="2019-01-13T13:00:00+00:00"
+          >
+            2019-01-13 13:00
+          </time>
+          <div
+            class="clickable emotion-18"
+          >
+            <div>
+              <div>
+                r1
+              </div>
+              <div
+                class=""
+                title="test deployment"
+              >
+                test deployment
+              </div>
+            </div>
+            <div
+              class="emotion-28"
+            >
+              <div
+                class="flexbox emotion-29 "
+              >
+                <div
+                  aria-label="Skipped"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="skipped_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Pending"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="pending_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="In progress"
+                  class="flexbox centered "
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="progress_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    1
+                  </div>
+                </div>
+                <div
+                  aria-label="Successful"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="success_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Failed"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="error_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="emotion-26"
+        >
+          <time
+            class="muted slightly-smaller"
+            datetime="2019-01-13T13:00:00+00:00"
+          >
+            2019-01-13 13:00
+          </time>
+          <div
+            class="clickable emotion-18"
+          >
+            <div>
+              <div>
+                r1
+              </div>
+              <div
+                class=""
+                title="test deployment 2"
+              >
+                test deployment 2
+              </div>
+            </div>
+            <div
+              class="emotion-28"
+            >
+              <div
+                class="flexbox emotion-29 "
+              >
+                <div
+                  aria-label="Skipped"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="skipped_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Pending"
+                  class="flexbox centered "
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="pending_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    1
+                  </div>
+                </div>
+                <div
+                  aria-label="In progress"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="progress_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Successful"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="success_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Failed"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="error_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <a
+          class="margin-top"
+          href="/deployments"
+        >
+          See all deployments
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/src/js/components/dashboard/__snapshots__/software-distribution.test.js.snap
+++ b/src/js/components/dashboard/__snapshots__/software-distribution.test.js.snap
@@ -548,7 +548,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
   column-gap: 8px;
 }
 
-.emotion-16 {
+.emotion-15 {
   position: relative;
   overflow: hidden;
   display: block;
@@ -558,13 +558,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
 }
 
 @media print {
-  .emotion-16 {
+  .emotion-15 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-17 {
+.emotion-16 {
   width: 100%;
   position: absolute;
   left: 0;
@@ -576,7 +576,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
   background-color: #337a87;
 }
 
-.emotion-22 {
+.emotion-19 {
   font-size: 1rem;
   cursor: pointer;
 }
@@ -814,41 +814,28 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
         >
           <div
             class="clickable emotion-13 "
-            title="somethingMore"
+            title="undefined"
           >
             <div
               class="text-overflow"
             >
-              somethingMore
+              undefined
             </div>
             <div>
-              20
+              1
             </div>
           </div>
           <div
             class="clickable emotion-13 "
-            title="Other"
+            title="raspotifyInstaller"
           >
             <div
               class="text-overflow"
             >
-              Other
+              raspotifyInstaller
             </div>
             <div>
-              12
-            </div>
-          </div>
-          <div
-            class="clickable emotion-13 "
-            title="something"
-          >
-            <div
-              class="text-overflow"
-            >
-              something
-            </div>
-            <div>
-              10
+              1
             </div>
           </div>
         </div>
@@ -858,57 +845,38 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
           <div
             class="clickable flexbox column barchart"
             style="justify-content: center;"
-            title="somethingMore"
+            title="undefined"
           >
             <span
               aria-valuemax="100"
               aria-valuemin="0"
-              aria-valuenow="48"
-              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-a31773 emotion-16"
+              aria-valuenow="0"
+              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-a31773 emotion-15"
               role="progressbar"
               style="height: 8px;"
             >
               <span
-                class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-17"
-                style="transform: translateX(-52.38095238095239%);"
+                class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-16"
+                style="transform: translateX(-100%);"
               />
             </span>
           </div>
           <div
             class="clickable flexbox column barchart"
             style="justify-content: center;"
-            title="Other"
+            title="raspotifyInstaller"
           >
             <span
               aria-valuemax="100"
               aria-valuemin="0"
-              aria-valuenow="29"
-              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-d5d5d5 emotion-16"
+              aria-valuenow="0"
+              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-337a87 emotion-15"
               role="progressbar"
               style="height: 8px;"
             >
               <span
-                class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-17"
-                style="transform: translateX(-71.42857142857143%);"
-              />
-            </span>
-          </div>
-          <div
-            class="clickable flexbox column barchart"
-            style="justify-content: center;"
-            title="something"
-          >
-            <span
-              aria-valuemax="100"
-              aria-valuemin="0"
-              aria-valuenow="24"
-              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-337a87 emotion-16"
-              role="progressbar"
-              style="height: 8px;"
-            >
-              <span
-                class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-17"
-                style="transform: translateX(-76.19047619047619%);"
+                class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-16"
+                style="transform: translateX(-100%);"
               />
             </span>
           </div>
@@ -920,7 +888,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
     >
       <div />
       <div
-        class="flexbox centered muted emotion-22"
+        class="flexbox centered muted emotion-19"
       >
         <svg
           aria-hidden="true"
@@ -934,7 +902,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-1:focus::-ms-input-p
           />
         </svg>
         <span
-          class="emotion-22"
+          class="emotion-19"
         >
           add a widget
         </span>

--- a/src/js/components/dashboard/deployments.test.js
+++ b/src/js/components/dashboard/deployments.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Deployments from './deployments';
 
-const mockStore = configureStore([thunk]);
-
 describe('Deployments Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Deployments clickHandle={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<Deployments clickHandle={jest.fn} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/dashboard/devices.js
+++ b/src/js/components/dashboard/devices.js
@@ -95,7 +95,7 @@ export const Devices = ({ clickHandle }) => {
     <>
       <div className="dashboard" ref={anchor}>
         <AcceptedDevices devicesCount={acceptedDevicesCount} onClick={clickHandle} />
-        {!!acceptedDevicesCount && <ActionableDevices issues={availableIssueOptions} />}
+        {!!acceptedDevicesCount && <ActionableDevices issues={availableIssueOptions} onClick={clickHandle} />}
         {!!pendingDevicesCount && !acceptedDevicesCount && (
           <PendingDevices
             advanceOnboarding={step => dispatch(advanceOnboarding(step))}

--- a/src/js/components/dashboard/devices.test.js
+++ b/src/js/components/dashboard/devices.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Devices from './devices';
 
-const mockStore = configureStore([thunk]);
-
 describe('Devices Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Devices getAllDevicesByStatus={jest.fn()} />
-      </Provider>
-    );
+    const { baseElement } = render(<Devices getAllDevicesByStatus={jest.fn()} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/dashboard/software-distribution.js
+++ b/src/js/components/dashboard/software-distribution.js
@@ -27,10 +27,19 @@ import {
   getReportsData
 } from '../../actions/deviceActions';
 import { saveUserSettings } from '../../actions/userActions';
-import { DEVICE_STATES, UNGROUPED_GROUP } from '../../constants/deviceConstants';
 import { rootfsImageVersion, softwareTitleMap } from '../../constants/releaseConstants';
 import { isEmpty } from '../../helpers';
-import { getAttributesList, getFeatures, getGroupNames, getIsEnterprise, getUserSettings } from '../../selectors';
+import {
+  getAcceptedDevices,
+  getAttributesList,
+  getDeviceReports,
+  getDeviceReportsForUser,
+  getDevicesById,
+  getFeatures,
+  getGroupNames,
+  getGroupsByIdWithoutUngrouped,
+  getIsEnterprise
+} from '../../selectors';
 import EnterpriseNotification from '../common/enterpriseNotification';
 import { extractSoftwareInformation } from '../devices/device-details/installedsoftware';
 import ChartAdditionWidget from './widgets/chart-addition';
@@ -84,21 +93,16 @@ const listSoftware = attributes => {
 export const SoftwareDistribution = () => {
   const dispatch = useDispatch();
 
-  const reports = useSelector(
-    state =>
-      getUserSettings(state).reports ||
-      state.users.globalSettings[`${state.users.currentUser}-reports`] ||
-      (Object.keys(state.devices.byId).length ? defaultReports : [])
-  );
-  // eslint-disable-next-line no-unused-vars
-  const { [UNGROUPED_GROUP.id]: ungrouped, ...groups } = useSelector(state => state.devices.groups.byId);
+  const reports = useSelector(getDeviceReportsForUser);
+  const groups = useSelector(getGroupsByIdWithoutUngrouped);
   const { hasReporting } = useSelector(getFeatures);
   const attributes = useSelector(getAttributesList);
-  const hasDevices = useSelector(state => state.devices.byStatus[DEVICE_STATES.accepted].total);
+  const { total } = useSelector(getAcceptedDevices);
+  const hasDevices = !!total;
   const isEnterprise = useSelector(getIsEnterprise);
-  const reportsData = useSelector(state => state.devices.reports);
+  const reportsData = useSelector(getDeviceReports);
   const groupNames = useSelector(getGroupNames);
-  const devicesById = useSelector(state => state.devices.byId);
+  const devicesById = useSelector(getDevicesById);
 
   useEffect(() => {
     dispatch(getDeviceAttributes());

--- a/src/js/components/dashboard/software-distribution.test.js
+++ b/src/js/components/dashboard/software-distribution.test.js
@@ -12,11 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -25,9 +22,7 @@ import { TIMEOUTS, chartTypes } from '../../constants/appConstants';
 import { rootfsImageVersion } from '../../constants/releaseConstants';
 import SoftwareDistribution from './software-distribution';
 
-const mockStore = configureStore([thunk]);
-
-const state = {
+const preloadedState = {
   ...defaultState,
   devices: {
     ...defaultState.devices,
@@ -69,14 +64,9 @@ const reportsSpy = jest.spyOn(DeviceActions, 'deriveReportsData');
 
 describe('Devices Component', () => {
   it('renders correctly', async () => {
-    let store = mockStore(state);
-    const ui = (
-      <Provider store={store}>
-        <SoftwareDistribution />
-      </Provider>
-    );
+    const ui = <SoftwareDistribution />;
 
-    const { baseElement, rerender } = render(ui);
+    const { baseElement, rerender } = render(ui, { preloadedState });
     await act(async () => {
       jest.runAllTimers();
       jest.runAllTicks();
@@ -91,22 +81,18 @@ describe('Devices Component', () => {
   });
 
   it('renders correctly for enterprise', async () => {
-    let store = mockStore({
-      ...state,
+    const testState = {
+      ...preloadedState,
       app: {
-        ...state,
+        ...preloadedState.app,
         features: {
-          ...state.app.features,
+          ...preloadedState.app.features,
           isEnterprise: true
         }
       }
-    });
-    const ui = (
-      <Provider store={store}>
-        <SoftwareDistribution />
-      </Provider>
-    );
-    const { baseElement, rerender } = render(ui);
+    };
+    const ui = <SoftwareDistribution />;
+    const { baseElement, rerender } = render(ui, { preloadedState: testState });
     await act(async () => {
       jest.runAllTimers();
       jest.runAllTicks();

--- a/src/js/components/deployments/__snapshots__/deployments.test.js.snap
+++ b/src/js/components/deployments/__snapshots__/deployments.test.js.snap
@@ -239,6 +239,346 @@ exports[`Deployments Component renders correctly 1`] = `
   color: rgba(10, 10, 11, 0.78);
 }
 
+.emotion-12 {
+  border-bottom: 1px solid #d4e9e7;
+}
+
+.emotion-12 span {
+  background: #fff;
+}
+
+.emotion-13 {
+  white-space: initial;
+}
+
+.emotion-15 {
+  background-color: #f7f7f7;
+  padding: 10px 20px;
+  border-radius: 4px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  min-height: 70px;
+}
+
+.emotion-15 .chart-container {
+  min-height: 70px;
+}
+
+.emotion-15 .progress-chart {
+  min-height: 45px;
+}
+
+.emotion-15 .compact .progress-step,
+.emotion-15 .detailed .progress-step {
+  min-height: 45px;
+}
+
+.emotion-15 .progress-step,
+.emotion-15 .detailed .progress-step-total {
+  position: absolute;
+  border-right-style: none;
+}
+
+.emotion-15 .progress-step-total .progress-bar {
+  background-color: #d4e9e7;
+}
+
+.emotion-15 .progress-step-number {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+}
+
+.emotion-15.minimal {
+  padding: initial;
+}
+
+.emotion-15.no-background {
+  background: none;
+}
+
+.emotion-15.stepped-progress .progress-step-total {
+  margin-left: -0.25%;
+  width: 100.5%;
+}
+
+.emotion-15.stepped-progress .progress-step-total .progress-bar {
+  background-color: #fff;
+  border: 1px solid #a9a9a9;
+  border-radius: 2px;
+  height: 12px;
+}
+
+.emotion-15.stepped-progress .detailed .progress-step {
+  min-height: 20px;
+}
+
+.emotion-16 {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-column-gap: 16px;
+}
+
+.emotion-16 .progress-chart.detailed {
+  min-height: 20px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-17 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: Lato,sans-serif;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #337a87;
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  border-radius: 2px;
+  font-size: 14px;
+  font-weight: bold;
+  background-color: transparent;
+  color: rgba(10, 10, 11, 0.78);
+  justify-self: center;
+  text-transform: none;
+}
+
+.emotion-17::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-17.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-17 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-17:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgb(35, 85, 94);
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-17:hover {
+    background-color: #337a87;
+  }
+}
+
+.emotion-17:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-17.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-17.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.emotion-17:hover {
+  colors: #337a87;
+}
+
+.emotion-17.MuiButton-text {
+  color: rgba(10, 10, 11, 0.78);
+}
+
+.emotion-17:hover {
+  background-color: transparent;
+  color: rgba(10, 10, 11, 0.78);
+}
+
+.emotion-19 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  font-size: 1.3929rem;
+  padding: 8px;
+  border-radius: 50%;
+  overflow: visible;
+  color: rgba(0, 0, 0, 0.54);
+  -webkit-transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  padding: 12px;
+  font-size: 1.625rem;
+  font-size: 1.2rem;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.emotion-19::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-19.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-19 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-19:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-19:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-19.Mui-disabled {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-20 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.3929rem;
+}
+
+.emotion-20 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-24 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: inherit;
+}
+
+.emotion-24 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-30 {
+  border-color: rgba(0, 0, 0, 0.06);
+  background-color: #fdfdfd;
+  color: rgba(10, 10, 11, 0.78);
+}
+
+.emotion-30 .dashboard-header span {
+  background-color: #fdfdfd;
+  color: rgba(10, 10, 11, 0.78);
+}
+
+.emotion-30 .MuiButtonBase-root {
+  color: rgba(10, 10, 11, 0.78);
+}
+
 <div
   class="margin-left-small margin-top"
   style="max-width: 80vw;"
@@ -313,23 +653,787 @@ exports[`Deployments Component renders correctly 1`] = `
     </button>
   </div>
   <div
-    class="loaderContainer shrunk"
+    class="fadeIn"
   >
     <div
-      class="  loader"
+      class="margin-left"
     >
-      <span
-        class="dot dot_1"
-      />
-      <span
-        class="dot dot_2"
-      />
-      <span
-        class="dot dot_3"
-      />
-      <span
-        class="dot dot_4"
-      />
+      <h4
+        class="dashboard-header emotion-12 margin-top-large  margin-right"
+      >
+        <span>
+          In progress now
+        </span>
+      </h4>
+      <div
+        class="fadeIn deploy-table-contain "
+      >
+        <div
+          class="deployment-item deployment-header-item muted progress-item"
+        >
+          <div
+            class=""
+          >
+            Release
+          </div>
+          <div
+            class=""
+          >
+            Target device(s)
+          </div>
+          <div
+            class=""
+          >
+            Start time
+          </div>
+          <div
+            class=""
+          >
+            End time
+          </div>
+          <div
+            class="align-right column-defined"
+          >
+            # devices
+          </div>
+          <div
+            class=""
+          >
+            Status
+          </div>
+        </div>
+        <div
+          class="margin-right-small"
+        >
+          <div
+            class="deployment-item progress-item"
+          >
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Release
+              </span>
+              <div
+                class="text-overflow emotion-13"
+                title="r1"
+              >
+                r1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Target device(s)
+              </span>
+              <div
+                class="text-overflow emotion-13"
+                title="test deployment"
+              >
+                test deployment
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Start time
+              </span>
+              <span
+                aria-label="Tue Jan 01 2019 12:30:00 GMT+0000"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <time
+                  datetime="2019-01-01T12:30:00+00:00"
+                >
+                  2019-01-01 12:30
+                </time>
+              </span>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                End time
+              </span>
+              <span
+                aria-label=""
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <div
+                  class=""
+                >
+                  -
+                </div>
+              </span>
+            </div>
+            <div
+              class="align-right column-defined"
+            >
+              <span
+                class="deployment-item-title muted"
+              >
+                # devices
+              </span>
+              <div
+                class="align-right column-defined"
+              >
+                1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Status
+              </span>
+              <div
+                class="relative emotion-15  "
+              >
+                <div
+                  class="emotion-16"
+                >
+                  <div
+                    class="progress-chart relative detailed"
+                  >
+                    <div
+                      class="progress-step"
+                      style="left: 0%; width: 100%;"
+                    >
+                      <div
+                        class="progress-bar"
+                        style="width: 100%; background-color: rgb(170, 170, 170);"
+                      />
+                      <div
+                        style="display: contents;"
+                      >
+                        <div
+                          class="progress-bar green"
+                          style="width: 0%;"
+                        />
+                        <div
+                          class="progress-bar warning"
+                          style="left: 0%; width: 0%;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="progress-step relative flexbox progress-step-total"
+                    >
+                      <div
+                        class="progress-bar"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="flexbox center-aligned muted"
+                    style="justify-content: flex-end;"
+                  >
+                    0 failures
+                  </div>
+                </div>
+                <div
+                  class="flexbox space-between muted"
+                >
+                  <div>
+                    Devices in progress
+                  </div>
+                  <div>
+                    Current phase: 1 of 1
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-17"
+              tabindex="0"
+              type="button"
+            >
+              View details
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+            <button
+              aria-label="Abort"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge columnHeader emotion-19"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium cancelButton muted emotion-20"
+                data-testid="CancelOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm3.59-13L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+          </div>
+          <div
+            class="deployment-item progress-item"
+          >
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Release
+              </span>
+              <div
+                class="text-overflow emotion-13"
+                title="r1"
+              >
+                r1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Target device(s)
+              </span>
+              <div
+                class="text-overflow emotion-13"
+                title="test deployment 2"
+              >
+                test deployment 2
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Start time
+              </span>
+              <span
+                aria-label="Tue Jan 01 2019 12:25:00 GMT+0000"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <time
+                  datetime="2019-01-01T12:25:00+00:00"
+                >
+                  2019-01-01 12:25
+                </time>
+              </span>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                End time
+              </span>
+              <span
+                aria-label=""
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <div
+                  class=""
+                >
+                  -
+                </div>
+              </span>
+            </div>
+            <div
+              class="align-right column-defined"
+            >
+              <span
+                class="deployment-item-title muted"
+              >
+                # devices
+              </span>
+              <div
+                class="align-right column-defined"
+              >
+                1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Status
+              </span>
+              <div
+                class="flexbox center-aligned"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-24"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+                  />
+                </svg>
+                <span
+                  class="margin-left-small"
+                >
+                  Queued to start
+                </span>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-17"
+              tabindex="0"
+              type="button"
+            >
+              View details
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+            <button
+              aria-label="Abort"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge columnHeader emotion-19"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium cancelButton muted emotion-20"
+                data-testid="CancelOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm3.59-13L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="flexbox"
+        >
+          <div
+            class="loaderContainer shrunk"
+          >
+            <div
+              class="small  loader"
+            >
+              <span
+                class="dot dot_1"
+              />
+              <span
+                class="dot dot_2"
+              />
+              <span
+                class="dot dot_3"
+              />
+              <span
+                class="dot dot_4"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="deployments-pending margin-top margin-bottom-large emotion-30"
+    >
+      <h4
+        class="dashboard-header emotion-12 margin-small margin-top"
+      >
+        <span>
+          Pending
+        </span>
+      </h4>
+      <div
+        class="fadeIn deploy-table-contain margin-left-small"
+      >
+        <div
+          class="deployment-item deployment-header-item muted pending-item"
+        >
+          <div
+            class=""
+          >
+            Release
+          </div>
+          <div
+            class=""
+          >
+            Target device(s)
+          </div>
+          <div
+            class=""
+          >
+            Start time
+          </div>
+          <div
+            class=""
+          >
+            End time
+          </div>
+          <div
+            class="align-right column-defined"
+          >
+            # devices
+          </div>
+          <div
+            class=""
+          >
+            Status
+          </div>
+        </div>
+        <div
+          class=""
+        >
+          <div
+            class="deployment-item pending-item"
+          >
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Release
+              </span>
+              <div
+                class="text-overflow "
+                title="r1"
+              >
+                r1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Target device(s)
+              </span>
+              <div
+                class="text-overflow "
+                title="test deployment"
+              >
+                test deployment
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Start time
+              </span>
+              <span
+                aria-label="Tue Jan 01 2019 12:30:00 GMT+0000"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <time
+                  datetime="2019-01-01T12:30:00+00:00"
+                >
+                  2019-01-01 12:30
+                </time>
+              </span>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                End time
+              </span>
+              <span
+                aria-label=""
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <div
+                  class=""
+                >
+                  -
+                </div>
+              </span>
+            </div>
+            <div
+              class="align-right column-defined"
+            >
+              <span
+                class="deployment-item-title muted"
+              >
+                # devices
+              </span>
+              <div
+                class="align-right column-defined"
+              >
+                1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Status
+              </span>
+              <div
+                class="relative emotion-15  "
+              >
+                <div
+                  class="emotion-16"
+                >
+                  <div
+                    class="progress-chart relative detailed"
+                  >
+                    <div
+                      class="progress-step"
+                      style="left: 0%; width: 100%;"
+                    >
+                      <div
+                        class="progress-bar"
+                        style="width: 100%; background-color: rgb(170, 170, 170);"
+                      />
+                      <div
+                        style="display: contents;"
+                      >
+                        <div
+                          class="progress-bar green"
+                          style="width: 0%;"
+                        />
+                        <div
+                          class="progress-bar warning"
+                          style="left: 0%; width: 0%;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="progress-step relative flexbox progress-step-total"
+                    >
+                      <div
+                        class="progress-bar"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="flexbox center-aligned muted"
+                    style="justify-content: flex-end;"
+                  >
+                    0 failures
+                  </div>
+                </div>
+                <div
+                  class="flexbox space-between muted"
+                >
+                  <div>
+                    Devices in progress
+                  </div>
+                  <div>
+                    Current phase: 1 of 1
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-17"
+              tabindex="0"
+              type="button"
+            >
+              View details
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+            <button
+              aria-label="Abort"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge columnHeader emotion-19"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium cancelButton muted emotion-20"
+                data-testid="CancelOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm3.59-13L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+          </div>
+          <div
+            class="deployment-item pending-item"
+          >
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Release
+              </span>
+              <div
+                class="text-overflow "
+                title="r1"
+              >
+                r1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Target device(s)
+              </span>
+              <div
+                class="text-overflow "
+                title="test deployment 2"
+              >
+                test deployment 2
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Start time
+              </span>
+              <span
+                aria-label="Tue Jan 01 2019 12:25:00 GMT+0000"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <time
+                  datetime="2019-01-01T12:25:00+00:00"
+                >
+                  2019-01-01 12:25
+                </time>
+              </span>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                End time
+              </span>
+              <span
+                aria-label=""
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <div
+                  class=""
+                >
+                  -
+                </div>
+              </span>
+            </div>
+            <div
+              class="align-right column-defined"
+            >
+              <span
+                class="deployment-item-title muted"
+              >
+                # devices
+              </span>
+              <div
+                class="align-right column-defined"
+              >
+                1
+              </div>
+            </div>
+            <div>
+              <span
+                class="deployment-item-title muted"
+              >
+                Status
+              </span>
+              <div
+                class="flexbox center-aligned"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-24"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+                  />
+                </svg>
+                <span
+                  class="margin-left-small"
+                >
+                  Queued to start
+                </span>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-17"
+              tabindex="0"
+              type="button"
+            >
+              View details
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+            <button
+              aria-label="Abort"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge columnHeader emotion-19"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium cancelButton muted emotion-20"
+                data-testid="CancelOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm3.59-13L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root emotion-4"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="flexbox"
+        >
+          <div
+            class="loaderContainer shrunk"
+          >
+            <div
+              class="small  loader"
+            >
+              <span
+                class="dot dot_1"
+              />
+              <span
+                class="dot dot_2"
+              />
+              <span
+                class="dot dot_3"
+              />
+              <span
+                class="dot dot_4"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/js/components/deployments/__snapshots__/pastdeployments.test.js.snap
+++ b/src/js/components/deployments/__snapshots__/pastdeployments.test.js.snap
@@ -774,6 +774,534 @@ label+.emotion-20 {
   color: rgba(0, 0, 0, 0.26);
 }
 
+.emotion-31 {
+  -webkit-column-gap: 8px;
+  column-gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 32px);
+}
+
+.emotion-31>div {
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+}
+
+.emotion-31 .disabled {
+  opacity: 0.1;
+}
+
+.emotion-32 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: Lato,sans-serif;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #337a87;
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  border-radius: 2px;
+  font-size: 14px;
+  font-weight: bold;
+  background-color: transparent;
+  color: rgba(10, 10, 11, 0.78);
+  justify-self: center;
+  text-transform: none;
+}
+
+.emotion-32::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-32.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-32 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-32:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgb(35, 85, 94);
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-32:hover {
+    background-color: #337a87;
+  }
+}
+
+.emotion-32:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-32.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-32.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.emotion-32:hover {
+  colors: #337a87;
+}
+
+.emotion-32.MuiButton-text {
+  color: rgba(10, 10, 11, 0.78);
+}
+
+.emotion-32:hover {
+  background-color: transparent;
+  color: rgba(10, 10, 11, 0.78);
+}
+
+.emotion-34 {
+  overflow: auto;
+  color: rgba(10, 10, 11, 0.78);
+  font-size: 0.8125rem;
+}
+
+.emotion-34:last-child {
+  padding: 0;
+}
+
+.emotion-35 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 56px;
+  min-height: 52px;
+  padding-right: 2px;
+}
+
+@media (min-width:600px) {
+  .emotion-35 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media (min-width:0px) {
+  @media (orientation: landscape) {
+    .emotion-35 {
+      min-height: 48px;
+    }
+  }
+}
+
+@media (min-width:600px) {
+  .emotion-35 {
+    min-height: 64px;
+  }
+}
+
+@media (min-width:0px) and (orientation: landscape) {
+  .emotion-35 {
+    min-height: 52px;
+  }
+}
+
+@media (min-width:600px) {
+  .emotion-35 {
+    min-height: 52px;
+    padding-right: 2px;
+  }
+}
+
+.emotion-35 .MuiTablePagination-actions {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-left: 20px;
+}
+
+.emotion-36 {
+  -webkit-flex: 1 1 100%;
+  -ms-flex: 1 1 100%;
+  flex: 1 1 100%;
+}
+
+.emotion-37 {
+  font-family: Lato,sans-serif;
+  font-weight: 400;
+  font-size: 0.8125rem;
+  line-height: 1.43;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-38 {
+  line-height: 1.4375em;
+  font-family: Lato,sans-serif;
+  font-weight: 400;
+  font-size: 0.9286rem;
+  color: rgba(10, 10, 11, 0.78);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: inherit;
+  font-size: inherit;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-right: 32px;
+  margin-left: 8px;
+}
+
+.emotion-38.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-38 .MuiTablePagination-select {
+  padding-left: 8px;
+  padding-right: 24px;
+  text-align: right;
+  -webkit-text-align-last: right;
+  text-align-last: right;
+}
+
+.emotion-39 {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border-radius: 0;
+  cursor: pointer;
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+}
+
+.emotion-39:focus {
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 0;
+}
+
+.emotion-39::-ms-expand {
+  display: none;
+}
+
+.emotion-39.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-39[multiple] {
+  height: auto;
+}
+
+.emotion-39:not([multiple]) option,
+.emotion-39:not([multiple]) optgroup {
+  background-color: #fff;
+}
+
+.emotion-39.emotion-39.emotion-39 {
+  padding-right: 24px;
+  min-width: 16px;
+}
+
+.emotion-39.MuiSelect-select {
+  height: auto;
+  min-height: 1.4375em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.emotion-39::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-39::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-39:-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-39::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-39:focus {
+  outline: 0;
+}
+
+.emotion-39:invalid {
+  box-shadow: none;
+}
+
+.emotion-39::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39:-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39:focus:-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-39:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-39.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-39:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-40 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.emotion-41 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.3929rem;
+  position: absolute;
+  right: 0;
+  top: calc(50% - .5em);
+  pointer-events: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.emotion-41 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-41.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-42 {
+  font-family: Lato,sans-serif;
+  font-weight: 400;
+  font-size: 0.8125rem;
+  line-height: 1.43;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-43 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  font-size: 1.3929rem;
+  padding: 8px;
+  border-radius: 50%;
+  overflow: visible;
+  color: rgba(0, 0, 0, 0.54);
+  -webkit-transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  padding: 12px;
+  font-size: 1.625rem;
+  font-size: 1.2rem;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.emotion-43::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-43.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-43 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-43:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-43:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-43.Mui-disabled {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.26);
+}
+
 <div
   class="fadeIn margin-left margin-top-large"
 >
@@ -1020,6 +1548,359 @@ label+.emotion-20 {
   </div>
   <div
     class="deploy-table-contain"
-  />
+  >
+    <div
+      class="fadeIn deploy-table-contain margin-left-small"
+    >
+      <div
+        class="deployment-item deployment-header-item muted past-item"
+      >
+        <div
+          class=""
+        >
+          Release
+        </div>
+        <div
+          class=""
+        >
+          Target device(s)
+        </div>
+        <div
+          class=""
+        >
+          Start time
+        </div>
+        <div
+          class=""
+        >
+          End time
+        </div>
+        <div
+          class="align-right column-defined"
+        >
+          # devices
+        </div>
+        <div
+          class=""
+        >
+          Status
+        </div>
+        <div
+          class=""
+        >
+          Data downloaded
+        </div>
+      </div>
+      <div
+        class=""
+      >
+        <div
+          class="deployment-item past-item"
+        >
+          <div>
+            <span
+              class="deployment-item-title muted"
+            >
+              Release
+            </span>
+            <div
+              class="text-overflow "
+              title="r1"
+            >
+              r1
+            </div>
+          </div>
+          <div>
+            <span
+              class="deployment-item-title muted"
+            >
+              Target device(s)
+            </span>
+            <div
+              class="text-overflow "
+              title="test deployment"
+            >
+              test deployment
+            </div>
+          </div>
+          <div>
+            <span
+              class="deployment-item-title muted"
+            >
+              Start time
+            </span>
+            <span
+              aria-label="Tue Jan 01 2019 12:30:00 GMT+0000"
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <time
+                datetime="2019-01-01T12:30:00+00:00"
+              >
+                2019-01-01 12:30
+              </time>
+            </span>
+          </div>
+          <div>
+            <span
+              class="deployment-item-title muted"
+            >
+              End time
+            </span>
+            <span
+              aria-label=""
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <div
+                class=""
+              >
+                -
+              </div>
+            </span>
+          </div>
+          <div
+            class="align-right column-defined"
+          >
+            <span
+              class="deployment-item-title muted"
+            >
+              # devices
+            </span>
+            <div
+              class="align-right column-defined"
+            >
+              1
+            </div>
+          </div>
+          <div>
+            <span
+              class="deployment-item-title muted"
+            >
+              Status
+            </span>
+            <div
+              class="flexbox emotion-31 "
+            >
+              <div
+                aria-label="Skipped"
+                class="flexbox centered disabled"
+                data-mui-internal-clone-element="true"
+              >
+                <img
+                  src="skipped_status.png"
+                />
+                <div
+                  class="status"
+                >
+                  0
+                </div>
+              </div>
+              <div
+                aria-label="Pending"
+                class="flexbox centered disabled"
+                data-mui-internal-clone-element="true"
+              >
+                <img
+                  src="pending_status.png"
+                />
+                <div
+                  class="status"
+                >
+                  0
+                </div>
+              </div>
+              <div
+                aria-label="In progress"
+                class="flexbox centered "
+                data-mui-internal-clone-element="true"
+              >
+                <img
+                  src="progress_status.png"
+                />
+                <div
+                  class="status"
+                >
+                  1
+                </div>
+              </div>
+              <div
+                aria-label="Successful"
+                class="flexbox centered disabled"
+                data-mui-internal-clone-element="true"
+              >
+                <img
+                  src="success_status.png"
+                />
+                <div
+                  class="status"
+                >
+                  0
+                </div>
+              </div>
+              <div
+                aria-label="Failed"
+                class="flexbox centered disabled"
+                data-mui-internal-clone-element="true"
+              >
+                <img
+                  src="error_status.png"
+                />
+                <div
+                  class="status"
+                >
+                  0
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <span
+              class="deployment-item-title muted"
+            >
+              Data downloaded
+            </span>
+            <div
+              class="align-right"
+            >
+              -
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-32"
+            tabindex="0"
+            type="button"
+          >
+            View details
+            <span
+              class="MuiTouchRipple-root emotion-8"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="flexbox"
+      >
+        <div
+          class="MuiTablePagination-root flexbox margin-top margin-top-none emotion-34"
+        >
+          <div
+            class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar emotion-35"
+          >
+            <div
+              class="MuiTablePagination-spacer flexbox no-basis emotion-36"
+            />
+            <p
+              class="MuiTablePagination-selectLabel emotion-37"
+              id="mui-13"
+            >
+              Rows
+            </p>
+            <div
+              class="MuiInputBase-root MuiInputBase-colorPrimary emotion-38"
+            >
+              <div
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="mui-13 mui-12"
+                class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input emotion-39"
+                id="mui-12"
+                role="button"
+                tabindex="0"
+              >
+                20
+              </div>
+              <input
+                aria-hidden="true"
+                aria-invalid="false"
+                class="MuiSelect-nativeInput emotion-40"
+                tabindex="-1"
+                value="20"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard emotion-41"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </div>
+            <p
+              class="MuiTablePagination-displayedRows emotion-42"
+            />
+            <div
+              class="flexbox center-aligned"
+            >
+              <div>
+                1-1 of 1
+              </div>
+              <button
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge emotion-43"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                  data-testid="KeyboardArrowLeftIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.41 16.59 10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"
+                  />
+                </svg>
+              </button>
+              <div>
+                <button
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge emotion-43"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                    data-testid="KeyboardArrowRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="loaderContainer"
+        >
+          <div
+            class="small  loader"
+          >
+            <span
+              class="dot dot_1"
+            />
+            <span
+              class="dot dot_2"
+            />
+            <span
+              class="dot dot_3"
+            />
+            <span
+              class="dot dot_4"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/js/components/deployments/createdeployment.js
+++ b/src/js/components/deployments/createdeployment.js
@@ -40,7 +40,7 @@ import { createDeployment, getDeploymentsConfig } from '../../actions/deployment
 import { getGroupDevices, getSystemDevices } from '../../actions/deviceActions';
 import { advanceOnboarding } from '../../actions/onboardingActions';
 import { getReleases } from '../../actions/releaseActions';
-import { ALL_DEVICES, UNGROUPED_GROUP } from '../../constants/deviceConstants';
+import { ALL_DEVICES } from '../../constants/deviceConstants';
 import { onboardingSteps } from '../../constants/onboardingConstants';
 import { toggle, validatePhases } from '../../helpers';
 import {
@@ -50,6 +50,7 @@ import {
   getDocsVersion,
   getGlobalSettings,
   getGroupNames,
+  getGroupsByIdWithoutUngrouped,
   getIdAttribute,
   getIsEnterprise,
   getOnboardingState,
@@ -108,8 +109,7 @@ export const CreateDeployment = props => {
 
   const { canRetry, canSchedule, hasFullFiltering } = useSelector(getTenantCapabilities);
   const { createdGroup, groups, hasDynamicGroups } = useSelector(state => {
-    // eslint-disable-next-line no-unused-vars
-    const { [UNGROUPED_GROUP.id]: ungrouped, ...groups } = state.devices.groups.byId;
+    const groups = getGroupsByIdWithoutUngrouped(state);
     const createdGroup = Object.keys(groups).length ? Object.keys(groups)[0] : undefined;
     const hasDynamicGroups = Object.values(groups).some(group => !!group.id);
     return { createdGroup, hasDynamicGroups, groups };

--- a/src/js/components/deployments/createdeployment.test.js
+++ b/src/js/components/deployments/createdeployment.test.js
@@ -12,13 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -28,32 +24,21 @@ import { ForceDeploy, Retries, RolloutOptions } from './deployment-wizard/rollou
 import { ScheduleRollout } from './deployment-wizard/schedulerollout';
 import { Devices, ReleasesWarning, Software } from './deployment-wizard/softwaredevices';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.features,
+      isEnterprise: false,
+      isHosted: false
+    }
+  }
+};
 
 describe('CreateDeployment Component', () => {
-  let store;
-  let mockState = {
-    ...defaultState,
-    app: {
-      ...defaultState.app,
-      features: {
-        ...defaultState.features,
-        isEnterprise: false,
-        isHosted: false
-      }
-    }
-  };
-
-  beforeEach(() => {
-    store = mockStore(mockState);
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <CreateDeployment deploymentObject={{}} setDeploymentObject={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<CreateDeployment deploymentObject={{}} setDeploymentObject={jest.fn} />, { preloadedState });
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -79,10 +64,9 @@ describe('CreateDeployment Component', () => {
       it(`renders ${Component.displayName || Component.name} correctly`, () => {
         const { baseElement } = render(
           <LocalizationProvider dateAdapter={AdapterMoment}>
-            <Provider store={store}>
-              <Component {...props} />
-            </Provider>
-          </LocalizationProvider>
+            <Component {...props} />
+          </LocalizationProvider>,
+          { preloadedState }
         );
         const view = baseElement.lastChild;
         expect(view).toMatchSnapshot();
@@ -92,10 +76,9 @@ describe('CreateDeployment Component', () => {
       it(`renders ${Component.displayName || Component.name} correctly as enterprise`, () => {
         const { baseElement } = render(
           <LocalizationProvider dateAdapter={AdapterMoment}>
-            <Provider store={store}>
-              <Component {...props} isEnterprise />
-            </Provider>
-          </LocalizationProvider>
+            <Component {...props} isEnterprise />
+          </LocalizationProvider>,
+          { preloadedState }
         );
         const view = baseElement.lastChild;
         expect(view).toMatchSnapshot();

--- a/src/js/components/deployments/deployment-report/devicelist.test.js
+++ b/src/js/components/deployments/deployment-report/devicelist.test.js
@@ -12,38 +12,26 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { prettyDOM } from '@testing-library/dom';
 import { act, cleanup, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { adminUserCapabilities, defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import ProgressDeviceList from './devicelist';
 
-const mockStore = configureStore([thunk]);
-
 describe('ProgressDeviceList Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   afterEach(cleanup);
 
   it('renders correctly', async () => {
     const getDeploymentDevicesMock = jest.fn().mockResolvedValue(true);
     const ui = (
-      <Provider store={store}>
-        <ProgressDeviceList
-          selectedDevices={Object.values(defaultState.deployments.byId.d1.devices)}
-          deployment={defaultState.deployments.byId.d1}
-          getDeploymentDevices={getDeploymentDevicesMock}
-          userCapabilities={adminUserCapabilities}
-        />
-      </Provider>
+      <ProgressDeviceList
+        selectedDevices={Object.values(defaultState.deployments.byId.d1.devices)}
+        deployment={defaultState.deployments.byId.d1}
+        getDeploymentDevices={getDeploymentDevicesMock}
+        userCapabilities={adminUserCapabilities}
+      />
     );
     const { asFragment, rerender } = render(ui);
     await act(async () => jest.advanceTimersByTime(5000));

--- a/src/js/components/deployments/deployment-wizard/rolloutsteps.test.js
+++ b/src/js/components/deployments/deployment-wizard/rolloutsteps.test.js
@@ -12,34 +12,19 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import RolloutSteps from './rolloutsteps';
 
-const mockStore = configureStore([thunk]);
-
 describe('RolloutSteps Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    let tree = render(
-      <Provider store={store}>
-        <RolloutSteps onStepChange={jest.fn} steps={[]} />
-      </Provider>
-    );
+    let tree = render(<RolloutSteps onStepChange={jest.fn} steps={[]} />);
     let view = tree.baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
 
-    tree = render(
-      <Provider store={store}>
-        <RolloutSteps steps={[]} />
-      </Provider>
-    );
+    tree = render(<RolloutSteps steps={[]} />);
     view = tree.baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/deployments/deploymentitem.test.js
+++ b/src/js/components/deployments/deploymentitem.test.js
@@ -12,19 +12,11 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import DeploymentItem from './deploymentitem';
 import { defaultHeaders as columnHeaders } from './deploymentslist';
-
-const mockStore = configureStore([thunk]);
-
-const store = mockStore({ ...defaultState });
 
 describe('DeploymentItem Component', () => {
   it('renders correctly', async () => {
@@ -49,11 +41,7 @@ describe('DeploymentItem Component', () => {
         }
       }
     };
-    const { container } = render(
-      <Provider store={store}>
-        <DeploymentItem columnHeaders={columnHeaders} deployment={deployment} type="progress" />
-      </Provider>
-    );
+    const { container } = render(<DeploymentItem columnHeaders={columnHeaders} deployment={deployment} type="progress" />);
     expect(container.firstChild.firstChild).toMatchSnapshot();
     expect(container).toEqual(expect.not.stringMatching(undefineds));
   });

--- a/src/js/components/deployments/deployments.js
+++ b/src/js/components/deployments/deployments.js
@@ -22,10 +22,10 @@ import { abortDeployment, setDeploymentsState } from '../../actions/deploymentAc
 import { getDynamicGroups, getGroups } from '../../actions/deviceActions';
 import { advanceOnboarding } from '../../actions/onboardingActions';
 import { DEPLOYMENT_ROUTES, DEPLOYMENT_STATES, listDefaultsByState } from '../../constants/deploymentConstants';
-import { ALL_DEVICES, UNGROUPED_GROUP } from '../../constants/deviceConstants';
+import { ALL_DEVICES } from '../../constants/deviceConstants';
 import { onboardingSteps } from '../../constants/onboardingConstants';
 import { getISOStringBoundaries } from '../../helpers';
-import { getDevicesById, getIsEnterprise, getOnboardingState, getReleasesById, getUserCapabilities } from '../../selectors';
+import { getDevicesById, getGroupsByIdWithoutUngrouped, getIsEnterprise, getOnboardingState, getReleasesById, getUserCapabilities } from '../../selectors';
 import { useLocationParams } from '../../utils/liststatehook';
 import { getOnboardingComponentFor } from '../../utils/onboardingmanager';
 import useWindowSize from '../../utils/resizehook';
@@ -53,11 +53,7 @@ const routes = {
 export const defaultRefreshDeploymentsLength = 30000;
 
 export const Deployments = () => {
-  const groupsById = useSelector(state => {
-    // eslint-disable-next-line no-unused-vars
-    const { [UNGROUPED_GROUP.id]: ungrouped, ...groups } = state.devices.groups.byId;
-    return groups;
-  });
+  const groupsById = useSelector(getGroupsByIdWithoutUngrouped);
   const devicesById = useSelector(getDevicesById);
   const isEnterprise = useSelector(getIsEnterprise);
   const onboardingState = useSelector(getOnboardingState);

--- a/src/js/components/deployments/deployments.test.js
+++ b/src/js/components/deployments/deployments.test.js
@@ -12,24 +12,19 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, mockDate, undefineds } from '../../../../tests/mockData';
 import { render, selectMaterialUiSelectOption } from '../../../../tests/setupTests';
 import GeneralApi from '../../api/general-api';
 import { ALL_DEVICES } from '../../constants/deviceConstants';
-import { getConfiguredStore } from './../../reducers';
 import Deployments from './deployments';
 
-const mockStore = configureStore([thunk]);
 const defaultLocationProps = { location: { search: 'startDate=2019-01-01' }, match: {} };
 
 const specialKeys = {
@@ -38,7 +33,7 @@ const specialKeys = {
 };
 
 describe('Deployments Component', () => {
-  let mockState = {
+  const mockState = {
     ...defaultState,
     app: {
       ...defaultState.app,
@@ -73,14 +68,9 @@ describe('Deployments Component', () => {
   };
 
   it('renders correctly', async () => {
-    const store = mockStore(mockState);
     const get = jest.spyOn(GeneralApi, 'get');
-    const ui = (
-      <Provider store={store}>
-        <Deployments {...defaultLocationProps} />
-      </Provider>
-    );
-    const { baseElement, rerender } = render(ui);
+    const ui = <Deployments {...defaultLocationProps} />;
+    const { baseElement, rerender } = render(ui, { state: mockState });
     await waitFor(() => rerender(ui));
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
@@ -124,15 +114,12 @@ describe('Deployments Component', () => {
         }
       }
     };
-    const store = getConfiguredStore({ preloadedState });
     const ui = (
       <LocalizationProvider dateAdapter={AdapterMoment}>
-        <Provider store={store}>
-          <Deployments {...defaultLocationProps} />
-        </Provider>
+        <Deployments {...defaultLocationProps} />
       </LocalizationProvider>
     );
-    const { rerender } = render(ui);
+    const { rerender } = render(ui, { preloadedState });
     await user.click(screen.getByRole('tab', { name: /Finished/i }));
     await user.click(screen.getByRole('tab', { name: /Scheduled/i }));
     await user.click(screen.getByRole('tab', { name: /Active/i }));
@@ -170,15 +157,12 @@ describe('Deployments Component', () => {
         }
       }
     };
-    const store = getConfiguredStore({ preloadedState });
     const ui = (
       <LocalizationProvider dateAdapter={AdapterMoment}>
-        <Provider store={store}>
-          <Deployments {...defaultLocationProps} />
-        </Provider>
+        <Deployments {...defaultLocationProps} />
       </LocalizationProvider>
     );
-    const { rerender } = render(ui);
+    const { rerender } = render(ui, { preloadedState });
     await user.click(screen.getByRole('tab', { name: /Finished/i }));
     await user.click(screen.getByRole('button', { name: /Create a deployment/i }));
     const releaseId = 'release-998';
@@ -259,15 +243,12 @@ describe('Deployments Component', () => {
         }
       }
     };
-    const store = getConfiguredStore({ preloadedState });
     const ui = (
       <LocalizationProvider dateAdapter={AdapterMoment}>
-        <Provider store={store}>
-          <Deployments {...defaultLocationProps} />
-        </Provider>
+        <Deployments {...defaultLocationProps} />
       </LocalizationProvider>
     );
-    const { rerender } = render(ui);
+    const { rerender } = render(ui, { preloadedState });
     await user.click(screen.getByRole('button', { name: /Create a deployment/i }));
     const releaseId = 'release-998';
     act(() => {

--- a/src/js/components/deployments/deploymentslist.test.js
+++ b/src/js/components/deployments/deploymentslist.test.js
@@ -12,25 +12,15 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import DeploymentsList from './deploymentslist';
 
-const mockStore = configureStore([thunk]);
-
-const store = mockStore({ ...defaultState });
-
 describe('DeploymentsList Component', () => {
   it('renders correctly', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeploymentsList items={Object.values(defaultState.deployments.byId)} refreshItems={() => {}} type="pending" title="pending" />
-      </Provider>
+      <DeploymentsList items={Object.values(defaultState.deployments.byId)} refreshItems={() => {}} type="pending" title="pending" />
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/deployments/inprogressdeployments.js
+++ b/src/js/components/deployments/inprogressdeployments.js
@@ -21,8 +21,16 @@ import { setSnackbar } from '../../actions/appActions';
 import { getDeploymentsByStatus, setDeploymentsState } from '../../actions/deploymentActions';
 import { DEPLOYMENT_STATES } from '../../constants/deploymentConstants';
 import { onboardingSteps } from '../../constants/onboardingConstants';
-import { tryMapDeployments } from '../../helpers';
-import { getIdAttribute, getIsEnterprise, getOnboardingState, getUserCapabilities } from '../../selectors';
+import {
+  getDeploymentsByStatus as getDeploymentsByStatusSelector,
+  getDeploymentsSelectionState,
+  getDevicesById,
+  getIdAttribute,
+  getIsEnterprise,
+  getMappedDeploymentSelection,
+  getOnboardingState,
+  getUserCapabilities
+} from '../../selectors';
 import { getOnboardingComponentFor } from '../../utils/onboardingmanager';
 import useWindowSize from '../../utils/resizehook';
 import { clearAllRetryTimers, clearRetryTimer, setRetryTimer } from '../../utils/retrytimer';
@@ -51,19 +59,19 @@ const useStyles = makeStyles()(theme => ({
 export const Progress = ({ abort, createClick, ...remainder }) => {
   const dispatch = useDispatch();
   const dispatchedSetSnackbar = (...args) => dispatch(setSnackbar(...args));
-  const progress = useSelector(
-    state => state.deployments.selectionState.inprogress.selection.reduce(tryMapDeployments, { state, deployments: [] }).deployments
-  );
-  const pending = useSelector(state => state.deployments.selectionState.pending.selection.reduce(tryMapDeployments, { state, deployments: [] }).deployments);
   const { canConfigure, canDeploy } = useSelector(getUserCapabilities);
   const { attribute: idAttribute } = useSelector(getIdAttribute);
   const onboardingState = useSelector(getOnboardingState);
   const isEnterprise = useSelector(getIsEnterprise);
-  const pastDeploymentsCount = useSelector(state => state.deployments.byStatus.finished.total);
-  const pendingCount = useSelector(state => state.deployments.byStatus.pending.total);
-  const progressCount = useSelector(state => state.deployments.byStatus.inprogress.total);
-  const selectionState = useSelector(state => state.deployments.selectionState);
-  const devices = useSelector(state => state.devices.byId);
+  const {
+    finished: { total: pastDeploymentsCount },
+    pending: { total: pendingCount },
+    inprogress: { total: progressCount }
+  } = useSelector(getDeploymentsByStatusSelector);
+  const progress = useSelector(state => getMappedDeploymentSelection(state, DEPLOYMENT_STATES.inprogress));
+  const pending = useSelector(state => getMappedDeploymentSelection(state, DEPLOYMENT_STATES.pending));
+  const selectionState = useSelector(getDeploymentsSelectionState);
+  const devices = useSelector(getDevicesById);
 
   const { page: progressPage, perPage: progressPerPage } = selectionState.inprogress;
   const { page: pendingPage, perPage: pendingPerPage } = selectionState.pending;

--- a/src/js/components/deployments/inprogressdeployments.test.js
+++ b/src/js/components/deployments/inprogressdeployments.test.js
@@ -12,39 +12,26 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Progress from './inprogressdeployments';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  deployments: {
+    ...defaultState.deployments,
+    selectionState: {
+      ...defaultState.deployments.selectionState,
+      inprogress: { ...defaultState.deployments.selectionState.inprogress, selection: ['d1'] },
+      pending: { ...defaultState.deployments.selectionState.pending, selection: ['d2'] }
+    }
+  }
+};
 
 describe('InProgressDeployments Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      deployments: {
-        ...defaultState.deployments,
-        selectionState: {
-          ...defaultState.deployments.selectionState,
-          inprogress: { ...defaultState.deployments.selectionState.inprogress, selection: ['d1'] },
-          pending: { ...defaultState.deployments.selectionState.pending, selection: ['d2'] }
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Progress />
-      </Provider>
-    );
+    const { baseElement } = render(<Progress />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/deployments/pastdeployments.js
+++ b/src/js/components/deployments/pastdeployments.js
@@ -25,8 +25,16 @@ import { advanceOnboarding } from '../../actions/onboardingActions';
 import { BEGINNING_OF_TIME, SORTING_OPTIONS, TIMEOUTS } from '../../constants/appConstants';
 import { DEPLOYMENT_STATES, DEPLOYMENT_TYPES } from '../../constants/deploymentConstants';
 import { onboardingSteps } from '../../constants/onboardingConstants';
-import { getISOStringBoundaries, tryMapDeployments } from '../../helpers';
-import { getGroupNames, getIdAttribute, getOnboardingState, getUserCapabilities } from '../../selectors';
+import { getISOStringBoundaries } from '../../helpers';
+import {
+  getDeploymentsSelectionState,
+  getDevicesById,
+  getGroupNames,
+  getIdAttribute,
+  getMappedDeploymentSelection,
+  getOnboardingState,
+  getUserCapabilities
+} from '../../selectors';
 import { useDebounce } from '../../utils/debouncehook';
 import { getOnboardingComponentFor } from '../../utils/onboardingmanager';
 import useWindowSize from '../../utils/resizehook';
@@ -66,12 +74,12 @@ export const Past = props => {
   const dispatch = useDispatch();
   const dispatchedSetSnackbar = (...args) => dispatch(setSnackbar(...args));
 
-  const past = useSelector(state => state.deployments.selectionState.finished.selection.reduce(tryMapDeployments, { state, deployments: [] }).deployments);
+  const { finished: pastSelectionState } = useSelector(getDeploymentsSelectionState);
+  const past = useSelector(state => getMappedDeploymentSelection(state, type));
   const { canConfigure, canDeploy } = useSelector(getUserCapabilities);
   const { attribute: idAttribute } = useSelector(getIdAttribute);
   const onboardingState = useSelector(getOnboardingState);
-  const pastSelectionState = useSelector(state => state.deployments.selectionState.finished);
-  const devices = useSelector(state => state.devices.byId);
+  const devices = useSelector(getDevicesById);
   const groupNames = useSelector(getGroupNames);
 
   const debouncedSearch = useDebounce(searchValue, TIMEOUTS.debounceDefault);

--- a/src/js/components/deployments/pastdeployments.test.js
+++ b/src/js/components/deployments/pastdeployments.test.js
@@ -12,45 +12,35 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Past from './pastdeployments';
 
-const mockStore = configureStore([thunk]);
+const state = {
+  ...defaultState,
+  deployments: {
+    ...defaultState.deployments,
+    byId: {},
+    selectionState: {
+      ...defaultState.deployments.selectionState,
+      finished: {
+        selection: []
+      }
+    }
+  }
+};
 
 describe('PastDeployments Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      deployments: {
-        ...defaultState.deployments,
-        byId: {},
-        selectionState: {
-          ...defaultState.deployments.selectionState,
-          finished: {
-            selection: []
-          }
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
     const { baseElement } = render(
       <LocalizationProvider dateAdapter={AdapterMoment}>
-        <Provider store={store}>
-          <Past past={[]} groups={[]} refreshPast={() => {}} refreshDeployments={jest.fn} />
-        </Provider>
-      </LocalizationProvider>
+        <Past past={[]} groups={[]} refreshPast={() => {}} refreshDeployments={jest.fn} />
+      </LocalizationProvider>,
+      { state }
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/deployments/report.js
+++ b/src/js/components/deployments/report.js
@@ -37,7 +37,7 @@ import { TIMEOUTS } from '../../constants/appConstants';
 import { DEPLOYMENT_STATES, DEPLOYMENT_TYPES, deploymentStatesToSubstates } from '../../constants/deploymentConstants';
 import { AUDIT_LOGS_TYPES } from '../../constants/organizationConstants';
 import { statCollector, toggle } from '../../helpers';
-import { getDevicesById, getIdAttribute, getTenantCapabilities, getUserCapabilities } from '../../selectors';
+import { getDeploymentRelease, getDevicesById, getIdAttribute, getTenantCapabilities, getUserCapabilities } from '../../selectors';
 import ConfigurationObject from '../common/configurationobject';
 import Confirm from '../common/confirm';
 import LogDialog from '../common/dialogs/log';
@@ -100,12 +100,7 @@ export const DeploymentReport = ({ abort, open, onClose, past, retry, type }) =>
   });
   const devicesById = useSelector(getDevicesById);
   const { attribute: idAttribute } = useSelector(getIdAttribute);
-  const release = useSelector(state => {
-    const deployment = state.deployments.byId[state.deployments.selectionState.selectedId] || {};
-    return deployment.artifact_name && state.releases.byId[deployment.artifact_name]
-      ? state.releases.byId[deployment.artifact_name]
-      : { device_types_compatible: [] };
-  });
+  const release = useSelector(getDeploymentRelease);
   const tenantCapabilities = useSelector(getTenantCapabilities);
   const userCapabilities = useSelector(getUserCapabilities);
   // we can't filter by auditlog action via the api, so

--- a/src/js/components/deployments/report.test.js
+++ b/src/js/components/deployments/report.test.js
@@ -12,43 +12,31 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { prettyDOM } from '@testing-library/dom';
 import { act, cleanup, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import DeploymentReport from './report';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  deployments: {
+    ...defaultState.deployments,
+    selectedDeviceIds: [defaultState.deployments.byId.d1.devices.a1.id],
+    selectionState: {
+      selectedId: defaultState.deployments.byId.d1.id
+    }
+  }
+};
 
 describe('DeploymentReport Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      deployments: {
-        ...defaultState.deployments,
-        selectedDeviceIds: [defaultState.deployments.byId.d1.devices.a1.id],
-        selectionState: {
-          selectedId: defaultState.deployments.byId.d1.id
-        }
-      }
-    });
-  });
-
   afterEach(cleanup);
 
   it('renders correctly', async () => {
-    const ui = (
-      <Provider store={store}>
-        <DeploymentReport open type="finished" getDeploymentDevices={jest.fn} getDeviceById={jest.fn} getDeviceAuth={jest.fn} />
-      </Provider>
-    );
-    const { asFragment, rerender } = render(ui);
+    const ui = <DeploymentReport open type="finished" getDeploymentDevices={jest.fn} getDeviceById={jest.fn} getDeviceAuth={jest.fn} />;
+    const { asFragment, rerender } = render(ui, { preloadedState });
     act(() => jest.advanceTimersByTime(5000));
     await waitFor(() => rerender(ui));
     const view = prettyDOM(asFragment().childNodes[1], 100000, { highlight: false })

--- a/src/js/components/deployments/scheduleddeployments.js
+++ b/src/js/components/deployments/scheduleddeployments.js
@@ -25,8 +25,15 @@ import moment from 'moment';
 import { setSnackbar } from '../../actions/appActions';
 import { getDeploymentsByStatus, setDeploymentsState } from '../../actions/deploymentActions';
 import { DEPLOYMENT_STATES } from '../../constants/deploymentConstants';
-import { tryMapDeployments } from '../../helpers';
-import { getIdAttribute, getIsEnterprise, getUserCapabilities } from '../../selectors';
+import {
+  getDeploymentsByStatus as getDeploymentsByStatusSelector,
+  getDeploymentsSelectionState,
+  getDevicesById,
+  getIdAttribute,
+  getMappedDeploymentSelection,
+  getTenantCapabilities,
+  getUserCapabilities
+} from '../../selectors';
 import { clearAllRetryTimers, clearRetryTimer, setRetryTimer } from '../../utils/retrytimer';
 import EnterpriseNotification from '../common/enterpriseNotification';
 import { DeploymentDeviceCount, DeploymentEndTime, DeploymentPhases, DeploymentStartTime } from './deploymentitem';
@@ -68,17 +75,16 @@ export const Scheduled = ({ abort, createClick, openReport, ...remainder }) => {
   const [calendarEvents, setCalendarEvents] = useState([]);
   const [tabIndex, setTabIndex] = useState(tabs.list.index);
   const timer = useRef();
-  const items = useSelector(state => state.deployments.selectionState.scheduled.selection.reduce(tryMapDeployments, { state, deployments: [] }).deployments);
   const { canConfigure, canDeploy } = useSelector(getUserCapabilities);
-  const count = useSelector(state => state.deployments.byStatus.scheduled.total);
+  const {
+    scheduled: { total: count }
+  } = useSelector(getDeploymentsByStatusSelector);
   const { attribute: idAttribute } = useSelector(getIdAttribute);
-  const devices = useSelector(state => state.devices.byId);
+  const devices = useSelector(getDevicesById);
   // TODO: isEnterprise is misleading here, but is passed down to the DeploymentListItem, this should be renamed
-  const isEnterprise = useSelector(state => {
-    const { plan = 'os' } = state.organization.organization;
-    return getIsEnterprise(state) || plan !== 'os';
-  });
-  const scheduledState = useSelector(state => state.deployments.selectionState.scheduled);
+  const { canDelta: isEnterprise } = useSelector(getTenantCapabilities);
+  const { scheduled: scheduledState } = useSelector(getDeploymentsSelectionState);
+  const items = useSelector(state => getMappedDeploymentSelection(state, type));
   const dispatch = useDispatch();
   const dispatchedSetSnackbar = (...args) => dispatch(setSnackbar(...args));
   const { classes } = useStyles();

--- a/src/js/components/deployments/scheduleddeployments.test.js
+++ b/src/js/components/deployments/scheduleddeployments.test.js
@@ -12,52 +12,39 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import ScheduledDeployments from './scheduleddeployments';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.app.features,
+      isEnterprise: true,
+      isHosted: false
+    }
+  },
+  deployments: {
+    ...defaultState.deployments,
+    byStatus: {
+      ...defaultState.deployments.byStatus,
+      scheduled: { deploymentIds: [], total: 0 }
+    },
+    selectionState: {
+      ...defaultState.deployments.selectionState,
+      scheduled: {
+        selection: []
+      }
+    }
+  }
+};
 
 describe('ScheduledDeployments Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          isEnterprise: true,
-          isHosted: false
-        }
-      },
-      deployments: {
-        ...defaultState.deployments,
-        byStatus: {
-          ...defaultState.deployments.byStatus,
-          scheduled: { deploymentIds: [], total: 0 }
-        },
-        selectionState: {
-          ...defaultState.deployments.selectionState,
-          scheduled: {
-            selection: []
-          }
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <ScheduledDeployments />
-      </Provider>
-    );
+    const { baseElement } = render(<ScheduledDeployments />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/__snapshots__/device-groups.test.js.snap
+++ b/src/js/components/devices/__snapshots__/device-groups.test.js.snap
@@ -787,7 +787,7 @@ exports[`DeviceGroups Component renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="loaderContainer shrunk"
+              class="loaderContainer"
             >
               <div
                 class="small  loader"

--- a/src/js/components/devices/authorized-devices.test.js
+++ b/src/js/components/devices/authorized-devices.test.js
@@ -12,12 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -26,32 +23,23 @@ import * as UserActions from '../../actions/userActions';
 import Authorized from './authorized-devices';
 import { routes } from './base-devices';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  devices: {
+    ...defaultState.devices,
+    byStatus: {
+      ...defaultState.devices.byStatus,
+      accepted: {
+        deviceIds: [],
+        total: 0
+      }
+    }
+  }
+};
 
 describe('AuthorizedDevices Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      devices: {
-        ...defaultState.devices,
-        byStatus: {
-          ...defaultState.devices.byStatus,
-          accepted: {
-            deviceIds: [],
-            total: 0
-          }
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Authorized states={routes} />
-      </Provider>
-    );
+    const { baseElement } = render(<Authorized states={routes} />, { preloadedState });
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -72,7 +60,7 @@ describe('AuthorizedDevices Component', () => {
     // const devices = defaultState.devices.byStatus.accepted.deviceIds.map(id => defaultState.devices.byId[id]);
     const pageTotal = defaultState.devices.byStatus.accepted.deviceIds.length;
     // const deviceListState = { isLoading: false, selectedState: DEVICE_STATES.accepted, selection: [], sort: {} };
-    store = mockStore({
+    const preloadedState = {
       ...defaultState,
       app: {
         ...defaultState.app,
@@ -97,22 +85,20 @@ describe('AuthorizedDevices Component', () => {
         ...defaultState.users,
         customColumns: [{ attribute: { name: attributeNames.updateTime, scope: 'system' }, size: 220 }]
       }
-    });
+    };
     let ui = (
-      <Provider store={store}>
-        <Authorized
-          addDevicesToGroup={jest.fn}
-          onGroupClick={jest.fn}
-          onGroupRemoval={jest.fn}
-          onMakeGatewayClick={jest.fn}
-          onPreauthClick={jest.fn}
-          openSettingsDialog={jest.fn}
-          removeDevicesFromGroup={jest.fn}
-          showsDialog={false}
-        />
-      </Provider>
+      <Authorized
+        addDevicesToGroup={jest.fn}
+        onGroupClick={jest.fn}
+        onGroupRemoval={jest.fn}
+        onMakeGatewayClick={jest.fn}
+        onPreauthClick={jest.fn}
+        openSettingsDialog={jest.fn}
+        removeDevicesFromGroup={jest.fn}
+        showsDialog={false}
+      />
     );
-    const { rerender } = render(ui);
+    const { rerender } = render(ui, { preloadedState });
     await waitFor(() => expect(screen.getAllByRole('checkbox').length).toBeTruthy());
     await user.click(screen.getAllByRole('checkbox')[0]);
     expect(setListStateSpy).toHaveBeenCalledWith({ selection: [0, 1], setOnly: true });

--- a/src/js/components/devices/device-details/authsets/authsets.test.js
+++ b/src/js/components/devices/device-details/authsets/authsets.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../../tests/mockData';
+import { undefineds } from '../../../../../../tests/mockData';
 import { render } from '../../../../../../tests/setupTests';
 import Authsets from './authsets';
 
-const mockStore = configureStore([thunk]);
-
 describe('Authsets Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Authsets device={{ id: 'a1', status: 'accepted', attributes: [], auth_sets: [] }} open={true} />
-      </Provider>
-    );
+    const { baseElement } = render(<Authsets device={{ id: 'a1', status: 'accepted', attributes: [], auth_sets: [] }} open={true} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/device-details/authstatus.test.js
+++ b/src/js/components/devices/device-details/authstatus.test.js
@@ -12,40 +12,28 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { adminUserCapabilities, defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import AuthStatus from './authstatus';
 
-const mockStore = configureStore([thunk]);
-
 describe('AuthStatus Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <AuthStatus
-          device={{
-            ...defaultState.devices.byId.a1,
+      <AuthStatus
+        device={{
+          ...defaultState.devices.byId.a1,
 
-            auth_sets: [
-              ...defaultState.devices.byId.a1.auth_sets,
-              {
-                ...defaultState.devices.byId.a1.auth_sets[0],
-                status: 'pending'
-              }
-            ]
-          }}
-          userCapabilities={adminUserCapabilities}
-        />
-      </Provider>
+          auth_sets: [
+            ...defaultState.devices.byId.a1.auth_sets,
+            {
+              ...defaultState.devices.byId.a1.auth_sets[0],
+              status: 'pending'
+            }
+          ]
+        }}
+        userCapabilities={adminUserCapabilities}
+      />
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/devices/device-details/configuration.test.js
+++ b/src/js/components/devices/device-details/configuration.test.js
@@ -12,18 +12,13 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import Configuration, { ConfigEditingActions, ConfigEmptyNote, ConfigUpToDateNote, ConfigUpdateFailureActions, ConfigUpdateNote } from './configuration';
-
-const mockStore = configureStore([thunk]);
 
 describe('tiny components', () => {
   [ConfigEditingActions, ConfigUpdateFailureActions, ConfigUpdateNote, ConfigEmptyNote, ConfigUpToDateNote].forEach(async Component => {
@@ -48,33 +43,27 @@ describe('tiny components', () => {
 });
 
 describe('Configuration Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   const reportedTime = '2019-01-01T09:25:01.000Z';
   it('renders correctly', async () => {
     const setDeviceConfigMock = jest.fn().mockResolvedValue();
     const { baseElement } = render(
-      <Provider store={store}>
-        <Configuration
-          device={{
-            ...defaultState.devices.byId.a1,
-            config: {
-              configured: { uiPasswordRequired: true, foo: 'bar', timezone: 'GMT+2' },
-              reported: { uiPasswordRequired: true, foo: 'bar', timezone: 'GMT+2' },
-              updated_ts: defaultState.devices.byId.a1.updated_ts,
-              reported_ts: reportedTime
-            }
-          }}
-          abortDeployment={jest.fn}
-          applyDeviceConfig={setDeviceConfigMock}
-          getDeviceLog={jest.fn}
-          getSingleDeployment={jest.fn}
-          saveGlobalSettings={jest.fn}
-          setDeviceConfig={setDeviceConfigMock}
-        />
-      </Provider>
+      <Configuration
+        device={{
+          ...defaultState.devices.byId.a1,
+          config: {
+            configured: { uiPasswordRequired: true, foo: 'bar', timezone: 'GMT+2' },
+            reported: { uiPasswordRequired: true, foo: 'bar', timezone: 'GMT+2' },
+            updated_ts: defaultState.devices.byId.a1.updated_ts,
+            reported_ts: reportedTime
+          }
+        }}
+        abortDeployment={jest.fn}
+        applyDeviceConfig={setDeviceConfigMock}
+        getDeviceLog={jest.fn}
+        getSingleDeployment={jest.fn}
+        saveGlobalSettings={jest.fn}
+        setDeviceConfig={setDeviceConfigMock}
+      />
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
@@ -95,17 +84,15 @@ describe('Configuration Component', () => {
       }
     };
     let ui = (
-      <Provider store={store}>
-        <Configuration
-          device={device}
-          abortDeployment={jest.fn}
-          applyDeviceConfig={applyMock}
-          getDeviceLog={jest.fn}
-          getSingleDeployment={jest.fn}
-          saveGlobalSettings={jest.fn}
-          setDeviceConfig={submitMock}
-        />
-      </Provider>
+      <Configuration
+        device={device}
+        abortDeployment={jest.fn}
+        applyDeviceConfig={applyMock}
+        getDeviceLog={jest.fn}
+        getSingleDeployment={jest.fn}
+        saveGlobalSettings={jest.fn}
+        setDeviceConfig={submitMock}
+      />
     );
     const { rerender } = render(ui);
     expect(screen.queryByRole('button', { name: /import configuration/i })).not.toBeInTheDocument();
@@ -138,18 +125,16 @@ describe('Configuration Component', () => {
       }
     };
     ui = (
-      <Provider store={store}>
-        <Configuration
-          deployment={{ ...defaultState.deployments.byId.d1, created: device.config.updated_ts, finished: device.config.updated_ts, status: 'finished' }}
-          device={device}
-          abortDeployment={jest.fn}
-          applyDeviceConfig={applyMock}
-          getDeviceLog={jest.fn}
-          getSingleDeployment={jest.fn}
-          saveGlobalSettings={jest.fn}
-          setDeviceConfig={submitMock}
-        />
-      </Provider>
+      <Configuration
+        deployment={{ ...defaultState.deployments.byId.d1, created: device.config.updated_ts, finished: device.config.updated_ts, status: 'finished' }}
+        device={device}
+        abortDeployment={jest.fn}
+        applyDeviceConfig={applyMock}
+        getDeviceLog={jest.fn}
+        getSingleDeployment={jest.fn}
+        saveGlobalSettings={jest.fn}
+        setDeviceConfig={submitMock}
+      />
     );
     act(() => jest.advanceTimersByTime(2000));
     await waitFor(() => rerender(ui));

--- a/src/js/components/devices/device-details/connection.test.js
+++ b/src/js/components/devices/device-details/connection.test.js
@@ -12,10 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
@@ -23,17 +19,10 @@ import { ALL_DEVICES, DEVICE_CONNECT_STATES } from '../../../constants/deviceCon
 import { uiPermissionsById } from '../../../constants/userConstants';
 import DeviceConnection, { DeviceConnectionMissingNote, DeviceDisconnectedNote, PortForwardLink } from './connection';
 
-const mockStore = configureStore([thunk]);
-
 describe('tiny DeviceConnection components', () => {
-  const store = mockStore({ ...defaultState });
   [DeviceConnectionMissingNote, DeviceDisconnectedNote, PortForwardLink].forEach(async Component => {
     it(`renders ${Component.displayName || Component.name} correctly`, () => {
-      const { baseElement } = render(
-        <Provider store={store}>
-          <Component lastConnectionTs={defaultState.devices.byId.a1.updated_ts} />
-        </Provider>
-      );
+      const { baseElement } = render(<Component lastConnectionTs={defaultState.devices.byId.a1.updated_ts} />);
       const view = baseElement.firstChild;
       expect(view).toMatchSnapshot();
       expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -42,34 +31,21 @@ describe('tiny DeviceConnection components', () => {
 });
 
 describe('DeviceConnection Component', () => {
-  let store;
   const userCapabilities = {
     canAuditlog: true,
     canTroubleshoot: true,
     canWriteDevices: true,
     groupsPermissions: { [ALL_DEVICES]: [uiPermissionsById.connect.value, uiPermissionsById.manage.value] }
   };
-  beforeAll(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceConnection device={defaultState.devices.byId.a1} userCapabilities={userCapabilities} />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceConnection device={defaultState.devices.byId.a1} userCapabilities={userCapabilities} />);
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
   });
   it('renders correctly when disconnected', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceConnection
-          device={{ ...defaultState.devices.byId.a1, connect_status: DEVICE_CONNECT_STATES.disconnected }}
-          userCapabilities={userCapabilities}
-        />
-      </Provider>
+      <DeviceConnection device={{ ...defaultState.devices.byId.a1, connect_status: DEVICE_CONNECT_STATES.disconnected }} userCapabilities={userCapabilities} />
     );
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
@@ -77,13 +53,11 @@ describe('DeviceConnection Component', () => {
   });
   it('renders correctly when connected', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceConnection
-          device={{ ...defaultState.devices.byId.a1, connect_status: DEVICE_CONNECT_STATES.connected }}
-          hasAuditlogs
-          userCapabilities={userCapabilities}
-        />
-      </Provider>
+      <DeviceConnection
+        device={{ ...defaultState.devices.byId.a1, connect_status: DEVICE_CONNECT_STATES.connected }}
+        hasAuditlogs
+        userCapabilities={userCapabilities}
+      />
     );
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/devices/device-details/devicetags.test.js
+++ b/src/js/components/devices/device-details/devicetags.test.js
@@ -12,33 +12,21 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { adminUserCapabilities, defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceTags from './devicetags';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceTags Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceTags
-          device={{ ...defaultState.devices.byId.a1 }}
-          setDeviceTags={jest.fn}
-          setSnackbar={jest.fn}
-          showHelptips
-          userCapabilities={adminUserCapabilities}
-        />
-      </Provider>
+      <DeviceTags
+        device={{ ...defaultState.devices.byId.a1 }}
+        setDeviceTags={jest.fn}
+        setSnackbar={jest.fn}
+        showHelptips
+        userCapabilities={adminUserCapabilities}
+      />
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/devices/device-details/identity.test.js
+++ b/src/js/components/devices/device-details/identity.test.js
@@ -12,36 +12,20 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceIdentity from './identity';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceIdentity Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceIdentity device={defaultState.devices.byId.a1} setSnackbar={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceIdentity device={defaultState.devices.byId.a1} setSnackbar={jest.fn} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
   });
   it('renders correctly without a mac', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceIdentity device={defaultState.devices.byId.c1} setSnackbar={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceIdentity device={defaultState.devices.byId.c1} setSnackbar={jest.fn} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/device-details/monitoring.test.js
+++ b/src/js/components/devices/device-details/monitoring.test.js
@@ -12,27 +12,17 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { prettyDOM } from '@testing-library/dom';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceMonitoring, { DeviceMonitorsMissingNote } from './monitoring';
 
-const mockStore = configureStore([thunk]);
-
 describe('tiny components', () => {
   [DeviceMonitorsMissingNote].forEach(async Component => {
     it(`renders ${Component.displayName || Component.name} correctly`, () => {
-      const store = mockStore({ ...defaultState });
-      const { baseElement } = render(
-        <Provider store={store}>
-          <Component docsVersion="" />
-        </Provider>
-      );
+      const { baseElement } = render(<Component docsVersion="" />);
       const view = baseElement.firstChild;
       expect(view).toMatchSnapshot();
       expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -42,7 +32,7 @@ describe('tiny components', () => {
 
 describe('DeviceMonitoring Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({
+    const preloadedState = {
       ...defaultState,
       monitor: {
         ...defaultState.monitor,
@@ -58,12 +48,8 @@ describe('DeviceMonitoring Component', () => {
           }
         }
       }
-    });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceMonitoring device={defaultState.devices.byId.a1} isOffline />
-      </Provider>
-    );
+    };
+    const { baseElement } = render(<DeviceMonitoring device={defaultState.devices.byId.a1} isOffline />, { preloadedState });
     // special snapshot handling here to work around unstable ids in mui code...
     const view = prettyDOM(baseElement.firstChild.firstChild, 100000, { highlight: false })
       .replace(/id="mui-[0-9]*"/g, '')

--- a/src/js/components/devices/device-groups.js
+++ b/src/js/components/devices/device-groups.js
@@ -49,6 +49,7 @@ import {
   getLimitMaxed,
   getSelectedGroupInfo,
   getShowHelptips,
+  getSortedFilteringAttributes,
   getTenantCapabilities,
   getUserCapabilities
 } from '../../selectors';
@@ -77,10 +78,7 @@ export const DeviceGroups = () => {
   const { status: statusParam } = useParams();
 
   const { groupCount, selectedGroup, groupFilters = [] } = useSelector(getSelectedGroupInfo);
-  const filteringAttributes = useSelector(state => ({
-    ...state.devices.filteringAttributes,
-    identityAttributes: [...state.devices.filteringAttributes.identityAttributes, 'id']
-  }));
+  const filteringAttributes = useSelector(getSortedFilteringAttributes);
   const { canManageDevices } = useSelector(getUserCapabilities);
   const tenantCapabilities = useSelector(getTenantCapabilities);
   const { groupNames, ...groupsByType } = useSelector(getGroupsSelector);

--- a/src/js/components/devices/device-groups.test.js
+++ b/src/js/components/devices/device-groups.test.js
@@ -12,43 +12,31 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { prettyDOM } from '@testing-library/dom';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import DeviceGroups from './device-groups';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  devices: {
+    ...defaultState.devices,
+    groups: {
+      ...defaultState.devices.groups,
+      selectedGroup: 'testGroup'
+    },
+    deviceList: {
+      ...defaultState.devices.deviceList,
+      deviceIds: defaultState.devices.byStatus.accepted.deviceIds
+    }
+  }
+};
 
 describe('DeviceGroups Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      devices: {
-        ...defaultState.devices,
-        groups: {
-          ...defaultState.devices.groups,
-          selectedGroup: 'testGroup'
-        },
-        deviceList: {
-          ...defaultState.devices.deviceList,
-          deviceIds: defaultState.devices.byStatus.accepted.deviceIds
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceGroups />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceGroups />, { preloadedState });
     // special snapshot handling here to work around unstable ids in mui code...
     const view = prettyDOM(baseElement.firstChild, 100000, { highlight: false })
       .replace(/id="mui-[0-9]*"/g, '')

--- a/src/js/components/devices/devicelist.test.js
+++ b/src/js/components/devices/devicelist.test.js
@@ -12,13 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { prettyDOM } from '@testing-library/dom';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -26,26 +23,18 @@ import { getHeaders } from './authorized-devices';
 import { routes } from './base-devices';
 import DeviceList, { calculateResizeChange } from './devicelist';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceList Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceList
-          columnHeaders={[{ name: 1 }, { name: 2 }, { name: 3 }, { name: 4 }]}
-          customColumnSizes={[]}
-          devices={[]}
-          deviceListState={defaultState.devices.deviceList}
-          selectedRows={[]}
-          onPageChange={jest.fn}
-          pageTotal={50}
-        />
-      </Provider>
+      <DeviceList
+        columnHeaders={[{ name: 1 }, { name: 2 }, { name: 3 }, { name: 4 }]}
+        customColumnSizes={[]}
+        devices={[]}
+        deviceListState={defaultState.devices.deviceList}
+        selectedRows={[]}
+        onPageChange={jest.fn}
+        pageTotal={50}
+      />
     );
     // special snapshot handling here to work around unstable ids in mui code...
     const view = prettyDOM(baseElement.firstChild, 100000, { highlight: false })
@@ -100,24 +89,22 @@ describe('DeviceList Component', () => {
     const pageTotal = devices.length;
     const headers = getHeaders([], routes.allDevices.defaultHeaders, 'id', jest.fn);
     const ui = (
-      <Provider store={store}>
-        <DeviceList
-          columnHeaders={headers}
-          customColumnSizes={[]}
-          devices={devices}
-          deviceListState={defaultState.devices.deviceList}
-          selectedRows={[]}
-          headerKeys="1-2-3-4"
-          idAttribute="id"
-          onExpandClick={onExpandClickMock}
-          onResizeColumns={onResizeColumns}
-          onPageChange={onPageChange}
-          onSelect={onSelect}
-          onSort={onSort}
-          pageTotal={pageTotal}
-          setSnackbar={jest.fn}
-        />
-      </Provider>
+      <DeviceList
+        columnHeaders={headers}
+        customColumnSizes={[]}
+        devices={devices}
+        deviceListState={defaultState.devices.deviceList}
+        selectedRows={[]}
+        headerKeys="1-2-3-4"
+        idAttribute="id"
+        onExpandClick={onExpandClickMock}
+        onResizeColumns={onResizeColumns}
+        onPageChange={onPageChange}
+        onSelect={onSelect}
+        onSort={onSort}
+        pageTotal={pageTotal}
+        setSnackbar={jest.fn}
+      />
     );
     render(ui);
     await user.click(screen.getByText(devices[0].id));

--- a/src/js/components/devices/devicelistitem.test.js
+++ b/src/js/components/devices/devicelistitem.test.js
@@ -12,24 +12,15 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import DeviceListItem from './devicelistitem';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceListItem Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
     const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceListItem columnHeaders={[{ render: item => item }]} device={{ id: 1 }} deviceListState={{}} idAttribute="id" selectable />
-      </Provider>
+      <DeviceListItem columnHeaders={[{ render: item => item }]} device={{ id: 1 }} deviceListState={{}} idAttribute="id" selectable />
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/devices/dialogs/connecttogatewaydialog.test.js
+++ b/src/js/components/devices/dialogs/connecttogatewaydialog.test.js
@@ -12,25 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, token, undefineds } from '../../../../../tests/mockData';
+import { token, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import ConnectToGatewayDialog from './connecttogatewaydialog';
 
-const mockStore = configureStore([thunk]);
-
 describe('ConnectToGatewayDialog Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <ConnectToGatewayDialog gatewayIp="1.2.3.4" isPreRelease={false} docsVersion="" onCancel={jest.fn} tenantToken={token} />
-      </Provider>
-    );
+    const { baseElement } = render(<ConnectToGatewayDialog gatewayIp="1.2.3.4" isPreRelease={false} docsVersion="" onCancel={jest.fn} tenantToken={token} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/dialogs/make-gateway-dialog.test.js
+++ b/src/js/components/devices/dialogs/make-gateway-dialog.test.js
@@ -12,25 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import MakeGatewayDialog from './make-gateway-dialog';
 
-const mockStore = configureStore([thunk]);
-
 describe('CreateGroupExplainerContent Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <MakeGatewayDialog onCancel={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<MakeGatewayDialog onCancel={jest.fn} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/dialogs/troubleshootdialog.test.js
+++ b/src/js/components/devices/dialogs/troubleshootdialog.test.js
@@ -12,24 +12,16 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import TroubleshootDialog from './troubleshootdialog';
 
-const mockStore = configureStore([thunk]);
-
 describe('TroubleshootDialog Component', () => {
-  let store;
   let socketSpyFactory;
   const oldMatchMedia = window.matchMedia;
 
   beforeEach(() => {
-    store = mockStore({ ...defaultState });
     socketSpyFactory = jest.spyOn(window, 'WebSocket');
     socketSpyFactory.mockImplementation(() => ({
       addEventListener: jest.fn(),
@@ -60,9 +52,7 @@ describe('TroubleshootDialog Component', () => {
   it('renders correctly', async () => {
     const userCapabilities = { canTroubleshoot: true, canWriteDevices: true };
     const { baseElement } = render(
-      <Provider store={store}>
-        <TroubleshootDialog device={defaultState.devices.byId.a1} onCancel={jest.fn} open={true} userCapabilities={userCapabilities} />
-      </Provider>
+      <TroubleshootDialog device={defaultState.devices.byId.a1} onCancel={jest.fn} open={true} userCapabilities={userCapabilities} />
     );
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();

--- a/src/js/components/devices/expanded-device.js
+++ b/src/js/components/devices/expanded-device.js
@@ -40,6 +40,7 @@ import { TIMEOUTS, yes } from '../../constants/appConstants';
 import { DEVICE_STATES, EXTERNAL_PROVIDER } from '../../constants/deviceConstants';
 import { getDemoDeviceAddress, stringToBoolean } from '../../helpers';
 import {
+  getDeviceConfigDeployment,
   getDeviceTwinIntegrations,
   getDevicesById,
   getDocsVersion,
@@ -209,13 +210,7 @@ export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, setDetailsT
   const { selectedGroup, groupFilters = [] } = useSelector(getSelectedGroupInfo);
   const { columnSelection = [] } = useSelector(getUserSettings);
   const { defaultDeviceConfig: defaultConfig } = useSelector(getGlobalSettings);
-  const { device, deviceConfigDeployment } = useSelector(state => {
-    const device = state.devices.byId[deviceId] || {};
-    const { config = {} } = device;
-    const { deployment_id: configDeploymentId } = config;
-    const deviceConfigDeployment = state.deployments.byId[configDeploymentId] || {};
-    return { device, deviceConfigDeployment };
-  });
+  const { device, deviceConfigDeployment } = useSelector(state => getDeviceConfigDeployment(state, deviceId));
   const devicesById = useSelector(getDevicesById);
   const docsVersion = useSelector(getDocsVersion);
   const features = useSelector(getFeatures);

--- a/src/js/components/devices/expanded-device.test.js
+++ b/src/js/components/devices/expanded-device.test.js
@@ -12,70 +12,56 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import { EXTERNAL_PROVIDER } from '../../constants/deviceConstants';
 import ExpandedDevice from './expanded-device';
 
-const mockStore = configureStore([thunk]);
-
-describe('ExpandedDevice Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          hasDeviceConfig: true,
-          hasDeviceConnect: true,
-          hasMonitor: true,
-          hasMultitenancy: true
-        }
-      },
-      devices: {
-        ...defaultState.devices,
-        byId: {
-          ...defaultState.devices.byId,
-          [defaultState.devices.byId.a1.id]: {
-            ...defaultState.devices.byId.a1,
-            attributes: {
-              ...defaultState.devices.byId.a1.attributes,
-              mender_is_gateway: true
-            }
-          }
-        },
-        groups: {
-          ...defaultState.devices.groups,
-          selectedGroup: 'testGroup'
-        }
-      },
-      organization: {
-        ...defaultState.organization,
-        externalDeviceIntegrations: [{ ...EXTERNAL_PROVIDER['iot-hub'], id: 'test' }]
-      },
-      users: {
-        ...defaultState.users,
-        onboarding: {
-          ...defaultState.onboarding,
-          complete: false
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.app.features,
+      hasDeviceConfig: true,
+      hasDeviceConnect: true,
+      hasMonitor: true,
+      hasMultitenancy: true
+    }
+  },
+  devices: {
+    ...defaultState.devices,
+    byId: {
+      ...defaultState.devices.byId,
+      [defaultState.devices.byId.a1.id]: {
+        ...defaultState.devices.byId.a1,
+        attributes: {
+          ...defaultState.devices.byId.a1.attributes,
+          mender_is_gateway: true
         }
       }
-    });
-  });
-
+    },
+    groups: {
+      ...defaultState.devices.groups,
+      selectedGroup: 'testGroup'
+    }
+  },
+  organization: {
+    ...defaultState.organization,
+    externalDeviceIntegrations: [{ ...EXTERNAL_PROVIDER['iot-hub'], id: 'test' }]
+  },
+  users: {
+    ...defaultState.users,
+    onboarding: {
+      ...defaultState.onboarding,
+      complete: false
+    }
+  }
+};
+describe('ExpandedDevice Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <ExpandedDevice deviceId={defaultState.devices.byId.a1.id} setDetailsTab={jest.fn} />
-      </Provider>
-    );
+    const { baseElement } = render(<ExpandedDevice deviceId={defaultState.devices.byId.a1.id} setDetailsTab={jest.fn} />, { preloadedState });
     const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/group-management/create-group.test.js
+++ b/src/js/components/devices/group-management/create-group.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import CreateGroup from './create-group';
 
-const mockStore = configureStore([thunk]);
-
 describe('CreateGroup Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <CreateGroup selectedDevices={[]} />
-      </Provider>
-    );
+    const { baseElement } = render(<CreateGroup selectedDevices={[]} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/group-management/group-definition.test.js
+++ b/src/js/components/devices/group-management/group-definition.test.js
@@ -12,27 +12,16 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import GroupDefinition, { validateGroupName } from './group-definition';
-
-const mockStore = configureStore([thunk]);
 
 const selectedDevices = [{ id: 'test' }];
 
 describe('GroupDefinition Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <GroupDefinition groups={[]} isCreationDynamic={true} />
-      </Provider>
-    );
+    const { baseElement } = render(<GroupDefinition groups={[]} isCreationDynamic={true} />);
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/devices/widgets/deviceadditionwidget.test.js
+++ b/src/js/components/devices/widgets/deviceadditionwidget.test.js
@@ -12,32 +12,17 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import DeviceAdditionWidget from './deviceadditionwidget';
 
-const mockStore = configureStore([thunk]);
-
-let store;
-
 describe('DeviceAdditionWidget Component', () => {
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <DeviceAdditionWidget docsVersion="" features={{}} onConnectClick={jest.fn} tenantCapabilities={{}} />
-      </Provider>
-    );
+    const { baseElement } = render(<DeviceAdditionWidget docsVersion="" features={{}} onConnectClick={jest.fn} tenantCapabilities={{}} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -46,11 +31,7 @@ describe('DeviceAdditionWidget Component', () => {
   it('works as intended', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const clickMock = jest.fn();
-    render(
-      <Provider store={store}>
-        <DeviceAdditionWidget docsVersion="" features={{}} onConnectClick={clickMock} tenantCapabilities={{}} />
-      </Provider>
-    );
+    render(<DeviceAdditionWidget docsVersion="" features={{}} onConnectClick={clickMock} tenantCapabilities={{}} />);
     await user.click(screen.getByRole('button', { name: /connect a new device/i }));
     expect(clickMock).toHaveBeenCalled();
   });

--- a/src/js/components/devices/widgets/filters.test.js
+++ b/src/js/components/devices/widgets/filters.test.js
@@ -12,28 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import Filters from './filters';
 
-const mockStore = configureStore([thunk]);
-
 describe('Filters Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Filters attributes={[{ key: 'testkey', value: 'testvalue' }]} filters={[]} onFilterChange={() => {}} open={true} />
-      </Provider>
-    );
+    const { baseElement } = render(<Filters attributes={[{ key: 'testkey', value: 'testvalue' }]} filters={[]} onFilterChange={() => {}} open={true} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/header/offerheader.test.js
+++ b/src/js/components/header/offerheader.test.js
@@ -12,25 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import OfferHeader from './offerheader';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeviceNotifications Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <OfferHeader />
-      </Provider>
-    );
+    const { baseElement } = render(<OfferHeader />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/help/__snapshots__/help.test.js.snap
+++ b/src/js/components/help/__snapshots__/help.test.js.snap
@@ -328,7 +328,7 @@ exports[`Help Component renders correctly 1`] = `
 exports[`Help Component static components renders Downloads correctly 1`] = `
 .emotion-0 {
   background-color: #fff;
-  color: rgba(0, 0, 0, 0.87);
+  color: rgba(10, 10, 11, 0.78);
   -webkit-transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);
@@ -336,6 +336,9 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   -webkit-transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   overflow-anchor: none;
+  border: none;
+  box-shadow: none;
+  padding: 0;
 }
 
 .emotion-0:before {
@@ -379,6 +382,15 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   margin: 16px 0;
 }
 
+.emotion-0:before {
+  display: none;
+}
+
+.emotion-0.Mui-expanded {
+  margin: auto;
+  background-color: #f7f7f7;
+}
+
 .emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -420,6 +432,8 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   padding: 0px 16px;
   -webkit-transition: min-height 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: min-height 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  margin-bottom: 0;
+  height: 48px;
 }
 
 .emotion-1::-moz-focus-inner {
@@ -454,6 +468,11 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   min-height: 64px;
 }
 
+.emotion-1.Mui-expanded {
+  height: 48px;
+  min-height: 48px;
+}
+
 .emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -466,28 +485,38 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   margin: 12px 0;
   -webkit-transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .emotion-2.Mui-expanded {
   margin: 20px 0;
 }
 
+.emotion-2.Mui-expanded {
+  margin: 0;
+}
+
+.emotion-2>:last-child {
+  padding-right: 12px;
+}
+
 .emotion-3 {
   margin: 0;
-  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-family: Lato,sans-serif;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   line-height: 1.57;
-  letter-spacing: 0.00714em;
 }
 
 .emotion-4 {
   margin: 0;
-  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-family: Lato,sans-serif;
   font-weight: 400;
-  font-size: 0.75rem;
+  font-size: 0.6964rem;
   line-height: 1.66;
-  letter-spacing: 0.03333em;
 }
 
 .emotion-5 {
@@ -525,7 +554,11 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   flex-shrink: 0;
   -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-size: 1.5rem;
+  font-size: 1.3929rem;
+}
+
+.emotion-6 iconButton {
+  margin-right: 8px;
 }
 
 .emotion-7 {
@@ -550,6 +583,9 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
 
 .emotion-10 {
   padding: 8px 16px 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-11 {
@@ -586,8 +622,8 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   text-decoration: none;
   color: inherit;
   max-width: 100%;
-  font-family: "Roboto","Helvetica","Arial",sans-serif;
-  font-size: 0.8125rem;
+  font-family: Lato,sans-serif;
+  font-size: 0.7545rem;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -601,7 +637,7 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   height: 32px;
-  color: rgba(0, 0, 0, 0.87);
+  color: rgba(10, 10, 11, 0.78);
   background-color: rgba(0, 0, 0, 0.08);
   border-radius: 16px;
   white-space: nowrap;
@@ -622,7 +658,7 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   -webkit-tap-highlight-color: transparent;
   cursor: pointer;
   background-color: transparent;
-  border: 1px solid #bdbdbd;
+  border: 1px solid #f7f7f7;
 }
 
 .emotion-11::-moz-focus-inner {
@@ -651,18 +687,18 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   margin-right: -6px;
   width: 24px;
   height: 24px;
-  color: #616161;
-  font-size: 0.75rem;
+  color: #bcbcbc;
+  font-size: 0.6964rem;
 }
 
 .emotion-11 .MuiChip-avatarColorPrimary {
   color: #fff;
-  background-color: #1565c0;
+  background-color: rgb(35, 85, 94);
 }
 
 .emotion-11 .MuiChip-avatarColorSecondary {
   color: #fff;
-  background-color: #7b1fa2;
+  background-color: rgb(65, 10, 46);
 }
 
 .emotion-11 .MuiChip-avatarSmall {
@@ -670,25 +706,25 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   margin-right: -4px;
   width: 18px;
   height: 18px;
-  font-size: 0.625rem;
+  font-size: 0.5804rem;
 }
 
 .emotion-11 .MuiChip-icon {
   margin-left: 5px;
   margin-right: -6px;
-  color: #616161;
+  color: #bcbcbc;
 }
 
 .emotion-11 .MuiChip-deleteIcon {
   -webkit-tap-highlight-color: transparent;
-  color: rgba(0, 0, 0, 0.26);
+  color: rgba(10, 10, 11, 0.26);
   font-size: 22px;
   cursor: pointer;
   margin: 0 5px 0 -6px;
 }
 
 .emotion-11 .MuiChip-deleteIcon:hover {
-  color: rgba(0, 0, 0, 0.4);
+  color: rgba(10, 10, 11, 0.4);
 }
 
 .emotion-11.Mui-focusVisible {
@@ -761,7 +797,11 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   flex-shrink: 0;
   -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-size: 1.25rem;
+  font-size: 1.1607rem;
+}
+
+.emotion-75 iconButton {
+  margin-right: 8px;
 }
 
 .emotion-91 {
@@ -798,8 +838,8 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   text-decoration: none;
   color: inherit;
   max-width: 100%;
-  font-family: "Roboto","Helvetica","Arial",sans-serif;
-  font-size: 0.8125rem;
+  font-family: Lato,sans-serif;
+  font-size: 0.7545rem;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -813,7 +853,7 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   height: 32px;
-  color: rgba(0, 0, 0, 0.87);
+  color: rgba(10, 10, 11, 0.78);
   background-color: rgba(0, 0, 0, 0.08);
   border-radius: 16px;
   white-space: nowrap;
@@ -861,18 +901,18 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   margin-right: -6px;
   width: 24px;
   height: 24px;
-  color: #616161;
-  font-size: 0.75rem;
+  color: #bcbcbc;
+  font-size: 0.6964rem;
 }
 
 .emotion-91 .MuiChip-avatarColorPrimary {
   color: #fff;
-  background-color: #1565c0;
+  background-color: rgb(35, 85, 94);
 }
 
 .emotion-91 .MuiChip-avatarColorSecondary {
   color: #fff;
-  background-color: #7b1fa2;
+  background-color: rgb(65, 10, 46);
 }
 
 .emotion-91 .MuiChip-avatarSmall {
@@ -880,25 +920,25 @@ exports[`Help Component static components renders Downloads correctly 1`] = `
   margin-right: -4px;
   width: 18px;
   height: 18px;
-  font-size: 0.625rem;
+  font-size: 0.5804rem;
 }
 
 .emotion-91 .MuiChip-icon {
   margin-left: 5px;
   margin-right: -6px;
-  color: #616161;
+  color: #bcbcbc;
 }
 
 .emotion-91 .MuiChip-deleteIcon {
   -webkit-tap-highlight-color: transparent;
-  color: rgba(0, 0, 0, 0.26);
+  color: rgba(10, 10, 11, 0.26);
   font-size: 22px;
   cursor: pointer;
   margin: 0 5px 0 -6px;
 }
 
 .emotion-91 .MuiChip-deleteIcon:hover {
-  color: rgba(0, 0, 0, 0.4);
+  color: rgba(10, 10, 11, 0.4);
 }
 
 .emotion-91.Mui-focusVisible {
@@ -3919,7 +3959,11 @@ exports[`Help Component static components renders GettingStarted correctly 1`] =
   flex-shrink: 0;
   -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-size: 1.25rem;
+  font-size: 1.1607rem;
+}
+
+.emotion-0 iconButton {
+  margin-right: 8px;
 }
 
 <div>
@@ -4051,7 +4095,11 @@ exports[`Help Component static components renders MenderHub correctly 1`] = `
   flex-shrink: 0;
   -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-size: 1.25rem;
+  font-size: 1.1607rem;
+}
+
+.emotion-0 iconButton {
+  margin-right: 8px;
 }
 
 <div>
@@ -4144,7 +4192,11 @@ exports[`Help Component static components renders Support correctly 1`] = `
   flex-shrink: 0;
   -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-size: 1.25rem;
+  font-size: 1.1607rem;
+}
+
+.emotion-0 iconButton {
+  margin-right: 8px;
 }
 
 <div>

--- a/src/js/components/help/help.test.js
+++ b/src/js/components/help/help.test.js
@@ -15,11 +15,11 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
-import { render } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
+import { render as testingLibRender } from '@testing-library/react';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
+import { render } from '../../../../tests/setupTests';
+import { getConfiguredStore } from '../../reducers';
 import { Downloads } from './downloads';
 import GettingStarted from './getting-started';
 import Help from './help';
@@ -27,23 +27,19 @@ import MenderHub from './mender-hub';
 import { helpProps } from './mockData';
 import Support from './support';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: { ...defaultState.app.features, hasAddons: true, isEnterprise: true },
+    versionInformation: { latestRelease: helpProps.versions }
+  }
+};
 
 describe('Help Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: { ...defaultState.app.features, hasAddons: true, isEnterprise: true },
-        versionInformation: { latestRelease: helpProps.versions }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
+    const store = getConfiguredStore({ preloadedState });
+    const { baseElement } = testingLibRender(
       <Provider store={store}>
         <MemoryRouter initialEntries={['/help/get-started']}>
           <Routes>
@@ -62,11 +58,7 @@ describe('Help Component', () => {
   describe('static components', () => {
     [Downloads, GettingStarted, MenderHub, Support].forEach(Component => {
       it(`renders ${Component.displayName || Component.name} correctly`, () => {
-        const { baseElement } = render(
-          <Provider store={store}>
-            <Component {...helpProps} />
-          </Provider>
-        );
+        const { baseElement } = render(<Component {...helpProps} />, { preloadedState });
         const view = baseElement.firstChild.firstChild;
         expect(view).toMatchSnapshot();
         expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/helptips/__snapshots__/onboardingcompletetip.test.js.snap
+++ b/src/js/components/helptips/__snapshots__/onboardingcompletetip.test.js.snap
@@ -15,11 +15,7 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
   flex-shrink: 0;
   -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-size: 1.3929rem;
-}
-
-.emotion-0 iconButton {
-  margin-right: 8px;
+  font-size: 1.5rem;
 }
 
 .emotion-1 {
@@ -29,20 +25,19 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
 }
 
 .emotion-2 {
-  background-color: rgba(188, 188, 188, 0.92);
+  background-color: rgba(97, 97, 97, 0.92);
   border-radius: 4px;
   color: #fff;
-  font-family: Lato,sans-serif;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
   padding: 4px 8px;
-  font-size: 0.6384rem;
+  font-size: 0.6875rem;
   max-width: 300px;
   margin: 2px;
   word-wrap: break-word;
   font-weight: 500;
-  background-color: rgb(50, 50, 50);
-  background-color: #337a87;
+  background-color: #1976d2;
   box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);
-  color: #e9e9e9;
+  color: #9e9e9e;
   font-size: 14px;
   max-width: 350px;
   padding: 12px 18px;
@@ -70,7 +65,7 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
 }
 
 .emotion-2 a {
-  color: #e9e9e9;
+  color: #9e9e9e;
 }
 
 .emotion-2.MuiTooltip-tooltipPlacementTop {
@@ -125,21 +120,18 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
   text-decoration: none;
   color: inherit;
   background-color: #fff;
-  font-family: Lato,sans-serif;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 500;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   line-height: 1.75;
+  letter-spacing: 0.02857em;
   text-transform: uppercase;
   min-width: 64px;
   padding: 6px 8px;
   border-radius: 4px;
   -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  color: #337a87;
-  border-radius: 2px;
-  font-size: 14px;
-  font-weight: bold;
-  padding: 10px 15px;
+  color: #1976d2;
   background-color: #fff;
   background-color: #fff;
 }
@@ -167,7 +159,7 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
 .emotion-3:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: rgba(51, 122, 135, 0.04);
+  background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
@@ -178,14 +170,6 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
 
 .emotion-3.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
-}
-
-.emotion-3:hover {
-  colors: #337a87;
-}
-
-.emotion-3.MuiButton-text {
-  color: rgba(10, 10, 11, 0.78);
 }
 
 .emotion-3:hover {
@@ -241,10 +225,11 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: inherit;
-  font-family: Lato,sans-serif;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 500;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   line-height: 1.75;
+  letter-spacing: 0.02857em;
   text-transform: uppercase;
   min-width: 64px;
   padding: 6px 16px;
@@ -252,11 +237,8 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
   -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   color: #fff;
-  background-color: #5d0f43;
+  background-color: #9c27b0;
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
-  border-radius: 2px;
-  font-size: 14px;
-  font-weight: bold;
 }
 
 .emotion-5::-moz-focus-inner {
@@ -278,13 +260,13 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
 .emotion-5:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: rgb(65, 10, 46);
+  background-color: #7b1fa2;
   box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
 }
 
 @media (hover: none) {
   .emotion-5:hover {
-    background-color: #5d0f43;
+    background-color: #9c27b0;
   }
 }
 
@@ -300,14 +282,6 @@ exports[`OnboardingCompleteTip Component renders correctly 1`] = `
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
-}
-
-.emotion-5:hover {
-  colors: #337a87;
-}
-
-.emotion-5.MuiButton-text {
-  color: rgba(10, 10, 11, 0.78);
 }
 
 <body>

--- a/src/js/components/helptips/baseonboardingtip.test.js
+++ b/src/js/components/helptips/baseonboardingtip.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import BaseOnboardingTip, { orientations } from './baseonboardingtip';
 
-const mockStore = configureStore([thunk]);
-
 describe('BaseOnboardingTip Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <BaseOnboardingTip anchor={{ left: 1, top: 1, right: 1, bottom: 1 }} component={<div>Testcontent</div>} id="test" />
-      </Provider>
-    );
+    const { baseElement } = render(<BaseOnboardingTip anchor={{ left: 1, top: 1, right: 1, bottom: 1 }} component={<div>Testcontent</div>} id="test" />);
     const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/helptips/deploymentcompletetip.test.js
+++ b/src/js/components/helptips/deploymentcompletetip.test.js
@@ -12,30 +12,16 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import DeploymentCompleteTip from './deploymentcompletetip';
 
-const mockStore = configureStore([thunk]);
-
 describe('DeploymentCompleteTip Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const ui = (
-      <Provider store={store}>
-        <DeploymentCompleteTip targetUrl="https://test.com" />
-      </Provider>
-    );
+    const ui = <DeploymentCompleteTip targetUrl="https://test.com" />;
     const { baseElement, rerender } = render(ui);
     await act(async () => {});
     await waitFor(() => rerender(ui));

--- a/src/js/components/helptips/helptooltips.js
+++ b/src/js/components/helptips/helptooltips.js
@@ -19,18 +19,13 @@ import { Help as HelpIcon, InfoOutlined as InfoIcon } from '@mui/icons-material'
 
 import { setSnackbar } from '../../actions/appActions';
 import { toggleHelptips } from '../../actions/userActions';
+import { getDeviceById } from '../../selectors';
 import ConfigurationObject from '../common/configurationobject';
 import DocsLink from '../common/docslink';
 import MenderTooltip, { MenderTooltipClickable } from '../common/mendertooltip';
 
 const actionCreators = { setSnackbar, toggleHelptips };
-const mapStateToProps = (state, ownProps) => {
-  let device = {};
-  if (ownProps.deviceId) {
-    device = state.devices.byId[ownProps.deviceId];
-  }
-  return { device };
-};
+const mapStateToProps = (state, ownProps) => ({ device: getDeviceById(state, ownProps.deviceId) });
 
 const HideHelptipsButton = ({ toggleHelptips }) => (
   <p>

--- a/src/js/components/helptips/helptooltips.test.js
+++ b/src/js/components/helptips/helptooltips.test.js
@@ -12,10 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -30,45 +26,36 @@ import {
   ExpandDevice
 } from './helptooltips';
 
-const mockStore = configureStore([thunk]);
-
-describe('Helptooltips Components', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          hasMultitenancy: true,
-          isHosted: true
-        }
-      },
-      devices: {
-        ...defaultState.devices,
-        byId: {
-          ...defaultState.devices.byId,
-          a1: {
-            ...defaultState.devices.byId.a1,
-            attributes: {
-              ...defaultState.devices.byId.a1.attributes,
-              device_type: ['raspberrypi12']
-            }
-          }
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.app.features,
+      hasMultitenancy: true,
+      isHosted: true
+    }
+  },
+  devices: {
+    ...defaultState.devices,
+    byId: {
+      ...defaultState.devices.byId,
+      a1: {
+        ...defaultState.devices.byId.a1,
+        attributes: {
+          ...defaultState.devices.byId.a1.attributes,
+          device_type: ['raspberrypi12']
         }
       }
-    });
-  });
+    }
+  }
+};
 
+describe('Helptooltips Components', () => {
   [AddGroup, AuthButton, ConfigureAddOnTip, ConfigureRaspberryLedTip, ConfigureTimezoneTip, DeviceSupportTip, ExpandArtifact, ExpandDevice].forEach(
     async Component => {
       it(`renders ${Component.displayName || Component.name} correctly`, () => {
-        const { baseElement } = render(
-          <Provider store={store}>
-            <Component deviceId={defaultState.devices.byId.a1.id} />
-          </Provider>
-        );
+        const { baseElement } = render(<Component deviceId={defaultState.devices.byId.a1.id} />, { preloadedState });
         const view = baseElement.firstChild.childNodes.length > 1 ? baseElement.firstChild.childNodes : baseElement.firstChild.firstChild;
         expect(view).toMatchSnapshot();
       });

--- a/src/js/components/helptips/onboardingcompletetip.test.js
+++ b/src/js/components/helptips/onboardingcompletetip.test.js
@@ -13,41 +13,42 @@
 //    limitations under the License.
 import React from 'react';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 
-import { act, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
+import { act, render as testingLibRender, waitFor } from '@testing-library/react';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
-import { render } from '../../../../tests/setupTests';
+import { getConfiguredStore } from '../../reducers';
 import OnboardingCompleteTip from './onboardingcompletetip';
-
-const mockStore = configureStore([thunk]);
 
 describe('OnboardingCompleteTip Component', () => {
   let store;
   beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          hasMultitenancy: true,
-          isHosted: true
+    jest.spyOn(global, 'encodeURIComponent').mockImplementationOnce(() => 'http%3A%2F%2Ftest.com');
+    store = getConfiguredStore({
+      preloadedState: {
+        ...defaultState,
+        app: {
+          ...defaultState.app,
+          features: {
+            ...defaultState.app.features,
+            hasMultitenancy: true,
+            isHosted: true
+          }
         }
       }
     });
-    jest.spyOn(global, 'encodeURIComponent').mockImplementationOnce(() => 'http%3A%2F%2Ftest.com');
   });
 
   it('renders correctly', async () => {
     const ui = (
-      <Provider store={store}>
-        <OnboardingCompleteTip targetUrl="https://test.com" />
-      </Provider>
+      <MemoryRouter initialEntries={[`/password`]}>
+        <Provider store={store}>
+          <OnboardingCompleteTip targetUrl="https://test.com" />
+        </Provider>
+      </MemoryRouter>
     );
-    const { baseElement, rerender } = render(ui);
+    const { baseElement, rerender } = testingLibRender(ui);
     await act(async () => {});
     await waitFor(() => rerender(ui));
     const view = baseElement;

--- a/src/js/components/helptips/onboardingtips.test.js
+++ b/src/js/components/helptips/onboardingtips.test.js
@@ -12,10 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { render } from '../../../../tests/setupTests';
 import {
@@ -46,21 +42,10 @@ import {
   WelcomeSnackTip
 } from './onboardingtips';
 
-const mockStore = configureStore([thunk]);
-
 describe('OnboardingTips Components', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({});
-  });
-
   describe('DevicePendingTip', () => {
     it('renders correctly', async () => {
-      const { baseElement } = render(
-        <Provider store={store}>
-          <DevicePendingTip />
-        </Provider>
-      );
+      const { baseElement } = render(<DevicePendingTip />);
       const view = baseElement.firstChild.firstChild;
       expect(view).toMatchSnapshot();
     });
@@ -68,11 +53,7 @@ describe('OnboardingTips Components', () => {
 
   describe('WelcomeSnackTip', () => {
     it('renders correctly', async () => {
-      const { baseElement } = render(
-        <Provider store={store}>
-          <WelcomeSnackTip />
-        </Provider>
-      );
+      const { baseElement } = render(<WelcomeSnackTip />);
       const view = baseElement.firstChild.firstChild;
       expect(view).toMatchSnapshot();
     });

--- a/src/js/components/leftnav.test.js
+++ b/src/js/components/leftnav.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../tests/mockData';
+import { undefineds } from '../../../tests/mockData';
 import { render } from '../../../tests/setupTests';
 import LeftNav from './leftnav';
 
-const mockStore = configureStore([thunk]);
-
 describe('LeftNav Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <LeftNav />
-      </Provider>
-    );
+    const { baseElement } = render(<LeftNav />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/login/__snapshots__/login.test.js.snap
+++ b/src/js/components/login/__snapshots__/login.test.js.snap
@@ -621,6 +621,26 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
 }
 
 .emotion-32 {
+  height: 0;
+  overflow: hidden;
+  -webkit-transition: height 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: height 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  visibility: hidden;
+}
+
+.emotion-33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-34 {
+  width: 100%;
+}
+
+.emotion-40 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -637,15 +657,15 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
   margin-top: 18px;
 }
 
-.emotion-32.Mui-disabled {
+.emotion-40.Mui-disabled {
   cursor: default;
 }
 
-.emotion-32 .MuiFormControlLabel-label.Mui-disabled {
+.emotion-40 .MuiFormControlLabel-label.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-33 {
+.emotion-41 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -684,42 +704,42 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
   color: rgba(10, 10, 11, 0.78);
 }
 
-.emotion-33::-moz-focus-inner {
+.emotion-41::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-33.Mui-disabled {
+.emotion-41.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-33 {
+  .emotion-41 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-33:hover {
+.emotion-41:hover {
   background-color: rgba(51, 122, 135, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-33:hover {
+  .emotion-41:hover {
     background-color: transparent;
   }
 }
 
-.emotion-33.Mui-checked,
-.emotion-33.MuiCheckbox-indeterminate {
+.emotion-41.Mui-checked,
+.emotion-41.MuiCheckbox-indeterminate {
   color: #337a87;
 }
 
-.emotion-33.Mui-disabled {
+.emotion-41.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-34 {
+.emotion-42 {
   cursor: inherit;
   position: absolute;
   opacity: 0;
@@ -732,7 +752,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
   z-index: 1;
 }
 
-.emotion-37 {
+.emotion-45 {
   margin: 0;
   line-height: 1.5;
   font-family: Lato,sans-serif;
@@ -740,15 +760,15 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
   font-size: 0.9286rem;
 }
 
-.emotion-39 {
+.emotion-47 {
   color: #fff;
 }
 
-.emotion-39 a {
+.emotion-47 a {
   color: #7adce6;
 }
 
-.emotion-41 {
+.emotion-49 {
   bottom: calc(56px + 3vh);
   right: 0;
   z-index: 0;
@@ -1009,15 +1029,55 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
               Forgot your password?
             </a>
           </div>
-          <div />
+          <div
+            class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-32"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper MuiCollapse-vertical emotion-33"
+            >
+              <div
+                class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-34"
+              >
+                <div
+                  class="MuiFormControl-root   emotion-17"
+                  style="width: 400px;"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard emotion-18"
+                    data-shrink="false"
+                    for="token2fa"
+                  >
+                    Two Factor Authentication Code
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input emotion-20"
+                      id="token2fa"
+                      name="token2fa"
+                      placeholder="Two Factor Authentication Code"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-21"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
           <label
-            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-40"
           >
             <span
-              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-33"
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-41"
             >
               <input
-                class="PrivateSwitchBase-input emotion-34"
+                class="PrivateSwitchBase-input emotion-42"
                 data-indeterminate="false"
                 type="checkbox"
               />
@@ -1037,7 +1097,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
               />
             </span>
             <span
-              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-37"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-45"
             >
               Stay logged in
             </span>
@@ -1059,7 +1119,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
         </form>
       </div>
       <div
-        class="margin-top margin-bottom flexbox centered emotion-39"
+        class="margin-top margin-bottom flexbox centered emotion-47"
       >
         <div
           class="muted margin-right"
@@ -1088,7 +1148,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-20:focus::-ms-input-
     </div>
   </div>
   <svg
-    class="absolute emotion-41"
+    class="absolute emotion-49"
     id="Verymuch"
   />
 </div>

--- a/src/js/components/login/login.js
+++ b/src/js/components/login/login.js
@@ -16,7 +16,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { ChevronRight, Help as HelpIcon } from '@mui/icons-material';
-import { Button, Checkbox, FormControlLabel } from '@mui/material';
+import { Button, Checkbox, Collapse, FormControlLabel } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 import Cookies from 'universal-cookie';
@@ -215,18 +215,16 @@ export const Login = () => {
               ) : (
                 <div />
               )}
-              {has2FA ? (
+              <Collapse in={has2FA}>
                 <TextInput
                   hint="Two Factor Authentication Code"
                   label="Two Factor Authentication Code"
                   id="token2fa"
                   validations="isLength:6,isNumeric"
-                  required={true}
+                  required={has2FA}
                   controlRef={twoFARef}
                 />
-              ) : (
-                <div />
-              )}
+              </Collapse>
               <FormControlLabel control={<Checkbox color="primary" checked={noExpiry} onChange={onNoExpiryClick} />} label="Stay logged in" />
             </Form>
             {isHosted && twoFARef.current && (

--- a/src/js/components/login/password.test.js
+++ b/src/js/components/login/password.test.js
@@ -12,32 +12,18 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import * as UserActions from '../../actions/userActions';
 import Password from './password';
 
-const mockStore = configureStore([thunk]);
-
 describe('Password Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Password />
-      </Provider>
-    );
+    const { baseElement } = render(<Password />);
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -46,11 +32,7 @@ describe('Password Component', () => {
   it('works as intended', async () => {
     const startSpy = jest.spyOn(UserActions, 'passwordResetStart');
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const ui = (
-      <Provider store={store}>
-        <Password />
-      </Provider>
-    );
+    const ui = <Password />;
     const { rerender } = render(ui);
     await user.type(screen.queryByLabelText(/your email/i), 'something@example.com');
     await user.click(screen.getByRole('button', { name: /Send password reset link/i }));

--- a/src/js/components/login/passwordreset.test.js
+++ b/src/js/components/login/passwordreset.test.js
@@ -17,16 +17,13 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { act, screen, render as testingLibRender, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import * as UserActions from '../../actions/userActions';
+import { getConfiguredStore } from '../../reducers';
 import Password from './password';
 import PasswordReset from './passwordreset';
-
-const mockStore = configureStore([thunk]);
 
 const goodPassword = 'mysecretpassword!123';
 const badPassword = 'mysecretpassword!546';
@@ -34,15 +31,11 @@ const badPassword = 'mysecretpassword!546';
 describe('PasswordReset Component', () => {
   let store;
   beforeEach(() => {
-    store = mockStore({ ...defaultState });
+    store = getConfiguredStore();
   });
 
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <PasswordReset match={{ params: { secretHash: '' } }} />
-      </Provider>
-    );
+    const { baseElement } = render(<PasswordReset match={{ params: { secretHash: '' } }} />);
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/login/signup-steps/orgdata-entry.test.js
+++ b/src/js/components/login/signup-steps/orgdata-entry.test.js
@@ -12,25 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { formRenderWrapper } from '../../common/forms/form.test';
 import OrgDataEntry from './orgdata-entry';
 
-const mockStore = configureStore([thunk]);
-
 describe('Login Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = formRenderWrapper(
-      <Provider store={store}>
-        <OrgDataEntry classes={{ orgData: 'test' }} recaptchaSiteKey="test" />
-      </Provider>
-    );
+    const { baseElement } = formRenderWrapper(<OrgDataEntry classes={{ orgData: 'test' }} recaptchaSiteKey="test" />);
     const view = baseElement.getElementsByTagName('div')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/login/signup.test.js
+++ b/src/js/components/login/signup.test.js
@@ -12,33 +12,19 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 import { Route, Routes } from 'react-router-dom';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import Cookies from 'universal-cookie';
 
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Signup from './signup';
 
-const mockStore = configureStore([thunk]);
-
 describe('Signup Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Signup match={{ params: { campaign: '' } }} />
-      </Provider>
-    );
+    const { baseElement } = render(<Signup match={{ params: { campaign: '' } }} />);
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -47,12 +33,12 @@ describe('Signup Component', () => {
   it('allows signing up', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const ui = (
-      <Provider store={store}>
+      <>
         <Signup location={{ state: { from: '' } }} match={{ params: {} }} />
         <Routes>
           <Route path="/" element={<div>signed up</div>} />
         </Routes>
-      </Provider>
+      </>
     );
     const { container, rerender } = render(ui);
     expect(screen.getByText('Sign up with:')).toBeInTheDocument();

--- a/src/js/components/releases/__snapshots__/releases.test.js.snap
+++ b/src/js/components/releases/__snapshots__/releases.test.js.snap
@@ -1401,7 +1401,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-41:focus::-ms-input-
             </div>
           </div>
           <div
-            class="loaderContainer shrunk"
+            class="loaderContainer"
           >
             <div
               class="small  loader"

--- a/src/js/components/releases/artifact.test.js
+++ b/src/js/components/releases/artifact.test.js
@@ -12,26 +12,15 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../tests/mockData';
+import { undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Artifact from './artifact';
 import { columns } from './releasedetails';
 
-const mockStore = configureStore([thunk]);
-
 describe('Artifact Component', () => {
   it('renders correctly', async () => {
-    let store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Artifact artifact={{ device_types_compatible: ['test-type'], updates: [], modified: '2019-01-01' }} columns={columns} />
-      </Provider>
-    );
+    const { baseElement } = render(<Artifact artifact={{ device_types_compatible: ['test-type'], updates: [], modified: '2019-01-01' }} columns={columns} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/releases/artifactdetails.test.js
+++ b/src/js/components/releases/artifactdetails.test.js
@@ -12,29 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import ArtifactDetails, { transformArtifactCapabilities, transformArtifactMetadata } from './artifactdetails';
 
-const mockStore = configureStore([thunk]);
-
 describe('ArtifactDetails Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <ArtifactDetails artifact={{ description: 'text', name: 'test' }} />
-      </Provider>
-    );
+    const { baseElement } = render(<ArtifactDetails artifact={{ description: 'text', name: 'test' }} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/releases/dialogs/addartifact.test.js
+++ b/src/js/components/releases/dialogs/addartifact.test.js
@@ -12,31 +12,17 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import AddArtifact from './addartifact';
 
-const mockStore = configureStore([thunk]);
-
 describe('AddArtifact Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <AddArtifact onboardingState={{ complete: true }} />
-      </Provider>
-    );
+    const { baseElement } = render(<AddArtifact onboardingState={{ complete: true }} />);
     const view = baseElement.getElementsByClassName('MuiDialog-root')[0];
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -47,17 +33,15 @@ describe('AddArtifact Component', () => {
     const uploadMock = jest.fn(() => Promise.resolve());
     const menderFile = new File(['testContent'], 'test.mender');
     const ui = (
-      <Provider store={store}>
-        <AddArtifact
-          createArtifact={jest.fn}
-          onboardingState={{ complete: false }}
-          onUploadStarted={jest.fn}
-          uploadArtifact={uploadMock}
-          deviceTypes={['qemux86-64']}
-          advanceOnboarding={jest.fn}
-          releases={Object.values(defaultState.releases.byId)}
-        />
-      </Provider>
+      <AddArtifact
+        createArtifact={jest.fn}
+        onboardingState={{ complete: false }}
+        onUploadStarted={jest.fn}
+        uploadArtifact={uploadMock}
+        deviceTypes={['qemux86-64']}
+        advanceOnboarding={jest.fn}
+        releases={Object.values(defaultState.releases.byId)}
+      />
     );
     const { rerender } = render(ui);
     expect(screen.getByText(/Upload a premade/i)).toBeInTheDocument();
@@ -79,16 +63,14 @@ describe('AddArtifact Component', () => {
     const uploadMock = jest.fn(() => Promise.resolve());
     const menderFile = new File(['testContent plain'], 'testFile.txt');
     const ui = (
-      <Provider store={store}>
-        <AddArtifact
-          onUploadStarted={jest.fn}
-          onboardingState={{ complete: true }}
-          createArtifact={uploadMock}
-          deviceTypes={['qemux86-64']}
-          advanceOnboarding={jest.fn}
-          releases={Object.values(defaultState.releases.byId)}
-        />
-      </Provider>
+      <AddArtifact
+        onUploadStarted={jest.fn}
+        onboardingState={{ complete: true }}
+        createArtifact={uploadMock}
+        deviceTypes={['qemux86-64']}
+        advanceOnboarding={jest.fn}
+        releases={Object.values(defaultState.releases.byId)}
+      />
     );
     const { rerender } = render(ui);
     expect(screen.getByText(/Upload a premade/i)).toBeInTheDocument();

--- a/src/js/components/releases/releasedetails.test.js
+++ b/src/js/components/releases/releasedetails.test.js
@@ -12,37 +12,24 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import ReleaseDetails from './releasedetails';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  releases: {
+    ...defaultState.releases,
+    byId: {}
+  }
+};
 
 describe('ReleaseDetails Component', () => {
-  let store;
-
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      releases: {
-        ...defaultState.releases,
-        byId: {}
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <ReleaseDetails artifacts={[]} />
-      </Provider>
-    );
+    const { baseElement } = render(<ReleaseDetails artifacts={[]} />, { preloadedState });
     await act(async () => jest.advanceTimersByTime(1000));
     const view = baseElement.lastChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/releases/releases.test.js
+++ b/src/js/components/releases/releases.test.js
@@ -12,32 +12,17 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
-import { getConfiguredStore } from '../../reducers';
 import Releases from './releases';
 
-const mockStore = configureStore([thunk]);
-
 describe('Releases Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Releases />
-      </Provider>
-    );
+    const { baseElement } = render(<Releases />);
     await act(async () => jest.advanceTimersByTime(1000));
     const view = baseElement.firstChild;
     expect(view).toMatchSnapshot();
@@ -54,13 +39,8 @@ describe('Releases Component', () => {
         selectedRelease: defaultState.releases.byId.r1.Name
       }
     };
-    const store = getConfiguredStore({ preloadedState });
-    const ui = (
-      <Provider store={store}>
-        <Releases />
-      </Provider>
-    );
-    const { rerender } = render(ui);
+    const ui = <Releases />;
+    const { rerender } = render(ui, { preloadedState });
     await waitFor(() => expect(screen.queryAllByText(defaultState.releases.byId.r1.Name)[0]).toBeInTheDocument());
     await user.click(screen.getAllByText(defaultState.releases.byId.r1.Name)[0]);
     expect(screen.queryByDisplayValue(defaultState.releases.byId.r1.Artifacts[0].description)).toBeInTheDocument();
@@ -74,14 +54,7 @@ describe('Releases Component', () => {
   });
   it('has working search handling as expected', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const preloadedState = { ...defaultState };
-    const store = getConfiguredStore({ preloadedState });
-    const ui = (
-      <Provider store={store}>
-        <Releases />
-      </Provider>
-    );
-    render(ui);
+    render(<Releases />);
     expect(screen.queryByText(/Filtered from/i)).not.toBeInTheDocument();
     await user.type(screen.getByPlaceholderText(/Search/i), 'b1');
     await waitFor(() => expect(screen.queryByText(/Filtered from/i)).toBeInTheDocument(), { timeout: 2000 });

--- a/src/js/components/search-result.test.js
+++ b/src/js/components/search-result.test.js
@@ -12,21 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../tests/mockData';
 import { render } from '../../../tests/setupTests';
 import SearchResult from './search-result';
 
-const mockStore = configureStore([thunk]);
-
 describe('SearchResult Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
+  it('renders correctly', async () => {
+    const state = {
       ...defaultState,
       app: {
         ...defaultState.app,
@@ -44,15 +37,10 @@ describe('SearchResult Component', () => {
           sort: {}
         }
       }
+    };
+    const { baseElement } = render(<SearchResult onToggleSearchResult={jest.fn} open setSearchState={jest.fn} setSnackbar={jest.fn} />, {
+      preloadedState: state
     });
-  });
-
-  it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <SearchResult onToggleSearchResult={jest.fn} open setSearchState={jest.fn} setSnackbar={jest.fn} />
-      </Provider>
-    );
     const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/settings/accesstokenmanagement.test.js
+++ b/src/js/components/settings/accesstokenmanagement.test.js
@@ -12,51 +12,39 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { accessTokens, defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import * as UserActions from '../../actions/userActions';
 import AccessTokenManagement, { AccessTokenCreationDialog, AccessTokenRevocationDialog } from './accesstokenmanagement';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.app.features,
+      isEnterprise: true
+    }
+  },
+  users: {
+    ...defaultState.users,
+    byId: {
+      ...defaultState.users.byId,
+      [defaultState.users.currentUser]: {
+        ...defaultState.users.byId[defaultState.users.currentUser],
+        tokens: accessTokens
+      }
+    }
+  }
+};
 
 describe('UserManagement Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          isEnterprise: true
-        }
-      },
-      users: {
-        ...defaultState.users,
-        byId: {
-          ...defaultState.users.byId,
-          [defaultState.users.currentUser]: {
-            ...defaultState.users.byId[defaultState.users.currentUser],
-            tokens: accessTokens
-          }
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <AccessTokenManagement />
-      </Provider>
-    );
+    const { baseElement } = render(<AccessTokenManagement />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -65,12 +53,8 @@ describe('UserManagement Component', () => {
   it('works as expected', async () => {
     const getSpy = jest.spyOn(UserActions, 'getTokens');
     const createSpy = jest.spyOn(UserActions, 'generateToken');
-    const ui = (
-      <Provider store={store}>
-        <AccessTokenManagement />
-      </Provider>
-    );
-    const { rerender } = render(ui);
+    const ui = <AccessTokenManagement />;
+    const { rerender } = render(ui, { preloadedState });
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     await user.click(screen.getByRole('button', { name: /generate a token/i }));

--- a/src/js/components/settings/global.test.js
+++ b/src/js/components/settings/global.test.js
@@ -12,53 +12,41 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Global from './global';
 
-const mockStore = configureStore([thunk]);
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.app.features,
+      hasReporting: true,
+      hasMultitenancy: true,
+      isEnterprise: true,
+      isHosted: true
+    }
+  },
+  deployments: {
+    ...defaultState.deployments,
+    config: {
+      ...defaultState.deployments.config,
+      binaryDelta: {
+        ...defaultState.deployments.config.binaryDelta,
+        timeout: 5
+      },
+      hasDelta: true
+    }
+  }
+};
 
 describe('GlobalSettings Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          hasReporting: true,
-          hasMultitenancy: true,
-          isEnterprise: true,
-          isHosted: true
-        }
-      },
-      deployments: {
-        ...defaultState.deployments,
-        config: {
-          ...defaultState.deployments.config,
-          binaryDelta: {
-            ...defaultState.deployments.config.binaryDelta,
-            timeout: 5
-          },
-          hasDelta: true
-        }
-      }
-    });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Global />
-      </Provider>
-    );
+    const { baseElement } = render(<Global />, { preloadedState });
     await waitFor(() => expect(screen.getByText(/xDelta3/i)).toBeVisible());
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/settings/integrations.test.js
+++ b/src/js/components/settings/integrations.test.js
@@ -12,10 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
@@ -34,8 +30,8 @@ const integrations = [
     credentials: { type: EXTERNAL_PROVIDER['iot-core'].credentialsType, aws: 'something else' }
   }
 ];
-const mockStore = configureStore([thunk]);
-const store = mockStore({ ...defaultState, organization: { ...defaultState.organization, externalDeviceIntegrations: integrations } });
+
+const preloadedState = { ...defaultState, organization: { ...defaultState.organization, externalDeviceIntegrations: integrations } };
 
 describe('IntegrationConfiguration Component', () => {
   it('renders correctly', async () => {
@@ -50,11 +46,7 @@ describe('IntegrationConfiguration Component', () => {
 
 describe('Integrations Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Integrations />
-      </Provider>
-    );
+    const { baseElement } = render(<Integrations />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/settings/organization/organization.js
+++ b/src/js/components/settings/organization/organization.js
@@ -120,7 +120,7 @@ export const Organization = () => {
   useEffect(() => {
     setHasSingleSignOn(!!samlConfigs.length);
     setIsConfiguringSSO(!!samlConfigs.length);
-  }, [samlConfigs]);
+  }, [samlConfigs.length]);
 
   const onSSOClick = () => {
     if (hasSingleSignOn) {

--- a/src/js/components/settings/organization/organizationpaymentsettings.test.js
+++ b/src/js/components/settings/organization/organizationpaymentsettings.test.js
@@ -12,38 +12,27 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import OrganizationPaymentSettings from './organizationpaymentsettings';
 
-const mockStore = configureStore([thunk]);
-
+const preloadedState = {
+  organization: {
+    ...defaultState.organization,
+    card: {
+      last4: '1234',
+      expiration: { month: 8, year: 1230 },
+      brand: 'Visa'
+    }
+  }
+};
 describe('OrganizationPaymentSettings Component', () => {
-  let store;
   beforeEach(() => {
     Date.now = jest.fn(() => new Date('2020-07-01T12:00:00.000Z'));
-    store = mockStore({
-      organization: {
-        ...defaultState.organization,
-        card: {
-          last4: '1234',
-          expiration: { month: 8, year: 1230 },
-          brand: 'Visa'
-        }
-      }
-    });
   });
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <OrganizationPaymentSettings />
-      </Provider>
-    );
+    const { baseElement } = render(<OrganizationPaymentSettings />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/settings/roles.js
+++ b/src/js/components/settings/roles.js
@@ -20,9 +20,8 @@ import { Chip } from '@mui/material';
 
 import { getDynamicGroups, getGroups } from '../../actions/deviceActions';
 import { createRole, editRole, getRoles, removeRole } from '../../actions/userActions';
-import { UNGROUPED_GROUP } from '../../constants/deviceConstants';
 import { emptyRole, rolesById } from '../../constants/userConstants';
-import { getFeatures } from '../../selectors';
+import { getFeatures, getGroupsByIdWithoutUngrouped, getReleaseTagsById, getRolesList } from '../../selectors';
 import DetailsTable from '../common/detailstable';
 import RoleDefinition from './roledefinition';
 
@@ -46,13 +45,9 @@ export const RoleManagement = () => {
   const [role, setRole] = useState({ ...emptyRole });
   const dispatch = useDispatch();
   const features = useSelector(getFeatures);
-  const groups = useSelector(state => {
-    // eslint-disable-next-line no-unused-vars
-    const { [UNGROUPED_GROUP.id]: ungrouped, ...groups } = state.devices.groups.byId;
-    return groups;
-  });
-  const releaseTags = useSelector(state => state.releases.releaseTags.reduce((accu, key) => ({ ...accu, [key]: key }), {}));
-  const roles = useSelector(state => Object.entries(state.users.rolesById).map(([id, role]) => ({ id, ...role })));
+  const groups = useSelector(getGroupsByIdWithoutUngrouped);
+  const releaseTags = useSelector(getReleaseTagsById);
+  const roles = useSelector(getRolesList);
 
   useEffect(() => {
     if (Object.keys(groups).length) {

--- a/src/js/components/settings/roles.test.js
+++ b/src/js/components/settings/roles.test.js
@@ -12,12 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render, selectMaterialUiSelectOption } from '../../../../tests/setupTests';
@@ -26,20 +23,9 @@ import { ALL_DEVICES } from '../../constants/deviceConstants';
 import { ALL_RELEASES } from '../../constants/releaseConstants';
 import Roles from './roles';
 
-const mockStore = configureStore([thunk]);
-
 describe('Roles Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Roles />
-      </Provider>
-    );
+    const { baseElement } = render(<Roles />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -50,12 +36,7 @@ describe('Roles Component', () => {
     const editRoleSpy = jest.spyOn(UserActions, 'editRole');
     const removeRoleSpy = jest.spyOn(UserActions, 'removeRole');
 
-    const ui = (
-      <Provider store={store}>
-        <Roles />
-      </Provider>
-    );
-    render(ui);
+    render(<Roles />);
 
     const role = screen.getByText(/test description/i).parentElement;
     await user.click(within(role).getByText(/view details/i));

--- a/src/js/components/settings/settings.test.js
+++ b/src/js/components/settings/settings.test.js
@@ -16,30 +16,29 @@ import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { render as testingLibRender } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
+import { getConfiguredStore } from '../../reducers';
 import Settings from './settings';
-
-const mockStore = configureStore([thunk]);
 
 describe('Settings Component', () => {
   let store;
   beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          isHosted: false,
-          hasMultitenancy: true
+    store = getConfiguredStore({
+      preloadedState: {
+        ...defaultState,
+        app: {
+          ...defaultState.app,
+          features: {
+            ...defaultState.app.features,
+            isHosted: false,
+            hasMultitenancy: true
+          }
+        },
+        organization: {
+          ...defaultState.organization,
+          organization: {}
         }
-      },
-      organization: {
-        ...defaultState.organization,
-        organization: {}
       }
     });
   });

--- a/src/js/components/settings/upgrade.test.js
+++ b/src/js/components/settings/upgrade.test.js
@@ -12,18 +12,13 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../tests/mockData';
 import { render } from '../../../../tests/setupTests';
 import Upgrade, { PostUpgradeNote, PricingContactNote } from './upgrade';
-
-const mockStore = configureStore([thunk]);
 
 describe('smaller components', () => {
   [PostUpgradeNote, PricingContactNote].forEach(Component => {
@@ -44,32 +39,29 @@ describe('smaller components', () => {
   });
 });
 
+const preloadedState = {
+  ...defaultState,
+  app: {
+    ...defaultState.app,
+    features: {
+      ...defaultState.app.features,
+      hasDeviceConfig: true,
+      hasDeviceConnect: true
+    }
+  }
+};
+
 describe('Upgrade Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.app.features,
-          hasDeviceConfig: true,
-          hasDeviceConnect: true
-        }
-      }
-    });
-  });
   it('renders correctly', async () => {
     jest.mock('@stripe/stripe-js', () => ({
       loadStripe: () => ({ createPaymentMethod: jest.fn() })
     }));
     const stripe = loadStripe('123');
     const { baseElement } = render(
-      <Provider store={store}>
-        <Elements stripe={stripe}>
-          <Upgrade />
-        </Elements>
-      </Provider>
+      <Elements stripe={stripe}>
+        <Upgrade />
+      </Elements>,
+      { preloadedState }
     );
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();

--- a/src/js/components/settings/user-management/selfusermanagement.test.js
+++ b/src/js/components/settings/user-management/selfusermanagement.test.js
@@ -12,28 +12,18 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import { yes } from '../../../constants/appConstants';
 import SelfUserManagement from './selfusermanagement';
 
-const mockStore = configureStore([thunk]);
-
 describe('SelfUserManagement Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
-
   it('renders correctly', async () => {
-    store = mockStore({
+    const preloadedState = {
       ...defaultState,
       users: {
         ...defaultState.users,
@@ -45,12 +35,8 @@ describe('SelfUserManagement Component', () => {
           }
         }
       }
-    });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <SelfUserManagement />
-      </Provider>
-    );
+    };
+    const { baseElement } = render(<SelfUserManagement />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
@@ -58,16 +44,12 @@ describe('SelfUserManagement Component', () => {
 
   it('works as intended', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    store = mockStore({ ...defaultState, app: { ...defaultState.app, features: { ...defaultState.app.features, isEnterprise: true } } });
+    const preloadedState = { ...defaultState, app: { ...defaultState.app, features: { ...defaultState.app.features, isEnterprise: true } } };
 
     const copyCheck = jest.fn(yes);
     document.execCommand = copyCheck;
-    const ui = (
-      <Provider store={store}>
-        <SelfUserManagement />
-      </Provider>
-    );
-    const { rerender } = render(ui);
+    const ui = <SelfUserManagement />;
+    const { rerender } = render(ui, { preloadedState });
 
     await user.click(screen.getByRole('button', { name: /email/i }));
     const input = screen.getByDisplayValue(defaultState.users.byId.a1.email);

--- a/src/js/components/settings/user-management/twofactorauthsetup.test.js
+++ b/src/js/components/settings/user-management/twofactorauthsetup.test.js
@@ -12,28 +12,14 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
-import { defaultState, undefineds } from '../../../../../tests/mockData';
+import { undefineds } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
 import TwoFactorAuthSetup from './twofactorauthsetup';
 
-const mockStore = configureStore([thunk]);
-
 describe('TwoFactorAuthSetup Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({ ...defaultState });
-  });
   it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <TwoFactorAuthSetup />
-      </Provider>
-    );
+    const { baseElement } = render(<TwoFactorAuthSetup />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/settings/webhooks/webhooks.test.js
+++ b/src/js/components/settings/webhooks/webhooks.test.js
@@ -12,10 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds, webhookEvents } from '../../../../../tests/mockData';
 import { render } from '../../../../../tests/setupTests';
@@ -25,23 +21,16 @@ import { WebhookCreation } from './configuration';
 import Management from './management';
 import Webhooks from './webhooks';
 
-const mockStore = configureStore([thunk]);
-
 describe('Webhooks Component', () => {
   it('renders correctly', async () => {
-    const store = mockStore({ ...defaultState });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Webhooks />
-      </Provider>
-    );
+    const { baseElement } = render(<Webhooks />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
   });
 
   it('renders correctly with entries ', async () => {
-    const store = mockStore({
+    const preloadedState = {
       ...defaultState,
       organization: {
         ...defaultState.organization,
@@ -57,12 +46,8 @@ describe('Webhooks Component', () => {
           events: webhookEvents
         }
       }
-    });
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Webhooks />
-      </Provider>
-    );
+    };
+    const { baseElement } = render(<Webhooks />, { preloadedState });
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/src/js/components/uploads.test.js
+++ b/src/js/components/uploads.test.js
@@ -12,23 +12,17 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { defaultState, undefineds } from '../../../tests/mockData';
 import { render } from '../../../tests/setupTests';
 import Uploads from './uploads';
 
-const mockStore = configureStore([thunk]);
-
 describe('Uploads Component', () => {
-  let store;
-  beforeEach(() => {
-    store = mockStore({
+  it('renders correctly', async () => {
+    const preloadedState = {
       ...defaultState,
       app: {
         ...defaultState.app,
@@ -41,15 +35,8 @@ describe('Uploads Component', () => {
           }
         }
       }
-    });
-  });
-
-  it('renders correctly', async () => {
-    const { baseElement } = render(
-      <Provider store={store}>
-        <Uploads />
-      </Provider>
-    );
+    };
+    const { baseElement } = render(<Uploads />, { preloadedState });
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     user.hover(screen.getByRole('progressbar'));
     await waitFor(() => screen.queryByText(/in progress/i));

--- a/src/js/config/routes.test.js
+++ b/src/js/config/routes.test.js
@@ -15,32 +15,31 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, screen } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
+import { screen, render as testingLibRender } from '@testing-library/react';
 
 import { defaultState } from '../../../tests/mockData';
+import { getConfiguredStore } from '../reducers';
 import { PublicRoutes } from './routes';
-
-const mockStore = configureStore([thunk]);
 
 describe('Router', () => {
   let store;
   beforeEach(() => {
-    store = mockStore({
-      ...defaultState,
-      app: {
-        ...defaultState.app,
-        features: {
-          ...defaultState.features,
-          isHosted: true
+    store = getConfiguredStore({
+      preloadedState: {
+        ...defaultState,
+        app: {
+          ...defaultState.app,
+          features: {
+            ...defaultState.features,
+            isHosted: true
+          }
         }
       }
     });
   });
 
   test('invalid path should redirect to Dashboard', async () => {
-    render(
+    testingLibRender(
       <MemoryRouter initialEntries={['/random']}>
         <Provider store={store}>
           <PublicRoutes />
@@ -52,7 +51,7 @@ describe('Router', () => {
   });
 
   test('valid path should not redirect to 404', async () => {
-    render(
+    testingLibRender(
       <MemoryRouter initialEntries={['/']}>
         <Provider store={store}>
           <PublicRoutes />

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -320,13 +320,6 @@ export const generateDeploymentGroupDetails = (filter, groupName) =>
         .join(', ')})`
     : groupName;
 
-export const tryMapDeployments = (accu, id) => {
-  if (accu.state.deployments.byId[id]) {
-    accu.deployments.push(accu.state.deployments.byId[id]);
-  }
-  return accu;
-};
-
 export const mapDeviceAttributes = (attributes = []) =>
   attributes.reduce(
     (accu, attribute) => {

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -42,7 +42,6 @@ import {
   preformatWithRequestID,
   standardizePhases,
   stringToBoolean,
-  tryMapDeployments,
   unionizeStrings,
   validatePhases,
   versionCompare
@@ -548,15 +547,6 @@ describe('validatePhases function', () => {
         true
       )
     ).toEqual(true);
-  });
-});
-
-describe('tryMapDeployments function', () => {
-  it('works as expected', async () => {
-    expect(Object.keys(defaultState.deployments.byId).reduce(tryMapDeployments, { state: { ...defaultState }, deployments: [] }).deployments).toEqual(
-      Object.values(defaultState.deployments.byId)
-    );
-    expect(['unknownDeploymentId'].reduce(tryMapDeployments, { state: { ...defaultState }, deployments: [] }).deployments).toEqual([]);
   });
 });
 

--- a/src/js/main.test.js
+++ b/src/js/main.test.js
@@ -16,7 +16,7 @@ import Linkify from 'react-linkify';
 import * as router from 'react-router-dom';
 
 import { prettyDOM } from '@testing-library/dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, render as testLibRender, waitFor } from '@testing-library/react';
 import 'jsdom-worker';
 
 import { mockDate, undefineds } from '../../tests/mockData';
@@ -37,7 +37,7 @@ describe('Main Component', () => {
     const ui = <AppProviders />;
     const post = jest.spyOn(GeneralApi, 'post');
     jest.setSystemTime(mockDate);
-    const { baseElement, rerender } = render(ui);
+    const { baseElement, rerender } = testLibRender(ui);
     await waitFor(() => screen.queryByText('Software distribution'), { timeout: 2000 });
     await waitFor(() => rerender(ui));
     const view = prettyDOM(baseElement.firstChild, 100000, { highlight: false })

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -13,6 +13,7 @@
 //    limitations under the License.
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
+import { defaultState } from '../../../tests/mockData';
 import { SET_SNACKBAR, UPLOAD_PROGRESS } from '../constants/appConstants';
 import { RECEIVE_EXTERNAL_DEVICE_INTEGRATIONS } from '../constants/organizationConstants';
 import { USER_LOGOUT } from '../constants/userConstants';
@@ -36,16 +37,18 @@ const rootReducer = combineReducers({
   users: userReducer
 });
 
-const sessionReducer = (state, action) => {
+export const sessionReducer = (state, action) => {
   if (action.type === USER_LOGOUT) {
     state = undefined;
   }
   return rootReducer(state, action);
 };
 
-export const getConfiguredStore = config =>
-  configureStore({
+export const getConfiguredStore = (options = {}) => {
+  const { preloadedState = { ...defaultState }, ...config } = options;
+  return configureStore({
     ...config,
+    preloadedState,
     reducer: sessionReducer,
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware({
@@ -59,5 +62,6 @@ export const getConfiguredStore = config =>
         }
       })
   });
+};
 
-export default getConfiguredStore();
+export default getConfiguredStore({ preloadedState: {} });

--- a/tests/__mocks__/organizationHandlers.js
+++ b/tests/__mocks__/organizationHandlers.js
@@ -202,7 +202,7 @@ export const organizationHandlers = [
     if (!configId) {
       return res(ctx.status(550));
     }
-    return res(ctx.json({ email: 'user@acme.com', password: 'mypass1234', login: { google: 'bob@gmail.com' } }));
+    return res(ctx.json({ email: 'user@acme.com', password: 'mypass1234', login: { google: 'bob@gmail.com' }, config: '<div>not quite right</div>' }));
   }),
   rest.put(`${samlIdpApiUrlv1}/:configId`, ({ params: { configId } }, res, ctx) => {
     if (!configId) {

--- a/tests/__mocks__/userHandlers.js
+++ b/tests/__mocks__/userHandlers.js
@@ -25,6 +25,8 @@ export const userHandlers = [
       return res(ctx.status(401));
     } else if (user.includes('limited')) {
       return res(ctx.status(200), ctx.json('limitedToken'));
+    } else if (user.includes('2fa')) {
+      return res(ctx.status(401), ctx.json({ error: '2fa needed' }));
     }
     return res(ctx.status(200), ctx.json(token));
   }),

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -13,6 +13,7 @@
 //    limitations under the License.
 import React from 'react';
 import { createMocks } from 'react-idle-timer';
+import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
 import { ThemeProvider, createTheme } from '@mui/material/styles';
@@ -24,9 +25,10 @@ import { TextEncoder } from 'util';
 import { MessageChannel } from 'worker_threads';
 
 import { yes } from '../src/js/constants/appConstants';
+import { getConfiguredStore } from '../src/js/reducers';
 import { light as lightTheme } from '../src/js/themes/Mender';
 import handlers from './__mocks__/requestHandlers';
-import { menderEnvironment, mockDate, token as mockToken } from './mockData';
+import { defaultState, menderEnvironment, mockDate, token as mockToken } from './mockData';
 
 export const RETRY_TIMES = 3;
 export const TEST_LOCATION = 'localhost';
@@ -144,15 +146,17 @@ export const selectMaterialUiSelectOption = async (element, optionText, user) =>
 
 const theme = createTheme(lightTheme);
 
-const AllTheProviders = ({ children }) => {
-  return (
+const customRender = (ui, options = {}) => {
+  const { preloadedState = { ...defaultState }, store = getConfiguredStore({ preloadedState }), ...remainder } = options;
+  const AllTheProviders = ({ children }) => (
     <ThemeProvider theme={theme}>
-      <MemoryRouter>{children}</MemoryRouter>
+      <MemoryRouter>
+        <Provider store={store}>{children}</Provider>
+      </MemoryRouter>
     </ThemeProvider>
   );
+  return { store, ...render(ui, { wrapper: AllTheProviders, ...remainder }) };
 };
-
-const customRender = (ui, options) => render(ui, { wrapper: AllTheProviders, ...options });
 
 // re-export everything
 // eslint-disable-next-line import/export


### PR DESCRIPTION
~depends on #3804 + #3806~

This primarily changes the component tests to run wrapped with a redux store by default, leading to automatic interactions with the msw backend. This also makes it much easier to have smaller components that access the redux store across the codebase, without the extra work of preparing tests to use the store.

 + moved to broader selector usage as well in order to minimize additional state changes that are otherwise raised during test runs