### PR TITLE
fix: Fixed the infinite page redirects when the back button is pressed

### DIFF
--- a/src/js/utils/liststatehook.js
+++ b/src/js/utils/liststatehook.js
@@ -81,7 +81,7 @@ export const useLocationParams = (key, extras) => {
       navigate({ pathname, replace: true, search: `?${searchQuery}`, ...options });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(extras), key, location.search, location.pathname, navigate]
+    [JSON.stringify(extras), key]
   );
 
   return [value, setValue];


### PR DESCRIPTION
Remove the location and navigate from the useLocationParams.setValue callback dependencies as they change the set function that is presented in other useEffect dependencies. This happens when the back button is clicked, which leads to the location changing infinitely.

ChangeLog: Title