### PR TITLE
fix: only users with userManagement permissions can change global settings

### DIFF
--- a/src/js/components/settings/settings.js
+++ b/src/js/components/settings/settings.js
@@ -34,7 +34,7 @@ import Upgrade from './upgrade';
 let stripePromise = null;
 
 const sectionMap = {
-  'global-settings': { component: Global, text: () => 'Global settings', canAccess },
+  'global-settings': { component: Global, text: () => 'Global settings', canAccess: ({ userCapabilities: { canManageUsers } }) => canManageUsers },
   'my-profile': { component: SelfUserManagement, text: () => 'My profile', canAccess },
   'organization-and-billing': {
     component: Organization,


### PR DESCRIPTION
According to #MEN-6967 `The global settings must be moved out of the basic permissions and into the user management permission set.`, that's why canManageUsers permission is used. Could be changed to `isAdmin`

Ticket: MEN-6970

Changelog: None

