### PR TITLE
MEN-6748 - fix: fixed onboarding showing up even if cancelled

### DIFF
--- a/src/js/actions/onboardingActions.test.js
+++ b/src/js/actions/onboardingActions.test.js
@@ -39,7 +39,7 @@ export const defaultOnboardingState = {
   deviceType: null,
   progress: undefined,
   showConnectDeviceDialog: false,
-  showTips: null,
+  showTips: undefined,
   showTipsDialog: false,
   something: 'here'
 };

--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -29,6 +29,7 @@ import {
 } from '../constants/deviceConstants';
 import { READ_STATES, rolesByName, twoFAStates, uiPermissionsById } from '../constants/userConstants';
 import { attributeDuplicateFilter, duplicateFilter, getDemoDeviceAddress as getDemoDeviceAddressHelper, versionCompare } from '../helpers';
+import { onboardingSteps } from '../utils/onboardingmanager';
 
 const getAppDocsVersion = state => state.app.docsVersion;
 export const getFeatures = state => state.app.features;
@@ -238,9 +239,12 @@ export const getOfflineThresholdSettings = createSelector([getGlobalSettings], (
 export const getOnboardingState = createSelector([getOnboarding, getUserSettings], ({ complete, progress, showTips, ...remainder }, { onboarding = {} }) => ({
   ...remainder,
   ...onboarding,
-  complete,
-  progress,
-  showTips
+  complete: onboarding.complete || complete,
+  progress:
+    Object.keys(onboardingSteps).findIndex(step => step === progress) > Object.keys(onboardingSteps).findIndex(step => step === onboarding.progress)
+      ? progress
+      : onboarding.progress,
+  showTips: !onboarding.showTips ? onboarding.showTips : showTips
 }));
 
 export const getTooltipsState = createSelector([getTooltipsById, getUserSettings], (byId, { tooltips = {} }) =>


### PR DESCRIPTION
- from now on progress and disabled tooltips are explicitly favored over whatever is present in the UI at any moment

Ticket: MEN-6748
Changelog: Title