### PR TITLE
MEN-7041: Annoying message on Basic and Pro plan when config add-on disabled

### DIFF
--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -378,7 +378,7 @@ export const getTenantCapabilities = createSelector(
   ) => {
     const canDelta = isEnterprise || plan === PLANS.professional.id;
     const hasAuditlogs = isAuditlogEnabled && isEnterprise;
-    const hasDeviceConfig = isDeviceConfigEnabled && (!isEnterprise || addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled)));
+    const hasDeviceConfig = isDeviceConfigEnabled && addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled));
     const hasDeviceConnect = isDeviceConnectEnabled && (!isEnterprise || addons.some(addon => addon.name === 'troubleshoot' && Boolean(addon.enabled)));
     const hasMonitor = isMonitorEnabled && addons.some(addon => addon.name === 'monitor' && Boolean(addon.enabled));
     return {


### PR DESCRIPTION
Ticket: MEN-7041
Changelog: None

In previous implementation, add-on was considered enabled whenever the plan is not Enterprise. Could not reproduce locally, so could not test it, but this fix should help