### PR TITLE
fix: fixed xterm versions injection to allow downloading recorded remote terminal sessions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,9 +99,9 @@ export default (env, argv) => {
       }),
       new webpack.DefinePlugin({
         ENV: JSON.stringify(argv.mode),
-        XTERM_VERSION: JSON.stringify(require('./package.json').dependencies.xterm),
-        XTERM_FIT_VERSION: JSON.stringify(require('./package.json').dependencies['xterm-addon-fit']),
-        XTERM_SEARCH_VERSION: JSON.stringify(require('./package.json').dependencies['xterm-addon-search'])
+        XTERM_VERSION: JSON.stringify(require('./package.json').dependencies['@xterm/xterm']),
+        XTERM_FIT_VERSION: JSON.stringify(require('./package.json').dependencies['@xterm/addon-fit']),
+        XTERM_SEARCH_VERSION: JSON.stringify(require('./package.json').dependencies['@xterm/addon-search'])
       }),
       new HtmlWebPackPlugin({
         favicon: './src/favicon.svg',


### PR DESCRIPTION
follow up for https://github.com/mendersoftware/gui/pull/4409 - thankfully caught by the e2e tests, not sure if there is a nicer way to prevent this in the future