### PR TITLE
fix: move cookie-based JWT tokens to the local storage

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -32,7 +32,16 @@ export const getSessionInfo = () => {
     cleanUp();
     return { ...emptySession };
   }
-  sessionInfo.token = sessionInfo.token || cookies.get('JWT', { doNotParse: true });
+  if (!sessionInfo.token) {
+    let jwtTokenFromCookie = cookies.get('JWT', { doNotParse: true }) ?? '';
+    if (jwtTokenFromCookie) {
+      setSessionInfo({ token: jwtTokenFromCookie, undefined });
+      sessionInfo.token = jwtTokenFromCookie;
+      cookies.remove('JWT');
+      cookies.remove('JWT', { path: '/' });
+    }
+  }
+  sessionInfo.token = sessionInfo.token || undefined;
   tokenCache = sessionInfo.token;
   return sessionInfo;
 };


### PR DESCRIPTION
If the log in happens through SSO (e.g., OAuth 2.0 or SAML 2) the backend sets the JWT token in a cookie. The UI is then responsible for moving it to the local storage, as happens with the JWT token on a standard email/password log in. This fixes the expiration issues with cookie-based JWT tokens.

Changelog: None
Ticket: MEN-6849