### PR TITLE
chore(tests): use `3.6.x` (LTS) client to run e2e tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -335,7 +335,7 @@ build:docker-multiplatform:
     - curl -fsSL https://get.docker.com | sh
     - mv mender-stress-test-client tests/e2e_tests/ && cd tests/e2e_tests
     - mv /e2e/mender-demo-artifact.mender .
-    - docker pull mendersoftware/mender-client-docker-addons:master
+    - docker pull mendersoftware/mender-client-docker-addons:mender-3.6.x
     - npm ci --cache .npm --prefer-offline
   script:
     - npm run test-ci

--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -36,7 +36,7 @@ services:
       - ${GUI_REPOSITORY}/videos:/e2e/videos
 
   mender-client:
-    image: mendersoftware/mender-client-docker-addons:master
+    image: mendersoftware/mender-client-docker-addons:mender-3.6.x
     volumes:
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender.json:/etc/mender/mender.conf
       - ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf

--- a/tests/e2e_tests/run
+++ b/tests/e2e_tests/run
@@ -96,7 +96,7 @@ run_tests() {
         docker run --name connect-client -d --network=gui-tests_mender \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-test.json:/etc/mender/mender.conf \
             -v ${GUI_REPOSITORY}/tests/e2e_tests/dockerClient/mender-connect.json:/etc/mender/mender-connect.conf \
-            mendersoftware/mender-client-docker-addons:master
+            mendersoftware/mender-client-docker-addons:mender-3.6.x
     else
         while [[ $retries -gt 0 && -z $containerid ]]; do
             containerid=$(get_container_id mender-useradm)

--- a/tests/e2e_tests/utils/commands.ts
+++ b/tests/e2e_tests/utils/commands.ts
@@ -156,7 +156,7 @@ export const startDockerClient = async (baseUrl, token) => {
     `${projectRoot}/dockerClient/mender-test.json:/etc/mender/mender.conf`,
     '-v',
     `${projectRoot}/dockerClient/mender-connect-test.json:/etc/mender/mender-connect.conf`,
-    'mendersoftware/mender-client-docker-addons:master'
+    'mendersoftware/mender-client-docker-addons:mender-3.6.x'
   ];
   console.log(`starting with token: ${token}`);
   console.log(`starting using: docker ${args.join(' ')}`);


### PR DESCRIPTION
Changelog: None
Ticket: None