### PR TITLE
chore: get rid of deprecated @mui/styles package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@monaco-editor/react": "4.6.0",
         "@mui/icons-material": "5.14.16",
         "@mui/material": "5.14.16",
-        "@mui/styles": "5.14.16",
         "@mui/x-date-pickers": "6.18.0",
         "@redux-devtools/extension": "3.2.5",
         "@reduxjs/toolkit": "1.9.7",
@@ -4329,54 +4328,6 @@
         }
       }
     },
-    "node_modules/@mui/styles": {
-      "version": "5.14.16",
-      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.14.16.tgz",
-      "integrity": "sha512-pBA2eLBEfqLv/jmu9qGcErwml27upH2YBFRuRU2loZm5R57di5y/GjpM9EWc77+49axaTlHfO8LWbic4kPvxoQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@emotion/hash": "^0.9.1",
-        "@mui/private-theming": "^5.14.16",
-        "@mui/types": "^7.2.8",
-        "@mui/utils": "^5.14.16",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.10.0",
-        "jss-plugin-camel-case": "^10.10.0",
-        "jss-plugin-default-unit": "^10.10.0",
-        "jss-plugin-global": "^10.10.0",
-        "jss-plugin-nested": "^10.10.0",
-        "jss-plugin-props-sort": "^10.10.0",
-        "jss-plugin-rule-value-function": "^10.10.0",
-        "jss-plugin-vendor-prefixer": "^10.10.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styles/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@mui/system": {
       "version": "5.14.16",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.16.tgz",
@@ -8269,15 +8220,6 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
-    "node_modules/css-vendor": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
-      }
-    },
     "node_modules/css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
@@ -11056,11 +10998,6 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -11566,11 +11503,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
@@ -14779,88 +14711,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/jss"
-      }
-    },
-    "node_modules/jss-plugin-camel-case": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-default-unit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-global": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-nested": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-props-sort": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-rule-value-function": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-vendor-prefixer": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -18839,11 +18689,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/titleize": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@monaco-editor/react": "4.6.0",
     "@mui/icons-material": "5.14.16",
     "@mui/material": "5.14.16",
-    "@mui/styles": "5.14.16",
     "@mui/x-date-pickers": "6.18.0",
     "@redux-devtools/extension": "3.2.5",
     "@reduxjs/toolkit": "1.9.7",

--- a/src/js/components/app.js
+++ b/src/js/components/app.js
@@ -18,9 +18,7 @@ import { BrowserRouter, useLocation, useNavigate } from 'react-router-dom';
 
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-import { CssBaseline } from '@mui/material';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
-import withStyles from '@mui/styles/withStyles';
+import { CssBaseline, ThemeProvider, createTheme, styled } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { makeStyles } from 'tss-react/mui';
@@ -68,7 +66,7 @@ const reducePalette =
     return accu;
   };
 
-const cssVariables = ({ palette }) => {
+const cssVariables = ({ theme: { palette } }) => {
   const muiVariables = Object.entries(palette).reduce(reducePalette('--mui'), {});
   return {
     '@global': {
@@ -80,7 +78,7 @@ const cssVariables = ({ palette }) => {
   };
 };
 
-const WrappedBaseline = withStyles(cssVariables)(CssBaseline);
+const WrappedBaseline = styled(CssBaseline)(cssVariables);
 
 const useStyles = makeStyles()(() => ({
   public: {

--- a/src/js/components/devices/dialogs/__snapshots__/monitordetailsdialog.test.js.snap
+++ b/src/js/components/devices/dialogs/__snapshots__/monitordetailsdialog.test.js.snap
@@ -186,6 +186,15 @@ exports[`MonitorLogDialog Component renders correctly 1`] = `
   background-color: #f7f7f7;
 }
 
+.emotion-6 root:before {
+  display: none;
+}
+
+.emotion-6 root$expanded {
+  background-color: transparent;
+  margin: 0;
+}
+
 .emotion-7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -629,7 +638,7 @@ exports[`MonitorLogDialog Component renders correctly 1`] = `
         style="min-width: 600px;"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAccordion-root ForwardRef(Accordion)-root-1 MuiAccordion-gutters emotion-6"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAccordion-root MuiAccordion-gutters emotion-6"
         >
           <div
             aria-expanded="false"

--- a/src/js/components/devices/dialogs/monitordetailsdialog.js
+++ b/src/js/components/devices/dialogs/monitordetailsdialog.js
@@ -20,8 +20,19 @@ import {
   FileCopy as CopyPasteIcon,
   ReportProblemOutlined as WarningIcon
 } from '@mui/icons-material';
-import { Accordion, AccordionDetails, AccordionSummary, Button, Collapse, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from '@mui/material';
-import withStyles from '@mui/styles/withStyles';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  styled
+} from '@mui/material';
 
 import { TIMEOUTS } from '../../../constants/appConstants';
 import { toggle } from '../../../helpers';
@@ -62,7 +73,7 @@ const LogLine = ({ beExplicit, line, prefix }) => {
   );
 };
 
-const CustomAccordion = withStyles({
+const CustomAccordion = styled(Accordion)({
   root: {
     '&:before': {
       display: 'none'
@@ -73,7 +84,7 @@ const CustomAccordion = withStyles({
     }
   },
   expanded: {}
-})(Accordion);
+});
 
 const LogSection = ({ section = 'previous', lines }) => {
   const [expanded, setExpanded] = useState(false);

--- a/tests/licenses/directDependencies.csv
+++ b/tests/licenses/directDependencies.csv
@@ -12,7 +12,6 @@
 "@monaco-editor/react","MIT","https://github.com/suren-atoyan/monaco-react"
 "@mui/icons-material","MIT","https://github.com/mui/material-ui"
 "@mui/material","MIT","https://github.com/mui/material-ui"
-"@mui/styles","MIT","https://github.com/mui/material-ui"
 "@mui/x-date-pickers","MIT","https://github.com/mui/mui-x"
 "@redux-devtools/extension","MIT","https://github.com/reduxjs/redux-devtools"
 "@reduxjs/toolkit","MIT","https://github.com/reduxjs/redux-toolkit"


### PR DESCRIPTION
This is needed for the React upgrade to the 18th version, as @mui/styles was deprecated and stuck to the 17th version only

ChangeLog: None

Ticket: None