### PR TITLE
fix: use update_ts from inventory to calculate if the device is offline

### DIFF
--- a/src/js/actions/deviceActions.js
+++ b/src/js/actions/deviceActions.js
@@ -330,7 +330,7 @@ const reduceReceivedDevices = (devices, ids, state, status) =>
       device.created_ts = getEarliestTs(getEarliestTs(system.created_ts, device.created_ts), stateDevice.created_ts);
       device.updated_ts = device.attributes ? device.updated_ts : stateDevice.updated_ts;
       device.isNew = new Date(device.created_ts) > new Date(state.app.newThreshold);
-      device.isOffline = new Date(device.check_in_time) < new Date(state.app.offlineThreshold) || device.check_in_time === undefined;
+      device.isOffline = new Date(device.updated_ts) < new Date(state.app.offlineThreshold) || device.updated_ts === undefined;
       // all the other mapped attributes return as empty objects if there are no attributes to map, but identity will be initialized with an empty state
       // for device_type and artifact_name, potentially overwriting existing info, so rely on stored information instead if there are no attributes
       device.attributes = device.attributes ? { ...storedAttributes, ...inventory } : storedAttributes;


### PR DESCRIPTION
In the device list view we're not querying deviceauth service for the device data, so we don't have information about check_in time. Thus, we cannot use it to calculate if the device is offline or not.

Ticket: MEN-7202