### PR TITLE
fix: healthcheck url adjustment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY ./entrypoint.sh /usr/src/entrypoint.sh
 COPY httpd.conf /etc/nginx/nginx.conf
 RUN sed -i 's|/var/run/nginx.pid|/tmp/nginx.pid|g' /etc/nginx/nginx.conf && sed -i 's|listen 80;|listen 8090;|g' /etc/nginx/nginx.conf
 ENTRYPOINT ["/usr/src/entrypoint.sh"]
-HEALTHCHECK --interval=8s --timeout=15s --start-period=120s --retries=128 CMD wget --quiet --tries=1 --spider --output-document=/dev/null 127.0.0.1
+HEALTHCHECK --interval=8s --timeout=15s --start-period=120s --retries=128 CMD wget --quiet --tries=1 --spider --output-document=/dev/null 127.0.0.1:8090/ui/
 CMD ["nginx"]
 
 
@@ -34,5 +34,5 @@ COPY ./entrypoint.sh /usr/src/entrypoint.sh
 COPY httpd.conf /etc/nginx/nginx.conf
 COPY --from=build /usr/src/app/dist .
 ENTRYPOINT ["/usr/src/entrypoint.sh"]
-HEALTHCHECK --interval=8s --timeout=15s --start-period=120s --retries=128 CMD wget --quiet --tries=1 --spider --output-document=/dev/null 127.0.0.1
+HEALTHCHECK --interval=8s --timeout=15s --start-period=120s --retries=128 CMD wget --quiet --tries=1 --spider --output-document=/dev/null 127.0.0.1/ui/
 CMD ["nginx"]


### PR DESCRIPTION
Health check errors:

```
/var/www/mender-gui/dist # wget --quiet --tries=1 --spider --output-document=/dev/null 127.0.0.1
wget: can't connect to remote host (127.0.0.1): Connection refused
```

and in the logs:

```
127.0.0.1 - - [26/Jul/2023:16:10:19 +0000] "GET / HTTP/1.1" 301 162 "-" "Wget"
```

docker ps sees:

```
dd6ccfa31d43   mendersoftware/gui:mender-3.6.0-build9                                                 "/usr/src/entrypoint…"   4 minutes ago   Up 4 minutes (health: starting)   80/tcp, 8080/tcp
```

Changelog: Title
Ticket: None