### PR TITLE
ci: switch test container images to per-image registry paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -322,7 +322,7 @@ build:docker-multiplatform:
       - baseImage.tar
 
 .template:test:staging-deployment:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mendersoftware/mender-test-containers:gui-e2e-testing
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
   stage: test-deploy
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:dind

--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -1,6 +1,6 @@
 services:
   mender-gui-tests-runner:
-    image: mendersoftware/mender-test-containers:gui-e2e-testing
+    image: registry.gitlab.com/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
     command: tail -f /dev/null
     environment:
       - TEST_ENVIRONMENT


### PR DESCRIPTION
Migrates mender-test-containers image references from the legacy flat-tag format to the new per-image sub-repository format:

- `mendersoftware/mender-test-containers:gui-e2e-testing` → `mender-test-containers/gui-e2e-testing:master`

Ticket: QA-1604