### PR TITLE
fix: fixed an issue that prevented logging out right after signup

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -46,6 +46,8 @@ export const setSessionInfo = ({ token, expiresAt }) => {
 
 export const cleanUp = () => {
   tokenCache = '';
+  cookies.remove('JWT');
+  cookies.remove('JWT', { path: '/' });
   window.localStorage.removeItem('JWT');
   window.localStorage.removeItem('oauth');
 };


### PR DESCRIPTION
- the logout call would invalidate the JWT, but the cookie would still be around and only the localstorage related caches would be cleaned up
- with this any JWT cookie should be cleaned up as well

Ticket: None
Changelog: None