### PR TITLE
fix: fixed the final onboarding step not being displayed

### DIFF
--- a/src/js/actions/onboardingActions.js
+++ b/src/js/actions/onboardingActions.js
@@ -160,7 +160,7 @@ export const advanceOnboarding = stepId => (dispatch, getState) => {
   const madeProgress = steps[stepIndex + 1];
   const state = { ...getCurrentOnboardingState(getState()), progress: madeProgress };
   state.complete =
-    stepIndex + 1 >= Object.keys(onboardingSteps).findIndex(step => step === onboardingStepNames.DEPLOYMENTS_PAST_COMPLETED) ? true : state.complete;
+    stepIndex + 1 >= Object.keys(onboardingSteps).findIndex(step => step === onboardingStepNames.DEPLOYMENTS_PAST_COMPLETED_FAILURE) ? true : state.complete;
   Tracking.event({ category: 'onboarding', action: stepId });
   return Promise.all([dispatch(setOnboardingProgress(madeProgress)), dispatch(saveUserSettings({ onboarding: state }))]);
 };

--- a/src/js/components/helptips/onboardingcompletetip.js
+++ b/src/js/components/helptips/onboardingcompletetip.js
@@ -49,7 +49,6 @@ export const OnboardingCompleteTip = ({ anchor, targetUrl }) => {
         timer.current = setTimeout(() => dispatch(setOnboardingComplete(true)), 120000);
       });
     return () => {
-      dispatch(setOnboardingComplete(true));
       clearTimeout(timer.current);
     };
   }, [dispatch]);


### PR DESCRIPTION
ChangeLog: Title

Ticket: MEN-6949

* changed onboarding complete calculation; the next step after DEPLOYMENTS_PAST_COMPLETED_FAILURE should be the last one and finish onboarding, not DEPLOYMENTS_PAST_COMPLETED. 
* removed onboarding marked completed from useEffect of the onboarding complete tip component. This will happen on re-render as well. What prevents following DEPLOYMENTS_PAST_COMPLETED renders