### PR TITLE
feat: treat devices without update_ts as offline

### DIFF
--- a/src/js/constants/deviceConstants.js
+++ b/src/js/constants/deviceConstants.js
@@ -49,6 +49,12 @@ export const DEVICE_FILTERING_OPTIONS = {
     shortform: '<=',
     help: 'The "lesser than or equal" operator can work both on numbers and strings. In the latter case, the operator applies the lexicographical order to the value strings.'
   },
+  $ltne: {
+    key: '$ltne',
+    title: '$ltne',
+    shortform: 'ltne',
+    help: 'The "lesser than or does not exist" operator can work both on numbers and strings. In the latter case, the operator applies the lexicographical order to the value strings.'
+  },
   $in: {
     key: '$in',
     title: 'in',
@@ -199,7 +205,7 @@ export const DEVICE_ISSUE_OPTIONS = {
     filterRule: {
       scope: 'system',
       key: 'updated_ts',
-      operator: DEVICE_FILTERING_OPTIONS.$lt.key,
+      operator: DEVICE_FILTERING_OPTIONS.$ltne.key,
       value: ({ offlineThreshold }) => offlineThreshold
     },
     title: 'Offline devices'


### PR DESCRIPTION
The new "$ltne" filter operator allows to get list of device where the update_ts is lower than given value or update_ts doesn't exist.
Ticket: [MEN-6880](https://northerntech.atlassian.net/browse/MEN-6880)

[MEN-6880]: https://northerntech.atlassian.net/browse/MEN-6880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ